### PR TITLE
[RANGER-2671] unlink core-site.xml in usersync conf before chown and chmod

### DIFF
--- a/unixauthservice/scripts/setup.py
+++ b/unixauthservice/scripts/setup.py
@@ -533,6 +533,19 @@ def main():
     os.chown(ugsyncCryptPath, ownerId, groupId)
 
     writeXMLUsingProperties(fn, mergeProps, outfn)
+    
+    hadoop_conf_full_path = join(hadoop_conf, hadoopConfFileName)
+    usersync_conf_full_path = join(usersyncBaseDirFullName, confBaseDirName, hadoopConfFileName)
+    if not isfile(hadoop_conf_full_path):
+        print "WARN: core-site.xml file not found in provided hadoop conf path..."
+        f = open(usersync_conf_full_path, "w")
+        f.write("<configuration></configuration>")
+        f.close()
+        os.chown(usersync_conf_full_path, ownerId, groupId)
+        os.chmod(usersync_conf_full_path, 0750)
+    else:
+        if os.path.islink(usersync_conf_full_path):
+            os.remove(usersync_conf_full_path)
 
     fixPermList = [".", usersyncBaseDirFullName, confFolderName, certFolderName]
 
@@ -579,19 +592,6 @@ def main():
     f = open(join(confBaseDirName, ENV_PID_FILE), "a+")
     f.write("\nexport {0}={1}".format("UNIX_USERSYNC_USER", unix_user))
     f.close()
-
-    hadoop_conf_full_path = join(hadoop_conf, hadoopConfFileName)
-    usersync_conf_full_path = join(usersyncBaseDirFullName, confBaseDirName, hadoopConfFileName)
-    if not isfile(hadoop_conf_full_path):
-        print "WARN: core-site.xml file not found in provided hadoop conf path..."
-        f = open(usersync_conf_full_path, "w")
-        f.write("<configuration></configuration>")
-        f.close()
-        os.chown(usersync_conf_full_path, ownerId, groupId)
-        os.chmod(usersync_conf_full_path, 0750)
-    else:
-        if os.path.islink(usersync_conf_full_path):
-            os.remove(usersync_conf_full_path)
 
     if isfile(hadoop_conf_full_path) and not isfile(usersync_conf_full_path):
         os.symlink(hadoop_conf_full_path, usersync_conf_full_path)


### PR DESCRIPTION
If we run setup.sh in usersync a second time, the setup.py in usersync folder will change the permissions to 0750 and owner to ranger:ranger of hadoop core-site.xml. This will affect other software that needs to read core-site.xml, for example, hiveserver2 will fail to start because it does not have permission to read core-site.xml. Ranger should never change the permission or ownership of core-site.xml in hadoop conf dir. 
The reason why the permissions and owner of core-site.xml are modified is because the following code in unixauthservice/scripts/setup.py

```python
for dir in fixPermList:
    for root, dirs, files in os.walk(dir):
        os.chown(root, ownerId, groupId)
        os.chmod(root, 0755)
        for obj in dirs:
            dn = join(root, obj)
            os.chown(dn, ownerId, groupId)
            os.chmod(dn, 0755)
        for obj in files:
            fn = join(root, obj)
            os.chown(fn, ownerId, groupId)
            os.chmod(fn, 0750)
```
If we run setup.sh in usersync a second time, there will be a soft link of core-site.xml in /etc/ranger/usersync/conf. In the for loop, it will traverse to /etc/ranger/usersync/conf/core-site.xml, and use os.chown and os.chmod to change the permisson and ownership. We should unlink the soft link of core-site.xml before this for loop. 

JIRA: https://issues.apache.org/jira/browse/RANGER-2671