### PR TITLE
Fix ldapconfigcheck script

### DIFF
--- a/ugsync/ldapconfigchecktool/ldapconfigcheck/pom.xml
+++ b/ugsync/ldapconfigchecktool/ldapconfigcheck/pom.xml
@@ -101,5 +101,32 @@
     </dependencies>
     <build>
         <finalName>ldapconfigcheck-${project.version}</finalName>
+        <plugins>
+            <plugin>
+                <artifactId>maven-shade-plugin</artifactId>
+                <configuration>
+                    <filters>
+                        <filter>
+                            <artifact>*:*</artifact>
+                            <excludes>
+                                <exclude>META-INF/*.SF</exclude>
+                                <exclude>META-INF/*.DSA</exclude>
+                                <exclude>META-INF/*.RSA</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <phase>package</phase>
+                    </execution>
+                </executions>
+                <groupId>org.apache.maven.plugins</groupId>
+                <version>3.2.4</version>
+            </plugin>
+        </plugins>
     </build>
 </project>

--- a/ugsync/ldapconfigchecktool/ldapconfigcheck/scripts/run.sh
+++ b/ugsync/ldapconfigchecktool/ldapconfigcheck/scripts/run.sh
@@ -69,7 +69,7 @@ then
 	JAVA_CMD="$JAVA_CMD -p $password"
 fi
 
-if [${AUTH} == 1]
+if [ ${AUTH} == 1 ]
 then
 	prompt="Sample Authentication User Password:"
 	read -p "$prompt" -s authPassword


### PR DESCRIPTION
There is a bug in ldapconfigcheck run.sh script. 

After fixing a bug, maven-shade-plugin is applied so that ldapconfigcheck can work. 

There is not spring security library in classpath,  classnotfound error occurs.