### PR TITLE
RANGER-2976. User can not create external table in Hive Plugin

### DIFF
--- a/hive-agent/src/main/java/org/apache/ranger/authorization/hive/authorizer/RangerHiveAuthorizer.java
+++ b/hive-agent/src/main/java/org/apache/ranger/authorization/hive/authorizer/RangerHiveAuthorizer.java
@@ -1883,7 +1883,7 @@ public class RangerHiveAuthorizer extends RangerHiveAuthorizerBase {
 			case ALTERTBLPART_SKEWED_LOCATION:
 			case ALTERTABLE_OWNER:
 			case QUERY:
-				ret = FsAction.ALL;
+				ret = FsAction.READ_WRITE;
 				break;
 
 			case EXPLAIN:


### PR DESCRIPTION
For leaf files, we don't need the permission of FsAction.EXECUTE.