### PR TITLE
RANGER-2284: Fixed build using docker

### DIFF
--- a/build_ranger_using_docker.sh
+++ b/build_ranger_using_docker.sh
@@ -23,11 +23,11 @@
 
 #Usage: [sudo] ./build_ranger_using_docker.sh [-build_image] mvn  <build params>
 #Example 1 (default no param): (mvn -DskipTests=true clean compile package install assembly:assembly)
-#Example 2 (Regular build): ./build_ranger_using_docker.sh mvn clean install -DskipTests=true 
-#Example 3 (Recreate Docker image): ./build_ranger_using_docker.sh mvn -build_image clean install -DskipTests=true 
+#Example 2 (Regular build): ./build_ranger_using_docker.sh mvn clean install -DskipTests=true
+#Example 3 (Recreate Docker image): ./build_ranger_using_docker.sh mvn -build_image clean install -DskipTests=true
 #Notes: To remove build image manually, run "docker rmi ranger_dev" or "sudo docker rmi ranger_dev"
 
-default_command="mvn -DskipTests=true clean compile package install assembly:assembly"
+default_command="mvn -Drat.skip=true -DskipTests=true clean compile package install assembly:assembly"
 build_image=0
 if [ "$1" = "-build_image" ]; then
     build_image=1
@@ -67,22 +67,21 @@ RUN yum install -y wget
 RUN yum install -y git
 RUN yum install -y gcc
 
-#Download and install JDK8 from AWS s3's docker-assets 
+#Download and install JDK8 from AWS s3's docker-assets
 RUN wget https://s3.eu-central-1.amazonaws.com/docker-assets/dist/jdk-8u101-linux-x64.rpm
 RUN rpm -i jdk-8u101-linux-x64.rpm
 
 ENV JAVA_HOME /usr/java/latest
 ENV  PATH $JAVA_HOME/bin:$PATH
 
+ADD https://www.apache.org/dist/maven/maven-3/3.5.4/binaries/apache-maven-3.5.4-bin.tar.gz.sha512 /tools
+ADD http://www-us.apache.org/dist/maven/maven-3/3.5.4/binaries/apache-maven-3.5.4-bin.tar.gz /tools
+RUN sha512sum apache-maven-3.5.4-bin.tar.gz | cut -f 1 -d " " > tmp.sha512
 
-ADD https://www.apache.org/dist/maven/maven-3/3.5.3/binaries/apache-maven-3.5.3-bin.tar.gz.sha1 /tools
-ADD http://www-us.apache.org/dist/maven/maven-3/3.5.3/binaries/apache-maven-3.5.3-bin.tar.gz /tools
-RUN sha1sum  apache-maven-3.5.3-bin.tar.gz | cut -f 1 -d " " > tmp.sha1
+RUN diff -w tmp.sha512 apache-maven-3.5.4-bin.tar.gz.sha512
 
-RUN diff -w tmp.sha1 apache-maven-3.5.3-bin.tar.gz.sha1
-
-RUN tar xfz apache-maven-3.5.3-bin.tar.gz
-RUN ln -sf /tools/apache-maven-3.5.3 /tools/maven
+RUN tar xfz apache-maven-3.5.4-bin.tar.gz
+RUN ln -sf /tools/apache-maven-3.5.4 /tools/maven
 
 ENV  PATH /tools/maven/bin:$PATH
 ENV MAVEN_OPTS "-Xmx2048m -XX:MaxPermSize=512m"


### PR DESCRIPTION
https://www.apache.org/dist/maven/maven-3/ no longer has version 3.5.3

For more details, see https://issues.apache.org/jira/browse/RANGER-2284

