### PR TITLE
Reslove ranger-examples-distro module compile error

### DIFF
--- a/ranger-examples/distro/src/main/assembly/plugin-sampleapp.xml
+++ b/ranger-examples/distro/src/main/assembly/plugin-sampleapp.xml
@@ -67,4 +67,12 @@
         <fileMode>644</fileMode>
     </fileSet>
    </fileSets>
+   
+   <dependencySets>
+    <dependencySet>
+        <useProjectArtifact>true</useProjectArtifact>
+        <outputDirectory>lib</outputDirectory>
+        <scope>runtime</scope>
+    </dependencySet>
+   </dependencySets>
 </assembly>

--- a/ranger-examples/distro/src/main/assembly/sampleapp.xml
+++ b/ranger-examples/distro/src/main/assembly/sampleapp.xml
@@ -53,4 +53,12 @@
         <fileMode>644</fileMode>
     </fileSet>
    </fileSets>
+   
+   <dependencySets>
+    <dependencySet>
+        <useProjectArtifact>true</useProjectArtifact>
+        <outputDirectory>lib</outputDirectory>
+        <scope>runtime</scope>
+    </dependencySet>
+   </dependencySets>
 </assembly>


### PR DESCRIPTION
When compile ranger with below command:
`mvn -DskipTests clean compile package install assembly:assembly`
Throws create assembly failed:
`[ERROR] Failed to execute goal org.apache.maven.plugins:maven-assembly-plugin:2.6:single (default) on project ranger-examples-distro: Failed to create assembly: Error creating assembly archive sampleapp: You must set at least one file. -> [Help 1]`

[compile error.txt](https://github.com/apache/ranger/files/5042314/compile.error.txt)