### PR TITLE
RANGER-3763:The max limit of the requested entities is not configurable in tagsync

### DIFF
--- a/tagsync/src/main/java/org/apache/ranger/tagsync/process/TagSyncConfig.java
+++ b/tagsync/src/main/java/org/apache/ranger/tagsync/process/TagSyncConfig.java
@@ -99,6 +99,7 @@ public class TagSyncConfig extends Configuration {
 	private static final long DEFAULT_TAGSYNC_ATLASREST_SOURCE_DOWNLOAD_INTERVAL = 900000;
 	private static final long DEFAULT_TAGSYNC_FILESOURCE_MOD_TIME_CHECK_INTERVAL = 60000;
 	private static final long DEFAULT_TAGSYNC_SOURCE_RETRY_INITIALIZATION_INTERVAL = 10000;
+	private static final int DEFAULT_TAGSYNC_SOURCE_REQUESTED_ENTITIES_LIMIT_MAX = 10000;
 
 	private static final String AUTH_TYPE = "hadoop.security.authentication";
 	private static final String NAME_RULES = "hadoop.security.auth_to_local";
@@ -120,7 +121,7 @@ public class TagSyncConfig extends Configuration {
 	private static final int     DEFAULT_TAGSYNC_SINK_MAX_BATCH_SIZE = 1;
 	private static final String  TAGSYNC_SINK_MAX_BATCH_SIZE_PROP    = "ranger.tagsync.dest.ranger.max.batch.size";
 
-
+	private static final String TAGSYNC_ATLAS_REST_SOURCE_REQUESTED_ENTITIES_LIMIT_MAX  = "ranger.tagsync.source.atlasrest.requested.entities.limit.max";
 
 
 	private Properties props;
@@ -538,6 +539,19 @@ public class TagSyncConfig extends Configuration {
 	public static boolean isTagSyncMetricsEnabled(Properties prop) {
 		String val = prop.getProperty(TAGSYNC_METRICS_ENABLED_PROP);
 		return "true".equalsIgnoreCase(StringUtils.trimToEmpty(val));
+	}
+
+	static public int getTagSourceAtlasRequestedEntitiesLimitMax(Properties prop) {
+		String val = prop.getProperty(TAGSYNC_ATLAS_REST_SOURCE_REQUESTED_ENTITIES_LIMIT_MAX);
+		int ret = DEFAULT_TAGSYNC_SOURCE_REQUESTED_ENTITIES_LIMIT_MAX;
+		if (StringUtils.isNotBlank(val)) {
+			try {
+				ret = Integer.valueOf(val);
+			} catch (NumberFormatException exception) {
+				// Ignore
+			}
+		}
+		return ret;
 	}
 
 }

--- a/tagsync/src/main/java/org/apache/ranger/tagsync/source/atlasrest/AtlasRESTTagSource.java
+++ b/tagsync/src/main/java/org/apache/ranger/tagsync/source/atlasrest/AtlasRESTTagSource.java
@@ -63,7 +63,7 @@ import java.util.*;
 public class AtlasRESTTagSource extends AbstractTagSource implements Runnable {
 	private static final Logger LOG = LoggerFactory.getLogger(AtlasRESTTagSource.class);
 
-    	private static final int REQUESTED_ENTITIES_LIMIT_MAX = 10000;
+
     	private static final ThreadLocal<DateFormat> DATE_FORMATTER = new ThreadLocal<DateFormat>() {
 		@Override
 		protected DateFormat initialValue() {
@@ -79,6 +79,7 @@ public class AtlasRESTTagSource extends AbstractTagSource implements Runnable {
 	private String[] restUrls         = null;
 	private boolean  isKerberized     = false;
 	private String[] userNamePassword = null;
+	private int requestedEntitiesLimitMax;
 
 	private Thread myThread = null;
 
@@ -134,6 +135,7 @@ public class AtlasRESTTagSource extends AbstractTagSource implements Runnable {
 
 		sleepTimeBetweenCycleInMillis = TagSyncConfig.getTagSourceAtlasDownloadIntervalInMillis(properties);
 		isKerberized = TagSyncConfig.getTagsyncKerberosIdentity(properties) != null;
+        requestedEntitiesLimitMax = TagSyncConfig.getTagSourceAtlasRequestedEntitiesLimitMax(properties);
 
 		String restEndpoint       = TagSyncConfig.getAtlasRESTEndpoint(properties);
 		String sslConfigFile = TagSyncConfig.getAtlasRESTSslConfigFile(properties);
@@ -256,7 +258,7 @@ public class AtlasRESTTagSource extends AbstractTagSource implements Runnable {
             //searchParams.setIncludeSubClassifications(true);
             //searchParams.setIncludeSubTypes(true);
             searchParams.setIncludeClassificationAttributes(true);
-            searchParams.setLimit(REQUESTED_ENTITIES_LIMIT_MAX);
+            searchParams.setLimit(requestedEntitiesLimitMax);
 
             boolean isMoreData;
             int     nextStartIndex = 0;

--- a/tagsync/src/main/resources/ranger-tagsync-site.xml
+++ b/tagsync/src/main/resources/ranger-tagsync-site.xml
@@ -54,6 +54,10 @@
 		<value>900000</value>
 	</property>
 	<property>
+		<name>ranger.tagsync.source.atlasrest.requested.entities.limit.max</name>
+		<value>10000</value>
+	</property>
+	<property>
 		<name>ranger.tagsync.source.file</name>
 		<value>false</value>
 	</property>


### PR DESCRIPTION
This solves the configuration problem of the max limit of the requested entities