### PR TITLE
Decrypt the password coming from x_service_config_map

### DIFF
--- a/plugin-presto/src/main/java/org/apache/ranger/services/presto/client/PrestoClient.java
+++ b/plugin-presto/src/main/java/org/apache/ranger/services/presto/client/PrestoClient.java
@@ -79,8 +79,13 @@ public class PrestoClient extends BaseClient implements Closeable {
     String url = prop.getProperty("jdbc.url");
 
     Properties prestoProperties = new Properties();
-    prestoProperties.put(PRESTO_USER_NAME_PROP, prop.getProperty(HadoopConfigHolder.RANGER_LOGIN_USER_NAME_PROP));
-    prestoProperties.put(PRESTO_PASSWORD_PROP, prop.getProperty(HadoopConfigHolder.RANGER_LOGIN_PASSWORD));
+    prestoProperties.put(PRESTO_USER_NAME_PROP, prop.getProperty(HadoopConfigHolder.RANGER_LOGIN_USER_NAME_PROP));    
+    try {
+      prestoProperties.put(PRESTO_PASSWORD_PROP, decryptPassword(prop.getProperty(HadoopConfigHolder.RANGER_LOGIN_PASSWORD)));
+    } catch (IOException e) {
+      LOG.info("Password decryption failed; trying Presto connection with received password string");
+      prestoProperties.put(PRESTO_PASSWORD_PROP, prop.getProperty(HadoopConfigHolder.RANGER_LOGIN_PASSWORD));
+    }
 
     if (driverClassName != null) {
       try {


### PR DESCRIPTION
When the connection is established for presto service, the password is stored in x_service_config_map MySQL table.
Autocomplete will still not work if the password is not decrypted.
Added the step to decrypt the password.