### PR TITLE
XUserService has duplicate db query in when populateViewBean for XXUser

### DIFF
--- a/security-admin/src/main/java/org/apache/ranger/service/XUserService.java
+++ b/security-admin/src/main/java/org/apache/ranger/service/XUserService.java
@@ -210,8 +210,6 @@ public class XUserService extends XUserServiceBase<XXUser, VXUser> {
 	public VXUser populateViewBean(XXUser xUser) {
 		VXUser vObj = super.populateViewBean(xUser);
 		vObj.setIsVisible(xUser.getIsVisible());
-		String userName = vObj.getName();
-		populateUserAttributes(userName, vObj);
 		populateGroupList(xUser.getId(), vObj);
 		return vObj;
 	}


### PR DESCRIPTION
when request http api /service/xusers/users with GET method.ranger admin will query db and get XXUser,then transform the XXUser to VXUser. in the tranformation process,

XUserService.populateUserAttributes() method is called two times.and make extra 2 times db query.when the result users are many,this causes significant performance issue,rougly 40% performance down。so indeed we need to call populateUserAttributes() once .

we found this issue in our production environment with 1000+ users in ranger admin,and start the kafka or other component which enabled ranger authority.in the start process, setup_ranger_xxxx() is called and make http /service/xusers/users request to ranger.as it query all users in ranger,ranger admin will reponse in several ten seconds.