### PR TITLE
RANGER-3758: Demote the log level to trace about not having an HBase …

### DIFF
--- a/hbase-agent/src/main/java/org/apache/ranger/authorization/hbase/RangerAuthorizationCoprocessor.java
+++ b/hbase-agent/src/main/java/org/apache/ranger/authorization/hbase/RangerAuthorizationCoprocessor.java
@@ -211,7 +211,10 @@ public class RangerAuthorizationCoprocessor implements AccessControlService.Inte
 		try {
 			remoteAddr = RpcServer.getRemoteAddress().get();
 		} catch (NoSuchElementException e) {
-			LOG.info("Unable to get remote Address");
+			// HBase services will sometimes make calls as a part of
+			// internal operations. It is not worth logging when we do
+			// not have a remote address (a client's remote address).
+			LOG.trace("Unable to get remote Address");
 		}
 
 		if(remoteAddr == null) {


### PR DESCRIPTION
…remote client address

This is an expected case where there is no client address and there is
zero value derived from knowing that one is not present.