### PR TITLE
RANGER-3790: Ranger tagsync module should not depend on kafka server

### DIFF
--- a/distro/src/main/assembly/tagsync.xml
+++ b/distro/src/main/assembly/tagsync.xml
@@ -53,7 +53,6 @@
 							<include>org.apache.hadoop:hadoop-auth</include>
 							<include>org.apache.hadoop:hadoop-common</include>
 							<include>org.apache.commons:commons-compress</include>
-							<include>org.apache.kafka:kafka_${scala.binary.version}:jar:${kafka.version}</include>
 							<include>org.apache.kafka:kafka-clients:jar:${kafka.version}</include>
 							<include>org.apache.ranger:credentialbuilder</include>
 							<include>org.apache.ranger:ranger-plugins-cred</include>


### PR DESCRIPTION
This commit removes the unused kafka core dependency from the assembly xml of the tagsync module, so it will not be added to the distribution.