### PR TITLE
RANGER-3751: fix for elastic search audit date format

### DIFF
--- a/security-admin/src/main/java/org/apache/ranger/elasticsearch/ElasticSearchAccessAuditsService.java
+++ b/security-admin/src/main/java/org/apache/ranger/elasticsearch/ElasticSearchAccessAuditsService.java
@@ -257,7 +257,7 @@ public class ElasticSearchAccessAuditsService extends org.apache.ranger.AccessAu
 		}
 		value = source.get("evtTime");
 		if (value != null) {
-			accessAudit.setEventTime(MiscUtil.toDate(value));
+			accessAudit.setEventTime(MiscUtil.toLocalDate(value));
 		}
 		value = source.get("seq_num");
 		if (value != null) {


### PR DESCRIPTION
This fixes date time show as 1970 in UI for elasticsearch audit store. This issue was introduced by work with cloudwatch audit store.