### PR TITLE
Added URL option for reading Keystore files

### DIFF
--- a/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerRESTClient.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerRESTClient.java
@@ -24,6 +24,8 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URL;
+import java.net.URLConnection;
 import java.security.KeyManagementException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -430,6 +432,15 @@ public class RangerRESTClient {
 			}
 			else {
 				in = ClassLoader.getSystemResourceAsStream(fileName);
+			}
+			if(null==in) {
+				URL lurl = RangerRESTClient.class.getClassLoader().getResource(fileName);
+				
+				if (lurl == null ) {
+					lurl = RangerRESTClient.class.getClassLoader().getResource("/" + fileName);
+				}
+				 URLConnection urlConnection = lurl.openConnection();
+				 in = urlConnection.getInputStream();
 			}
 		}
 


### PR DESCRIPTION
In our use case it is not able to load from classpath, so added an option to read it by using URL similar what Ranger has now in org.apache.ranger.authorization.hadoop.config.RangerConfiguration to read the "ranger-" + serviceType + "-security.xml" and  "ranger-" + serviceType + "-audit.xml".
Please add it on next release. thankyou