### PR TITLE
setup.sh: Create lib directory before copying jar

### DIFF
--- a/security-admin/scripts/setup.sh
+++ b/security-admin/scripts/setup.sh
@@ -430,6 +430,7 @@ create_rollback_point() {
 
 copy_db_connector(){
 	log "[I] Copying ${DB_FLAVOR} Connector to $app_home/WEB-INF/lib ";
+	mkdir -p $app_home/WEB-INF/lib
         cp -f $SQL_CONNECTOR_JAR $app_home/WEB-INF/lib
 	check_ret_status $? "Copying ${DB_FLAVOR} Connector to $app_home/WEB-INF/lib failed"
 	log "[I] Copying ${DB_FLAVOR} Connector to $app_home/WEB-INF/lib DONE";


### PR DESCRIPTION
I ran into this while creating docker image for 2.1.0. I think this is a bug, but I cannot find any report elsewhere.

```
2021-01-15 08:02:34,119  [I] Copying POSTGRES Connector to /ranger-2.1.0-admin/ews/webapp/WEB-INF/lib 
2021-01-15 08:02:34,127  [I] Copying POSTGRES Connector to /ranger-2.1.0-admin/ews/webapp/WEB-INF/lib DONE
2021-01-15 08:02:34,130  [I] check if command python exists
2021-01-15 08:02:34,132  [I] 'python' command found
Error: Could not find or load main class org.apache.ranger.common.RangerVersionInfo
/ranger-2.1.0-admin/ews/ranger-admin-services.sh: line 182: cd: /ranger-2.1.0-admin/ews/webapp/WEB-INF/lib: Not a directory
```

```
root@f1376d3be7d3:/ranger-2.1.0-admin# ls -lh /ranger-2.1.0-admin/ews/webapp/WEB-INF/lib
-rw-r--r-- 1 root root 982K Jan 15 08:02 /ranger-2.1.0-admin/ews/webapp/WEB-INF/lib
root@f1376d3be7d3:/ranger-2.1.0-admin# ls -lh postgresql.jar 
-rw-r--r-- 1 ranger ranger 982K Oct 15 13:11 postgresql.jar
```