### PR TITLE
Python ranger_client call_api - add case for 404 response

### DIFF
--- a/intg/src/main/python/apache_ranger/client/ranger_client.py
+++ b/intg/src/main/python/apache_ranger/client/ranger_client.py
@@ -325,7 +325,7 @@ class RangerClient:
 
             ret = None
         elif response.status_code == HTTPStatus.SERVICE_NOT_FOUND:
-            LOG.error("Ranger service not found. HTTP Status: %s", HTTPStatus.SERVICE_UNAVAILABLE)
+            LOG.error("Ranger service not found. HTTP Status: %s", HTTPStatus.SERVICE_NOT_FOUND)
 
             ret = None
             

--- a/intg/src/main/python/apache_ranger/client/ranger_client.py
+++ b/intg/src/main/python/apache_ranger/client/ranger_client.py
@@ -324,8 +324,8 @@ class RangerClient:
             LOG.error("Ranger admin unavailable. HTTP Status: %s", HTTPStatus.SERVICE_UNAVAILABLE)
 
             ret = None
-        elif response.status_code == HTTPStatus.SERVICE_NOT_FOUND:
-            LOG.error("Ranger service not found. HTTP Status: %s", HTTPStatus.SERVICE_NOT_FOUND)
+        elif response.status_code == HTTPStatus.NOT_FOUND:
+            LOG.error("Not found. HTTP Status: %s", HTTPStatus.NOT_FOUND)
 
             ret = None
             

--- a/intg/src/main/python/apache_ranger/client/ranger_client.py
+++ b/intg/src/main/python/apache_ranger/client/ranger_client.py
@@ -324,6 +324,11 @@ class RangerClient:
             LOG.error("Ranger admin unavailable. HTTP Status: %s", HTTPStatus.SERVICE_UNAVAILABLE)
 
             ret = None
+        elif response.status_code == HTTPStatus.SERVICE_NOT_FOUND:
+            LOG.error("Ranger service not found. HTTP Status: %s", HTTPStatus.SERVICE_UNAVAILABLE)
+
+            ret = None
+            
         else:
             raise RangerServiceException(api, response)
 

--- a/intg/src/main/python/apache_ranger/utils.py
+++ b/intg/src/main/python/apache_ranger/utils.py
@@ -89,6 +89,6 @@ class HttpMethod(enum.Enum):
 class HTTPStatus:
     OK                    = 200
     NO_CONTENT            = 204
-    NOT_FOUND     = 404
+    NOT_FOUND             = 404
     INTERNAL_SERVER_ERROR = 500
     SERVICE_UNAVAILABLE   = 503

--- a/intg/src/main/python/apache_ranger/utils.py
+++ b/intg/src/main/python/apache_ranger/utils.py
@@ -89,5 +89,6 @@ class HttpMethod(enum.Enum):
 class HTTPStatus:
     OK                    = 200
     NO_CONTENT            = 204
+    SERVICE_NOT_FOUND     = 404
     INTERNAL_SERVER_ERROR = 500
     SERVICE_UNAVAILABLE   = 503

--- a/intg/src/main/python/apache_ranger/utils.py
+++ b/intg/src/main/python/apache_ranger/utils.py
@@ -89,6 +89,6 @@ class HttpMethod(enum.Enum):
 class HTTPStatus:
     OK                    = 200
     NO_CONTENT            = 204
-    SERVICE_NOT_FOUND     = 404
+    NOT_FOUND     = 404
     INTERNAL_SERVER_ERROR = 500
     SERVICE_UNAVAILABLE   = 503


### PR DESCRIPTION
One exemple of problem this PR wants to solve:
When using the method ranger.get_policy(), if the policy do not exists, i get the following error:

![image](https://user-images.githubusercontent.com/23335136/126023407-e0efa40c-28a9-4937-b570-fe72242a01d5.png)

It will crash any program.

This will happen with other methods too.

It happens because the API call do not have a case for dealing with the response 404 (resource do not exist).
So i'm adding it

After this fix, when ranger.get_policy() method is called for a policy da does not exists, it will return None