### PR TITLE
[RANGER-2667] set controlName to allow-all when disable presto plugin

### DIFF
--- a/agents-common/scripts/enable-agent.sh
+++ b/agents-common/scripts/enable-agent.sh
@@ -787,7 +787,7 @@ then
 	then
 		controlName="ranger"
 	else
-		controlName=""
+		controlName="allow-all"
 	fi
 	dt=`date '+%Y%m%d%H%M%S'`
 	fn=`ls ${HCOMPONENT_CONF_DIR}/access-control.properties 2> /dev/null`


### PR DESCRIPTION
Running the disable-presto-plugin.sh script will always get stuck. Because the script sets the
controlName to an empty string and passes it to the function addOrUpdatePropertyToFile when disable the presto plugin. If controlName is an empty string, addOrUpdatePropertyToFile will ignore this parameter and let fn to be the second parameter. So $3 passed to checkPropertyInFile will be empty. In checkPropertyInFile, if the second parameter is empty, the sed command will never return, and the disable-presto-plugin.sh script will always get stuck.

We should pass the default value of access-control.name and set controlName to be allow-all when disable presto plugin.

The default value of access-control.name can be seen here: https://prestodb.io/docs/current/security/built-in-system-access-control.html
JIRA: https://issues.apache.org/jira/browse/RANGER-2667