### PR TITLE
Extra debug logging in UserSync Group Search

### DIFF
--- a/ugsync/src/main/java/org/apache/ranger/ldapusersync/process/LdapUserGroupBuilder.java
+++ b/ugsync/src/main/java/org/apache/ranger/ldapusersync/process/LdapUserGroupBuilder.java
@@ -599,6 +599,11 @@ public class LdapUserGroupBuilder extends AbstractUserGroupSource {
 								LOG.error("No user information provided for group search!");
 								return;
 							}
+							if (LOG.isDebugEnabled()) {
+								LOG.debug("Searching for groups for user " + userInfo.getUserName() + 
+										" using filter " + String.format(extendedGroupSearchFilter, userInfo.getUserFullName(), 
+												userInfo.getUserName()));
+							}
 							groupSearchResultEnum = ldapContext
 									.search(groupSearchBase[ou], extendedGroupSearchFilter,
 											new Object[]{userInfo.getUserFullName(), userInfo.getUserName()},


### PR DESCRIPTION
When debugging issues with group search it can be hard to understand why
groups are not being found because the specific LDAP search filters used
i.e. The filter templates with placeholders filled are not logged.
This adds extra debug logging so when log level is DEBUG the exact LDAP
search filter to be used will be logged.  Users can then test this
filter directly against their LDAP server to determine why it is
incorrect and then adjust their configuration appropriately a