### PR TITLE
Update Hadoop To 3.3.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
         <googlecode.log4jdbc.version>1.2</googlecode.log4jdbc.version>
         <gson.version>2.9.0</gson.version>
         <guice.version>4.0</guice.version>
-        <hadoop.version>3.3.0</hadoop.version>
+        <hadoop.version>3.3.4</hadoop.version>
         <ozone.version>1.0.0</ozone.version>
         <hamcrest.version>2.2</hamcrest.version>
         <hbase.version>2.2.6</hbase.version>

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
         <commons.collections.version>3.2.2</commons.collections.version>
         <commons.compress.version>1.21</commons.compress.version>
         <commons.configuration1.version>1.10</commons.configuration1.version>
-        <commons.configuration.version>2.1.1</commons.configuration.version>
+        <commons.configuration.version>2.8.0</commons.configuration.version>
         <commons.dbcp.version>1.4</commons.dbcp.version>
         <commons.digester.version>2.1</commons.digester.version>
         <commons.io.version>2.11.0</commons.io.version>


### PR DESCRIPTION
Upgrading Hadoop to 3.3.4 will help reduce the number of open CVEs in the ranger product