### PR TITLE
[RANGER-3863] Update dependencies to support macOS aarch64 M1 (Apple Silicon) environment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -209,9 +209,9 @@
         <fasterxml.woodstox.version>5.0.3</fasterxml.woodstox.version>
         <fasterxml.jackson.version>2.13.2</fasterxml.jackson.version>
         <fasterxml.jackson.databind.version>2.13.2.2</fasterxml.jackson.databind.version>
-        <kstruct.gethostname4j.version>0.0.2</kstruct.gethostname4j.version>
-        <jna.version>5.2.0</jna.version>
-        <jna-platform.version>5.2.0</jna-platform.version>
+        <kstruct.gethostname4j.version>1.0.0</kstruct.gethostname4j.version>
+        <jna.version>5.7.0</jna.version>
+        <jna-platform.version>5.7.0</jna-platform.version>
         <!-- presto plugin deps -->
         <presto.airlift.version>0.192</presto.airlift.version>
         <presto.bval-jsr.version>2.0.0</presto.bval-jsr.version>


### PR DESCRIPTION
[JIRA LInk](https://issues.apache.org/jira/browse/RANGER-3863)

This Pr is to update dependencies to support macOS aarch64 devices.

We'll see the `UnsatisfiedLinkError` like below:

```plain
Exception in thread "main" java.lang.UnsatisfiedLinkError: /Users/USERNAME/Library/Caches/JetBrains/IntelliJIdea2020.3/tmp/jna6890631648374949923.tmp: dlopen(/Users/USERNAME/Library/Caches/JetBrains/IntelliJIdea2020.3/tmp/jna6890631648374949923.tmp, 1): no suitable image found.  Did find:
	/Users/USERNAME/Library/Caches/JetBrains/IntelliJIdea2020.3/tmp/jna6890631648374949923.tmp: no matching architecture in universal wrapper
	/Users/USERNAME/Library/Caches/JetBrains/IntelliJIdea2020.3/tmp/jna6890631648374949923.tmp: no matching architecture in universal wrapper
	at java.lang.ClassLoader$NativeLibrary.load(Native Method)
```

This is because the dependencies wasn't updated to the version which supports M1.

Maven repo link:
1. [Java Native Access](https://mvnrepository.com/artifact/net.java.dev.jna/jna/5.7.0), [changelog](https://github.com/java-native-access/jna/blob/master/CHANGES.md#release-570)
2. [gethostname4j](https://mvnrepository.com/artifact/com.kstruct/gethostname4j), [related PR](https://github.com/mattsheppard/gethostname4j/pull/8)
