### PR TITLE
RANGER-3375 Admin shouldn't see services in unassigned security zone

### DIFF
--- a/security-admin/src/main/java/org/apache/ranger/rest/ServiceREST.java
+++ b/security-admin/src/main/java/org/apache/ranger/rest/ServiceREST.java
@@ -33,6 +33,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
 import javax.annotation.PostConstruct;
@@ -194,6 +195,9 @@ public class ServiceREST {
 
 	@Autowired
 	XUserService xUserService;
+
+	@Autowired
+	SecurityZoneDBStore securityZoneDBStore;
 
 	@Autowired
 	AssetMgr assetMgr;
@@ -1017,9 +1021,13 @@ public class ServiceREST {
 										RangerConstants.ROLE_USER)) {
 							
 							List<RangerService> updateServiceList = new ArrayList<RangerService>();
+							List<RangerSecurityZone> securityZones = zoneStore.getSecurityZones(null);
+							Set<String> serviceNames = securityZones.stream().filter(sz -> sz.getAdminUsers().contains(loggedInVXUser.getName()))
+																											.flatMap(sz -> sz.getServices().keySet().stream()).collect(
+									Collectors.toSet());
 							for(RangerService rangerService : paginatedSvcs.getList()){
-								
-								if(rangerService != null){
+
+								if(rangerService != null && serviceNames.contains(rangerService.getName())){
 									updateServiceList.add(hideCriticalServiceDetailsForRoleUser(rangerService));
 								}
 							}


### PR DESCRIPTION
Right now an admin user can clear the Security Zone filter and see services that belong to a security zone to which the admin is not assigned.