### PR TITLE
RANGER-2999 fix build failing issue due to a failure of goal executio…

### DIFF
--- a/plugin-kylin/pom.xml
+++ b/plugin-kylin/pom.xml
@@ -47,6 +47,11 @@
             <artifactId>mockito-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.calcite</groupId>
+            <artifactId>calcite-core</artifactId>
+            <version>${calsite.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.kylin</groupId>
             <artifactId>kylin-server-base</artifactId>
             <version>${kylin.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -155,6 +155,7 @@
         <kerby.version>1.0.0</kerby.version>
         <knox.gateway.version>1.2.0</knox.gateway.version>
         <kylin.version>2.6.4</kylin.version>
+        <calsite.version>1.16.0</calsite.version>
         <libpam4j.version>1.10</libpam4j.version>
         <local.lib.dir>${project.basedir}/../lib/local</local.lib.dir>
         <log4j.version>1.2.17</log4j.version>

--- a/ranger-kylin-plugin-shim/pom.xml
+++ b/ranger-kylin-plugin-shim/pom.xml
@@ -33,6 +33,11 @@
     </parent>
     <dependencies>
         <dependency>
+            <groupId>org.apache.calcite</groupId>
+            <artifactId>calcite-core</artifactId>
+            <version>${calsite.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.kylin</groupId>
             <artifactId>kylin-server-base</artifactId>
             <version>${kylin.version}</version>


### PR DESCRIPTION
**Issue**
RANGER-2999
Ranger build is failing if you do not have already downloaded jar under ~/.m2 for calcite-linq4j-1.16.0-kylin-r2

**Root cause**
apache calsite dependecy  wich uses in kylin plugin wasn't included in the pom of "ranger-kylin-plugin" and "ranger-kylin-plugin-shim".

**Any changes to existing functionality?**
No