### PR TITLE
[Trino Plugin] fix the test failure

### DIFF
--- a/plugin-trino/pom.xml
+++ b/plugin-trino/pom.xml
@@ -67,12 +67,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>log4j-over-slf4j</artifactId>
-            <version>${slf4j.version}</version>
-	    <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.ranger</groupId>
             <artifactId>ranger-plugins-common</artifactId>
             <version>${project.version}</version>


### PR DESCRIPTION
I got test failure when test the trino plugin:
```
Caused by: java.lang.IllegalStateException: Detected both log4j-over-slf4j.jar AND bound slf4j-log4j12.jar on the class path, preempting StackOverflowError. See also http://www.slf4j.org/codes.html#log4jDelegationLoop for more details.
	at org.slf4j.impl.Log4jLoggerFactory.<clinit>(Log4jLoggerFactory.java:54)
	... 28 more
```
<img width="1702" alt="Screen Shot 2022-08-12 at 18 00 35" src="https://user-images.githubusercontent.com/4988379/184331932-7614a5a4-d828-4688-83ea-90fad2d069ee.png">


The failure is that the two jars `log4j-over-slf4j.jar` AND `slf4j-log4j12.jar` are detected in the classpath: https://stackoverflow.com/questions/20117720/detected-both-log4j-over-slf4j-jar-and-slf4j-log4j12-jar-on-the-class-path-pree
<img width="796" alt="Screen Shot 2022-08-12 at 17 51 05" src="https://user-images.githubusercontent.com/4988379/184332182-4aa4999e-3d6f-4839-8ccd-9f4f26497edb.png">

So I removed the test dependency `log4j-over-slf4j` to run the test.
