### PR TITLE
FIX: Update Docker Compose Ranger Depends On

### DIFF
--- a/dev-support/ranger-docker/docker-compose.ranger.yml
+++ b/dev-support/ranger-docker/docker-compose.ranger.yml
@@ -16,12 +16,9 @@ services:
     ports:
       - "6080:6080"
     depends_on:
-      ranger-zk:
-        condition: service_started
-      ranger-db:
-        condition: service_started
-      ranger-solr:
-        condition: service_started
+      - "ranger-zk"
+      - "ranger-db"
+      - "ranger-solr"
     environment:
       - RANGER_VERSION
     command:


### PR DESCRIPTION
Since the docker compose version is at '3', when the build starts, it cannot build the images because of the depends_on `condition: service_started`.