### PR TITLE
RANGER-3315 Fix travis CI - leverage docker to run CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,33 +13,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 sudo: false
+arch: amd64
+os: linux
+# Ubuntu 20.04 (Focal Fossa) on travis does not support openjdk 8
+# see https://github.com/travis-ci/docs-travis-ci-com/issues/2902
+dist: bionic
 language: java
+
 cache:
   directories:
   - $HOME/.m2
+
+services:
+  - docker
+
+# We have to install correct JDK as Travis CI installs dependencies before our script
+# see https://docs.travis-ci.com/user/languages/java/#maven-dependency-management
 jdk:
-  - oraclejdk8
-  - oraclejdk11
-  - openjdk10
-  - openjdk11
+  - openjdk8
 
-env:
-  - KEY=default VALUE=default
-# Environment to testing with different versions, disabled because ranger is not compatible
-#  - KEY=hadoop.version VALUE=2.8.0
-
-before_install:
-  - export MAVEN_OPTS="-Xmx1200M -XX:MaxPermSize=768m -Xms512m"
-
-install:
-  - mvn package -D$KEY=$VALUE -DskipTests -Dmaven.javadoc.skip=true -B -V
-
-# KafkaRangerAuthorizerGSSTest is a failing test, TestLdapUserGroup needs too much memory for travis
 script:
-  - mvn test -D$KEY=$VALUE -Dmaven.javadoc.skip=true -B -V -pl !plugin-kafka,!ugsync,!hive-agent
-  - mvn test -D$KEY=$VALUE -Dmaven.javadoc.skip=true -B -V -pl plugin-kafka -Dtest="*,!KafkaRangerAuthorizerGSSTest"
-  - mvn test -D$KEY=$VALUE -Dmaven.javadoc.skip=true -B -V -pl ugsync -Dtest="*,!TestLdapUserGroup"
-  - if [[ "$TRAVIS_JDK_VERSION" != "oraclejdk8" ]]; then mvn test -D$KEY=$VALUE -Dmaven.javadoc.skip=true -B -V -pl hive-agent -Dtest="*,!HIVERangerAuthorizerTest" -DfailIfNoTests=false ; fi
-  - if [[ "$TRAVIS_JDK_VERSION" == "oraclejdk8" ]]; then mvn test -D$KEY=$VALUE -Dmaven.javadoc.skip=true -B -V -pl hive-agent ; fi
+  - ./build_ranger_using_docker.sh mvn clean test


### PR DESCRIPTION
issue: https://issues.apache.org/jira/browse/RANGER-3315

We ought to reuse `build_ranger_using_docker.sh` to simplify ranger CI (all required dependencies can be included by container). Also, our travis CI config is broken because of following reasons.
1. Currently, only JDK 8 is supported (https://issues.apache.org/jira/browse/RANGER-3243)
2. the oracle JDK is NOT supported (https://github.com/sormuras/bach/issues/56)