### PR TITLE
RANGER-3985: use table creation rule for trino

### DIFF
--- a/plugin-trino/src/main/java/org/apache/ranger/authorization/trino/authorizer/RangerSystemAccessControl.java
+++ b/plugin-trino/src/main/java/org/apache/ranger/authorization/trino/authorizer/RangerSystemAccessControl.java
@@ -397,12 +397,9 @@ public class RangerSystemAccessControl
     }
   }
 
-  /**
-   * Create table is verified on schema level
-   */
   @Override
   public void checkCanCreateTable(SystemSecurityContext context, CatalogSchemaTableName table, Map<String, Object> properties) {
-    if (!hasPermission(createResource(table.getCatalogName(), table.getSchemaTableName().getSchemaName()), context, TrinoAccessType.CREATE)) {
+    if (!hasPermission(createResource(table), context, TrinoAccessType.CREATE)) {
       LOG.debug("RangerSystemAccessControl.checkCanCreateTable(" + table.getSchemaTableName().getTableName() + ") denied");
       AccessDeniedException.denyCreateTable(table.getSchemaTableName().getTableName());
     }
@@ -488,12 +485,9 @@ public class RangerSystemAccessControl
     }
   }
 
-  /**
-   * Create view is verified on schema level
-   */
   @Override
   public void checkCanCreateView(SystemSecurityContext context, CatalogSchemaTableName view) {
-    if (!hasPermission(createResource(view.getCatalogName(), view.getSchemaTableName().getSchemaName()), context, TrinoAccessType.CREATE)) {
+    if (!hasPermission(createResource(view), context, TrinoAccessType.CREATE)) {
       LOG.debug("RangerSystemAccessControl.checkCanCreateView(" + view.getSchemaTableName().getTableName() + ") denied");
       AccessDeniedException.denyCreateView(view.getSchemaTableName().getTableName());
     }

--- a/plugin-trino/src/test/java/org/apache/ranger/authorization/trino/authorizer/RangerSystemAccessControlTest.java
+++ b/plugin-trino/src/test/java/org/apache/ranger/authorization/trino/authorizer/RangerSystemAccessControlTest.java
@@ -132,7 +132,14 @@ public class RangerSystemAccessControlTest {
     assertEquals(accessControlManager.filterTables(context(alice), aliceCatalog, aliceTables), aliceTables);
     assertEquals(accessControlManager.filterTables(context(bob), "alice-catalog", aliceTables), ImmutableSet.of());
 
-    accessControlManager.checkCanCreateTable(context(alice), aliceTable,Map.of());
+    accessControlManager.checkCanCreateTable(context(alice), aliceTable, Map.of());
+    assertThrows(AccessDeniedException.class, () -> {
+      accessControlManager.checkCanCreateTable(
+        context(alice),
+        new CatalogSchemaTableName("alice-catalog", "schema", "wrong-table"),
+        Map.of()
+      );
+    });
     accessControlManager.checkCanDropTable(context(alice), aliceTable);
     accessControlManager.checkCanSelectFromColumns(context(alice), aliceTable, ImmutableSet.of());
     accessControlManager.checkCanInsertIntoTable(context(alice), aliceTable);
@@ -141,7 +148,7 @@ public class RangerSystemAccessControlTest {
 
 
     try {
-      accessControlManager.checkCanCreateTable(context(bob), aliceTable,Map.of());
+      accessControlManager.checkCanCreateTable(context(bob), aliceTable, Map.of());
     } catch (AccessDeniedException expected) {
     }
   }
@@ -151,6 +158,12 @@ public class RangerSystemAccessControlTest {
   public void testViewOperations()
   {
     accessControlManager.checkCanCreateView(context(alice), aliceView);
+    assertThrows(AccessDeniedException.class, () -> {
+      accessControlManager.checkCanCreateView(
+        context(alice),
+        new CatalogSchemaTableName("alice-catalog", "schema", "wrong-view")
+      );
+    });
     accessControlManager.checkCanDropView(context(alice), aliceView);
     accessControlManager.checkCanSelectFromColumns(context(alice), aliceView, ImmutableSet.of());
     accessControlManager.checkCanCreateViewWithSelectFromColumns(context(alice), aliceTable, ImmutableSet.of());

--- a/plugin-trino/src/test/resources/trino-policies.json
+++ b/plugin-trino/src/test/resources/trino-policies.json
@@ -293,6 +293,10 @@
         {
           "accesses": [
             {
+              "type": "create",
+              "isAllowed": true
+            },
+            {
               "type": "select",
               "isAllowed": true
             },
@@ -444,6 +448,10 @@
           "accesses": [
             {
               "type": "select",
+              "isAllowed": true
+            },
+            {
+              "type": "create",
               "isAllowed": true
             },
             {


### PR DESCRIPTION
The ranger rules to create tables in Trino currently check schema level to create.

If this is set, anyone can create any table/view. There is no way to limit the naming of tables.

However e.g. drop, alter rights are granted on table level. So user might create any table, but not remove them.

To allow a more strict implementation view/table creation should verify table name as well.

In that case the previous behaviour can be created by adding a rule to allow create on catalog/schema/*.