### PR TITLE
RANGER-3245 Install JDK from Ubuntu repository. Add job for ARM64 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,18 +15,21 @@
 
 
 sudo: false
+dist: bionic
 language: java
+
 cache:
   directories:
   - $HOME/.m2
-jdk:
-  - oraclejdk8
-  - oraclejdk11
-  - openjdk10
-  - openjdk11
 
+jdk:
+  - openjdk8
+  - openjdk11
+  - openjdk16
+  
 env:
   - KEY=default VALUE=default
+  
 # Environment to testing with different versions, disabled because ranger is not compatible
 #  - KEY=hadoop.version VALUE=2.8.0
 
@@ -34,12 +37,12 @@ before_install:
   - export MAVEN_OPTS="-Xmx1200M -XX:MaxPermSize=768m -Xms512m"
 
 install:
-  - mvn package -D$KEY=$VALUE -DskipTests -Dmaven.javadoc.skip=true -B -V
+  - mvn verify -D$KEY=$VALUE -DskipTests -Dmaven.javadoc.skip=true -B -V
 
 # KafkaRangerAuthorizerGSSTest is a failing test, TestLdapUserGroup needs too much memory for travis
 script:
   - mvn test -D$KEY=$VALUE -Dmaven.javadoc.skip=true -B -V -pl !plugin-kafka,!ugsync,!hive-agent
   - mvn test -D$KEY=$VALUE -Dmaven.javadoc.skip=true -B -V -pl plugin-kafka -Dtest="*,!KafkaRangerAuthorizerGSSTest"
   - mvn test -D$KEY=$VALUE -Dmaven.javadoc.skip=true -B -V -pl ugsync -Dtest="*,!TestLdapUserGroup"
-  - if [[ "$TRAVIS_JDK_VERSION" != "oraclejdk8" ]]; then mvn test -D$KEY=$VALUE -Dmaven.javadoc.skip=true -B -V -pl hive-agent -Dtest="*,!HIVERangerAuthorizerTest" -DfailIfNoTests=false ; fi
-  - if [[ "$TRAVIS_JDK_VERSION" == "oraclejdk8" ]]; then mvn test -D$KEY=$VALUE -Dmaven.javadoc.skip=true -B -V -pl hive-agent ; fi
+  - if [[ "$TRAVIS_JDK_VERSION" != "openjdk8" ]]; then mvn test -D$KEY=$VALUE -Dmaven.javadoc.skip=true -B -V -pl hive-agent -Dtest="*,!HIVERangerAuthorizerTest" -DfailIfNoTests=false ; fi
+  - if [[ "$TRAVIS_JDK_VERSION" == "openjdk8" ]]; then mvn test -D$KEY=$VALUE -Dmaven.javadoc.skip=true -B -V -pl hive-agent ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ cache:
 jdk:
   - openjdk8
   - openjdk11
-  - openjdk16
   
 env:
   - KEY=default VALUE=default

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,32 +16,46 @@
 
 sudo: false
 dist: bionic
-language: java
+language: generic
 
 cache:
   directories:
-  - $HOME/.m2
+    - $HOME/.m2
 
-jdk:
-  - openjdk8
-  - openjdk11
-  
 env:
-  - KEY=default VALUE=default
-  
+  global:
+    - KEY=default VALUE=default
+
 # Environment to testing with different versions, disabled because ranger is not compatible
 #  - KEY=hadoop.version VALUE=2.8.0
 
+jobs:
+  include:
+    - name: Linux AMD64 OpenJDK8
+      env: JDK_VERSION=8
+    - name: Linux AMD64 OpenJDK11
+      env: JDK_VERSION=11
+    - name: Linux ARM64 OpenJDK11
+      arch: arm64-graviton2
+      dist: focal
+      virt: lxd
+      group: edge
+      env:
+        - JDK_VERSION=11
+        - MAVEN_ARGS="-DskipJSTests=true -P!all"
+
 before_install:
   - export MAVEN_OPTS="-Xmx1200M -XX:MaxPermSize=768m -Xms512m"
+  - sudo apt update -y
+  - sudo apt install openjdk-${JDK_VERSION}-jdk maven
 
 install:
