### PR TITLE
RANGER-3938: Fix for ranger audits in case of an alias

### DIFF
--- a/security-admin/src/main/java/org/apache/ranger/elasticsearch/ElasticSearchUtil.java
+++ b/security-admin/src/main/java/org/apache/ranger/elasticsearch/ElasticSearchUtil.java
@@ -174,7 +174,7 @@ public class ElasticSearchUtil {
         }
         MultiGetRequest multiGetRequest = new MultiGetRequest();
         for (SearchHit hit : hits) {
-            MultiGetRequest.Item item = new MultiGetRequest.Item(index, null, hit.getId());
+            MultiGetRequest.Item item = new MultiGetRequest.Item(hit.getIndex(), null, hit.getId());
             item.fetchSourceContext(FetchSourceContext.FETCH_SOURCE);
             multiGetRequest.add(item);
         }


### PR DESCRIPTION
Fixes [RANGER-3938](https://issues.apache.org/jira/browse/RANGER-3938)
Lets say for ranger audit, we configure an elasticsearch alias(rollover alias). And if there are 2 or more indices for an alias then audit API doesn't work. Because while fetching the records, ranger uses multi get request on an alias. 
It results in below error:
```
Alias [alias-name] has more than one indices associated with it [[index-000002, index-000001]], can't execute a single index op
```

[Code snippet](https://github.com/apache/ranger/blob/6c8a142881896f2c6d1696bcee02c401867a45f9/security-admin/src/main/java/org/apache/ranger/elasticsearch/ElasticSearchUtil.java#L175-L180):
```
        MultiGetRequest multiGetRequest = new MultiGetRequest();
        for (SearchHit hit : hits) {
            MultiGetRequest.Item item = new MultiGetRequest.Item(index, null, hit.getId());
            item.fetchSourceContext(FetchSourceContext.FETCH_SOURCE);
            multiGetRequest.add(item);
        }
```

So there can be 2 possible approaches to resolve this:

- #### Approach 1(Quick and fast) [THIS MERGE REQUEST HAS THIS FIX]:
Use hit.getIndex() instead of index(in this case its has alias) for a MultiGetRequest.Item object.
So that all the documents can be get by id with its index only instead of alias.

- #### Approach 2(Change the MultiGet to search) [NOT PART OF THIS MERGE REQUEST]:
```
POST /_search
{
    "query": {
        "ids" : {
            "values" : ["id1", "id2"]
        }
    }
}
```

Please review.