### PR TITLE
RANGER-3313 Remove org.apache.ranger.audit.entity.AuthzAuditEventDbOb…

### DIFF
--- a/agents-audit/src/main/resources/META-INF/persistence.xml
+++ b/agents-audit/src/main/resources/META-INF/persistence.xml
@@ -17,8 +17,6 @@
 -->
 <persistence version="2.0" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd">
 	<persistence-unit name="xa_server">
-		<class>org.apache.ranger.audit.entity.AuthzAuditEventDbObj</class>
-
 		<properties>
 			<property name="eclipselink.logging.level" value="SEVERE"/>
 		</properties>


### PR DESCRIPTION
RANGER-3184 had removed support for audit to RDBMS. The org.apache.ranger.audit.entity.AuthzAuditEventDbObj in the class element can be removed also.