-  - mvn verify -D$KEY=$VALUE -DskipTests -Dmaven.javadoc.skip=true -B -V
+  - mvn package $MAVEN_ARGS -D$KEY=$VALUE -DskipTests -Dmaven.javadoc.skip=true --no-transfer-progress -B -V
 
 # KafkaRangerAuthorizerGSSTest is a failing test, TestLdapUserGroup needs too much memory for travis
 script:
-  - mvn test -D$KEY=$VALUE -Dmaven.javadoc.skip=true -B -V -pl !plugin-kafka,!ugsync,!hive-agent
-  - mvn test -D$KEY=$VALUE -Dmaven.javadoc.skip=true -B -V -pl plugin-kafka -Dtest="*,!KafkaRangerAuthorizerGSSTest"
-  - mvn test -D$KEY=$VALUE -Dmaven.javadoc.skip=true -B -V -pl ugsync -Dtest="*,!TestLdapUserGroup"
-  - if [[ "$TRAVIS_JDK_VERSION" != "openjdk8" ]]; then mvn test -D$KEY=$VALUE -Dmaven.javadoc.skip=true -B -V -pl hive-agent -Dtest="*,!HIVERangerAuthorizerTest" -DfailIfNoTests=false ; fi
-  - if [[ "$TRAVIS_JDK_VERSION" == "openjdk8" ]]; then mvn test -D$KEY=$VALUE -Dmaven.javadoc.skip=true -B -V -pl hive-agent ; fi
+  - mvn test $MAVEN_ARGS -D$KEY=$VALUE -Dmaven.javadoc.skip=true -B -V -pl !plugin-kafka,!ugsync,!hive-agent
+  - mvn test $MAVEN_ARGS -D$KEY=$VALUE -Dmaven.javadoc.skip=true -B -V -pl plugin-kafka -Dtest="*,!KafkaRangerAuthorizerGSSTest"
+  - mvn test $MAVEN_ARGS -D$KEY=$VALUE -Dmaven.javadoc.skip=true -B -V -pl ugsync -Dtest="*,!TestLdapUserGroup"
+  - if [[ "$JDK_VERSION" != "8" ]]; then mvn test $MAVEN_ARGS -D$KEY=$VALUE -Dmaven.javadoc.skip=true -B -V -pl hive-agent -Dtest="*,!HIVERangerAuthorizerTest" -DfailIfNoTests=false ; fi
+  - if [[ "$JDK_VERSION" == "8" ]]; then mvn test $MAVEN_ARGS -D$KEY=$VALUE -Dmaven.javadoc.skip=true -B -V -pl hive-agent ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ before_install:
   - sudo apt install openjdk-${JDK_VERSION}-jdk maven
 
 install:
-  - mvn package $MAVEN_ARGS -D$KEY=$VALUE -DskipTests -Dmaven.javadoc.skip=true --no-transfer-progress -B -V
+  - mvn install $MAVEN_ARGS -D$KEY=$VALUE -DskipTests -Dmaven.javadoc.skip=true --no-transfer-progress -B -V
 
 # KafkaRangerAuthorizerGSSTest is a failing test, TestLdapUserGroup needs too much memory for travis
 script:

--- a/security-admin/pom.xml
+++ b/security-admin/pom.xml
@@ -916,15 +916,8 @@
                             <fail>true</fail>
                         </configuration>
                     </execution>
-                </executions>
-            </plugin>
 
-            <!-- duplicate JAVA patch file version validator plugin -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <version>1.4.1</version>
-                <executions>
+                    <!-- duplicate JAVA patch file version validator plugin -->
                     <execution>
                         <id>duplicate-java-patch-file-version-validator</id>
                         <goals>

--- a/unixauthpam/pom.xml
+++ b/unixauthpam/pom.xml
@@ -32,6 +32,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>native-maven-plugin</artifactId>
+                <version>1.0-alpha-11</version>
                 <extensions>true</extensions>
                 <configuration>
                     <compilerStartOptions>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/RANGER-3245

Oracle 8 is not available at TravisCI anymore. Use OpenJDK 1.8 and 11 instead.

**Note**: this PR depends on https://github.com/apache/ranger/pull/96. Without it the build on JDK 11 will still fail.