### PR TITLE
RANGER-2856: A policy should be deleted if it has no policyItems

### DIFF
--- a/security-admin/src/main/java/org/apache/ranger/biz/PolicyRefUpdater.java
+++ b/security-admin/src/main/java/org/apache/ranger/biz/PolicyRefUpdater.java
@@ -334,7 +334,7 @@ public class PolicyRefUpdater {
 		return true;
 	}
 
-	static List<List<? extends RangerPolicyItem>> getAllPolicyItems(RangerPolicy policy) {
+	public static List<List<? extends RangerPolicyItem>> getAllPolicyItems(RangerPolicy policy) {
 		List<List<? extends RangerPolicyItem>> ret = new ArrayList<>();
 
 		if (CollectionUtils.isNotEmpty(policy.getPolicyItems())) {

--- a/security-admin/src/main/java/org/apache/ranger/rest/PublicAPIsv2.java
+++ b/security-admin/src/main/java/org/apache/ranger/rest/PublicAPIsv2.java
@@ -554,6 +554,25 @@ public class PublicAPIsv2 {
 		}
 	}
 
+	@DELETE
+	@Path("/api/server/purgepolicies/{serviceName}")
+	@PreAuthorize("hasRole('ROLE_SYS_ADMIN')")
+	public void purgeEmptyPolicies(@PathParam("serviceName") String serviceName, @Context HttpServletRequest request) {
+		if (logger.isDebugEnabled()) {
+			logger.debug("==> PublicAPIsv2.purgeEmptyPolicies(" + serviceName + ")");
+		}
+
+		if (serviceName == null) {
+			throw restErrorUtil.createRESTException(HttpServletResponse.SC_BAD_REQUEST , "Invalid service name", true);
+		}
+
+		serviceREST.purgeEmptyPolicies(serviceName, request);
+
+		if (logger.isDebugEnabled()) {
+			logger.debug("<== PublicAPIsv2.purgeEmptyPolicies(" + serviceName + ")");
+		}
+	}
+
 	/*
 	 * Role Creation API
 	 */

--- a/security-admin/src/main/java/org/apache/ranger/rest/ServiceREST.java
+++ b/security-admin/src/main/java/org/apache/ranger/rest/ServiceREST.java
@@ -62,8 +62,11 @@ import org.apache.ranger.admin.client.datatype.RESTResponse;
 import org.apache.ranger.authorization.hadoop.config.RangerAdminConfig;
 import org.apache.ranger.authorization.utils.StringUtil;
 import org.apache.ranger.biz.AssetMgr;
+import org.apache.ranger.biz.PolicyRefUpdater;
 import org.apache.ranger.biz.RangerPolicyAdmin;
 import org.apache.ranger.biz.RangerBizUtil;
+import org.apache.ranger.biz.RangerPolicyAdminCache;
+import org.apache.ranger.biz.RangerPolicyAdminCacheForEngineOptions;
 import org.apache.ranger.biz.RoleDBStore;
 import org.apache.ranger.biz.SecurityZoneDBStore;
 import org.apache.ranger.biz.ServiceDBStore;
@@ -108,8 +111,6 @@ import org.apache.ranger.plugin.model.validation.RangerValidator.Action;
 import org.apache.ranger.plugin.policyengine.RangerAccessResource;
 import org.apache.ranger.plugin.policyengine.RangerAccessResourceImpl;
 import org.apache.ranger.plugin.policyengine.RangerPolicyEngine;
-import org.apache.ranger.biz.RangerPolicyAdminCache;
-import org.apache.ranger.biz.RangerPolicyAdminCacheForEngineOptions;
 import org.apache.ranger.plugin.policyengine.RangerPolicyEngineOptions;
 import org.apache.ranger.plugin.service.ResourceLookupContext;
 import org.apache.ranger.plugin.store.EmbeddedServiceDefsUtil;
@@ -3281,6 +3282,52 @@ public class ServiceREST {
 
 		if (LOG.isDebugEnabled()) {
 			LOG.debug("<== ServiceREST.deletePolicyDeltas(" + olderThan + ")");
+		}
+	}
+
+	@DELETE
+	@Path("/server/purgepolicies/{serviceName}")
+	@PreAuthorize("hasRole('ROLE_SYS_ADMIN')")
+	public void purgeEmptyPolicies(@PathParam("serviceName") String serviceName, @Context HttpServletRequest request) {
+		if (LOG.isDebugEnabled()) {
+			LOG.debug("==> ServiceREST.purgeEmptyPolicies(" + serviceName + ")");
+		}
+
+		if (serviceName == null) {
+			throw restErrorUtil.createRESTException(HttpServletResponse.SC_BAD_REQUEST , "Invalid service name", true);
+		}
+
+		RangerPerfTracer perf = null;
+
+		try {
+			if(RangerPerfTracer.isPerfTraceEnabled(PERF_LOG)) {
+				perf = RangerPerfTracer.getPerfTracer(PERF_LOG, "ServiceREST.purgeEmptyPolicies(serviceName=" + serviceName + ")");
+			}
+
+			if (svcStore.getServiceByName(serviceName) == null) {
+				throw new Exception("service does not exist - name=" + serviceName);
+			}
+
+			ServicePolicies servicePolicies = svcStore.getServicePolicies(serviceName, -1L);
+			if (servicePolicies != null && CollectionUtils.isNotEmpty(servicePolicies.getPolicies())) {
+				for (RangerPolicy policy : servicePolicies.getPolicies()) {
+					if (CollectionUtils.isEmpty(PolicyRefUpdater.getAllPolicyItems(policy))) {
+						deletePolicy(policy.getId());
+					}
+				}
+			}
+		} catch(WebApplicationException excp) {
+			throw excp;
+		} catch(Throwable excp) {
+			LOG.error("purgeEmptyPolicies(" + serviceName + ") failed", excp);
+
+			throw restErrorUtil.createRESTException(excp.getMessage());
+		} finally {
+			RangerPerfTracer.log(perf);
+		}
+
+		if (LOG.isDebugEnabled()) {
+			LOG.debug("<== ServiceREST.purgeEmptyPolicies(" + serviceName + ")");
 		}
 	}
 


### PR DESCRIPTION
Condition: A policy contains only one policyItem and the policyItem only sets one user and no groups.

Action: Delete the user in the policyItem using API: 'http://ip:6080/service/xusers/users/{id}?forceDelete=true'

Result: The policy still exists, but it has no policyItems. A policy with no policyItems is completely meaningless and it should be deleted.