### PR TITLE
RANGER-3164: Fix build ranger-base docker image error

### DIFF
--- a/dev-support/ranger-docker/Dockerfile.ranger-base
+++ b/dev-support/ranger-docker/Dockerfile.ranger-base
@@ -22,7 +22,7 @@ RUN apt-get update && \
     DEBIAN_FRONTEND="noninteractive" apt-get -y install curl wget tzdata \
     python python3 python3-pip openjdk-8-jdk bc iputils-ping ssh pdsh && \
     curl https://bootstrap.pypa.io/get-pip.py --output /tmp/get-pip.py && \
-    python2 /tmp/get-pip.py && \
+    python3 /tmp/get-pip.py && \
     pip3 install apache-ranger && \
     pip3 install requests && \
     pip install requests


### PR DESCRIPTION
### Fix build image error

**COMMAND:** `docker-compose -f docker-compose.ranger-base.yml -f docker-compose.ranger-build.yml up --remove-orphans`

**ERROR:**

![image](https://user-images.githubusercontent.com/20113411/106077186-0be68e80-614c-11eb-97c8-f134f417fc94.png)

