### PR TITLE
Remove os.path.join causing incorrect windows path

### DIFF
--- a/intg/src/main/python/apache_ranger/client/ranger_client.py
+++ b/intg/src/main/python/apache_ranger/client/ranger_client.py
@@ -19,7 +19,6 @@
 
 import json
 import logging
-import os
 from apache_ranger.exceptions                 import RangerServiceException
 from apache_ranger.model.ranger_base          import RangerBase
 from apache_ranger.model.ranger_policy        import RangerPolicy
@@ -31,6 +30,7 @@ from apache_ranger.model.ranger_service_tags  import RangerServiceTags
 from apache_ranger.utils                      import *
 from requests                                 import Session
 from requests                                 import Response
+from urllib.parse                             import urljoin
 
 LOG = logging.getLogger(__name__)
 
@@ -402,7 +402,7 @@ class RESTResponse(RangerBase):
 
 class RangerClientHttp:
     def __init__(self, url, auth):
-        self.url          = url
+        self.url          = url.rstrip('/')
         self.session      = Session()
         self.session.auth = auth
 
@@ -417,7 +417,7 @@ class RangerClientHttp:
         if request_data:
             params['data'] = json.dumps(request_data)
 
-        path = os.path.join(self.url, api.path)
+        path = urljoin(self.url, api.path.lstrip('/'))
 
         if LOG.isEnabledFor(logging.DEBUG):
             LOG.debug("------------------------------------------------------")


### PR DESCRIPTION
@mneethiraj **The exact same issue occurred with `apache-atlas` and was already merged https://github.com/apache/atlas/pull/203**

When running on *Windows* the `os.path.join` using the operating systems `os.sep=\` which causing the full url to be incorrect.

Using `urllib.parse` might be a little bit slower, but is less error-prone.