### PR TITLE
Parse URL using urlib.parse or urlparse instead of os package

### DIFF
--- a/intg/src/main/python/apache_ranger/client/ranger_client.py
+++ b/intg/src/main/python/apache_ranger/client/ranger_client.py
@@ -19,7 +19,10 @@
 
 import json
 import logging
-import os
+try:
+    from urllib.parse import urljoin
+except ImportError:
+    from urlparse import urljoin
 from apache_ranger.exceptions                 import RangerServiceException
 from apache_ranger.model.ranger_base          import RangerBase
 from apache_ranger.model.ranger_policy        import RangerPolicy
@@ -279,7 +282,7 @@ class RangerClient:
         if request_data:
             params['data'] = json.dumps(request_data)
 
-        path = os.path.join(self.url, api.path)
+        path = urljoin(self.url, api.path)
 
         if LOG.isEnabledFor(logging.DEBUG):
             LOG.debug("------------------------------------------------------")


### PR DESCRIPTION
Working on Windows OS produces bug when given Ranger URL has not leading slash which is not common behavior in base URL structure.

```python
from apache_ranger.client.ranger_client import RangerService, RangerClient

ranger_url = "http://dummy.hostname.com:6080"
ranger_auth = ("dummy.username", "dummy.password")
ranger = RangerClient(ranger_url, ranger_auth)

for role in ranger.find_roles():
    print(str(role.id))
```
Above code leads to such error on Windows like systems.
```
Traceback (most recent call last):
  File "C:\Users\szczesny\Desktop\cdpctl\main.py", line 8, in <module>
    for role in ranger.find_roles():
  File "C:\Users\szczesny\AppData\Local\pypoetry\Cache\virtualenvs\cdpctl-1KAmzwEP-py3.9\lib\site-packages\apache_ranger\client\ranger_client.py", line 327, in find_roles
    resp = self.__call_api(RangerClient.FIND_ROLES, filter)
  File "C:\Users\szczesny\AppData\Local\pypoetry\Cache\virtualenvs\cdpctl-1KAmzwEP-py3.9\lib\site-packages\apache_ranger\client\ranger_client.py", line 427, in __call_api
    raise RangerServiceException(api, response)
  File "C:\Users\szczesny\AppData\Local\pypoetry\Cache\virtualenvs\cdpctl-1KAmzwEP-py3.9\lib\site-packages\apache_ranger\exceptions.py", line 39, in __init__
    respJson = response.json()
  File "C:\Users\szczesny\AppData\Local\pypoetry\Cache\virtualenvs\cdpctl-1KAmzwEP-py3.9\lib\site-packages\requests\models.py", line 910, in json
    return complexjson.loads(self.text, **kwargs)
  File "C:\Users\szczesny\AppData\Local\Programs\Python\Python39\lib\json\__init__.py", line 346, in loads
    return _default_decoder.decode(s)
  File "C:\Users\szczesny\AppData\Local\Programs\Python\Python39\lib\json\decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "C:\Users\szczesny\AppData\Local\Programs\Python\Python39\lib\json\decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```
The root cause is target endpoint `http://dummy.hostname.com:6080\service/public/v2/api/roles`.

It can be fixed by manually adding leading slash, but it is just an ugly workaround and may lead to problem when hostname along with port will come from env vars.

```python
[...]
ranger_url = "http://dummy.hostname.com:6080/"
[...]
```
