### PR TITLE
RANGER-3788: Bump spring to 5.3.20 and spring.security to 5.7.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -196,9 +196,9 @@
         <slf4j.version>1.7.32</slf4j.version>
         <solr.version>8.6.3</solr.version>
         <spring-ldap-core.version>2.3.5.RELEASE</spring-ldap-core.version>
-        <springframework.security.version>5.6.3</springframework.security.version>
-        <springframework.test.version>5.3.19</springframework.test.version>
-        <springframework.version>5.3.19</springframework.version>
+        <springframework.security.version>5.7.1</springframework.security.version>
+        <springframework.test.version>5.3.20</springframework.test.version>
+        <springframework.version>5.3.20</springframework.version>
         <sqoop.version>1.99.7</sqoop.version>
         <storm.version>1.2.4</storm.version>
         <sun-jersey-bundle.version>1.19</sun-jersey-bundle.version>


### PR DESCRIPTION
PR for https://issues.apache.org/jira/browse/RANGER-3788 

Inspired by https://github.com/apache/nifi/pull/6095/files to solve 

- https://nvd.nist.gov/vuln/detail/CVE-2022-22970 
-  https://nvd.nist.gov/vuln/detail/CVE-2022-22971