### PR TITLE
Remove deprecated sudo setting.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 
-sudo: false
 language: java
 cache:
   directories:


### PR DESCRIPTION
[Travis are now recommending removing the sudo tag.](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration)