### PR TITLE
Update Log4j to 2.17.0 to address CVE-2021-45105

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -227,7 +227,7 @@
         <lucene.version>8.4.0</lucene.version>
         <hppc.version>0.8.0</hppc.version>
         <joda.time.version>2.10.6</joda.time.version>
-        <log4j.core.version>2.16.0</log4j.core.version>
+        <log4j.core.version>2.17.0</log4j.core.version>
         <jsonsmart.version>2.3.1</jsonsmart.version>
         <nimbus-jose-jwt.version>8.22.1</nimbus-jose-jwt.version>
     </properties>


### PR DESCRIPTION
Updating Log4j version to 2.17.0 because of CVE-2021-45105 vulnerability.
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105