### PR TITLE
modifying admin-web.xml for atlas-ranger-plugin

### DIFF
--- a/src/main/assembly/admin-web.xml
+++ b/src/main/assembly/admin-web.xml
@@ -297,6 +297,21 @@
      			</includes>
     		</moduleSet>
 
+<moduleSet>
+     <binaries>
+        <includeDependencies>true</includeDependencies>
+        <outputDirectory>/ews/webapp/WEB-INF/classes/ranger-plugins/atlas</outputDirectory>
+        <unpack>false</unpack>
+        <directoryMode>755</directoryMode>
+        <fileMode>644</fileMode>
+     </binaries>
+     <includes>
+       <include>org.apache.ranger:ranger-atlas-plugin</include>
+     </includes>
+    </moduleSet>
+
+
+
       <moduleSet>
           <binaries>
               <includeDependencies>true</includeDependencies>


### PR DESCRIPTION
 Committer: zhangqiang2 <zhangqiang2@zte.com.cn>

# Overview

The source code of our contribution “Pull-Request” aims to solve the problem of manually copying ranger-atlas-plugin.jar, that is a prerequisite for using the ranger-atlas plugin, under the existing code.

For those who are new to ranger-atlas, one will always find difficult that the ranger's Web UI has no plugin connection after successfully installing the plugin. This problem always occurs, because there is no corresponding Atlas folder in the specified path of ranger-admin, and there is no ranger-atlas-plugin.jar in that Atlas folder. Meanwhile, ranger's official document does not provide any guidance to beginners, to tell them to copy the jar package to the specified path, leading to many developers can not use some parts of the ranger functionalities.

Our open source contribution that only modifies a small part of source code can directly generate the corresponding Atlas folder and jar package. It means that by using our contribution, developers no need to manually create a folder and import the relevant jar package. In this way, this can bring good convenience to the developers and users.

# Implementation Details

## Existing Problem (Motivation of this Contribution):

After installing the ranger-atlas plugin, the connection failure will be displayed on the ranger's Web UI view the installation log and found an error:

atlas failed to find service class org.apache.ranger.services.atlas.RangerServiceAtlas. Resource lookup will not be available. Please make sure plugin jar is in the correct place.

Later one cannot fine the Atlas file in the following directory :

ranger-0.6.2-SNAPSHOT-admin/ews/webapp/WEB-INF/classes/ranger-plugins

To solve this problem, one can only manually create the atlas folder and import the ranger-atlas-plugin.jar package, which is not convenient for the end user.

## Our Solution/Contribution:

Download incubator-ranger code directly from gitHub，Open it with compiler in src-main-assembly file path of admin-web.xml, as follows:
![file0001](https://cloud.githubusercontent.com/assets/21661425/22365573/306086f4-e4b3-11e6-9c43-c5eb82c3eee1.jpg)
The code of admin-web.xml is related with Ranger, and compiled automatically to generate the component folder. For example, the following figure is related to Yarn.
![file0002](https://cloud.githubusercontent.com/assets/21661425/22365602/5f7e48d6-e4b3-11e6-859f-89d4a699ceab.jpg)
We then add the following Atlas-related code:
![file0003](https://cloud.githubusercontent.com/assets/21661425/22365620/766aa440-e4b3-11e6-9259-d637e5807c23.jpg)
The code set the output path, the permissions of some file, the contents of folder contains, etc.

## Verification:

Re-compile the code, reinstall the ranger, atlas and ranger-atlas-plugin and start. First, the specified path has been automatically generated as Atlas folder, and the folder already has ranger-atlas-plugin.jar：
![file0004](https://cloud.githubusercontent.com/assets/21661425/22365651/a9b98f46-e4b3-11e6-80d2-9811f498ad0a.jpg)
Second, the Ranger Web UI shows a successful connection, which shows that our implementation is correct.
![file0005](https://cloud.githubusercontent.com/assets/21661425/22365661/ba31d130-e4b3-11e6-933e-8df20a4020cd.jpg)
