### PR TITLE
RANGER-3310 build_ranger_using_docker.sh does not reuse maven local c…

### DIFF
--- a/build_ranger_using_docker.sh
+++ b/build_ranger_using_docker.sh
@@ -87,7 +87,7 @@ ENV PATH $JAVA_HOME/bin:$PATH
 
 
 ADD https://www.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz.sha512 /tools
-ADD http://www-us.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz /tools
+ADD https://downloads.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz /tools
 RUN sha512sum  apache-maven-3.6.3-bin.tar.gz | cut -f 1 -d " " > tmp.sha1
 
 RUN cat apache-maven-3.6.3-bin.tar.gz.sha512 | cut -f 1 -d " " > tmp.sha1.download


### PR DESCRIPTION
issue: https://issues.apache.org/jira/browse/RANGER-3310

# Description
The command 'stat -c "%u" pom.xml' is used to get the UID from host. However, the command is not supported by macOS. Hence, macOS users can't pass 'mvn xxxx' to call build_ranger_using_docker.sh since it causes error like "stat: illegal option -- c". The maven cache of host is mounted to correct path when the command line starts with "mvn". In other words, macOS users can't reuse maven cache and all dependencies have to be download again...

This patch aims to add following changes.

1. instead of using gosu, we directly align UDI inside/outside containers (the container can modify the .m2 folder of host)
2. mount the m2 folder to correct path when running container.

# Test Result (macOS M1)

```./build_ranger_using_docker.sh 2>&1 > ~/log```

[RANGER-3310.log](https://github.com/apache/ranger/files/6610499/RANGER-3310.log)

# Test Result (ubuntu 21.04 amd64)

```./build_ranger_using_docker.sh 2>&1 > ~/log```

[RANGER-3310.log](https://github.com/apache/ranger/files/6632317/RANGER-3310.log)

# Test Result (macOS amd64)

```./build_ranger_using_docker.sh 2>&1 > ~/log```

[RANGER-3310.log](https://github.com/apache/ranger/files/6655126/RANGER-3310.log)



