### PR TITLE
RANGER-4071: Support for LDAP/AD usernames and group names with special chars

### DIFF
--- a/ugsync/src/main/java/org/apache/ranger/unixusersync/config/UserGroupSyncConfig.java
+++ b/ugsync/src/main/java/org/apache/ranger/unixusersync/config/UserGroupSyncConfig.java
@@ -1335,16 +1335,18 @@ public class UserGroupSyncConfig  {
 		return isUserSyncNameValidationEnabled;
 	}
 
-	public String getRegexSeparator() throws RuntimeException {
+	public String getRegexSeparator() {
+		String ret = DEFAULT_MAPPING_SEPARATOR;
 		String val = prop.getProperty(SYNC_MAPPING_SEPARATOR);
 		if(StringUtils.isNotEmpty(val)) {
-			if (val.length() == 1)
-				return val;
-			else{
-				throw new RuntimeException("More than one character found in RegEx Separator");
+			if (val.length() == 1) {
+				ret = val;
+			} else {
+				LOG.warn("More than one character found in RegEx Separator, using default RegEx Separator");
 			}
 		}
-		return DEFAULT_MAPPING_SEPARATOR;
+		LOG.info(String.format("Using %s as the RegEx Separator", ret));
+		return ret;
 	}
 
 

--- a/ugsync/src/main/java/org/apache/ranger/unixusersync/config/UserGroupSyncConfig.java
+++ b/ugsync/src/main/java/org/apache/ranger/unixusersync/config/UserGroupSyncConfig.java
@@ -1342,7 +1342,7 @@ public class UserGroupSyncConfig  {
 			if (val.length() == 1) {
 				ret = val;
 			} else {
-				LOG.warn("More than one character found in RegEx Separator, using default RegEx Separator");
+				LOG.warn("More than one character found in RegEx Separator, using default RegEx Separator /");
 			}
 		}
 		LOG.info(String.format("Using %s as the RegEx Separator", ret));

--- a/ugsync/src/main/java/org/apache/ranger/unixusersync/config/UserGroupSyncConfig.java
+++ b/ugsync/src/main/java/org/apache/ranger/unixusersync/config/UserGroupSyncConfig.java
@@ -254,6 +254,9 @@ public class UserGroupSyncConfig  {
 	private static final String SYNC_MAPPING_GROUPNAME_HANDLER = "ranger.usersync.mapping.groupname.handler";
 	private static final String DEFAULT_SYNC_MAPPING_GROUPNAME_HANDLER = "org.apache.ranger.usergroupsync.RegEx";
 
+	private static final String SYNC_MAPPING_SEPARATOR = "ranger.usersync.mapping.regex.separator";
+
+	private static final String DEFAULT_MAPPING_SEPARATOR = "/";
     private static final String ROLE_ASSIGNMENT_LIST_DELIMITER = "ranger.usersync.role.assignment.list.delimiter";
 
     private static final String USERS_GROUPS_ASSIGNMENT_LIST_DELIMITER = "ranger.usersync.users.groups.assignment.list.delimiter";
@@ -1330,6 +1333,18 @@ public class UserGroupSyncConfig  {
 			isUserSyncNameValidationEnabled  = Boolean.valueOf(val);
 		}
 		return isUserSyncNameValidationEnabled;
+	}
+
+	public String getRegexSeparator() throws RuntimeException {
+		String val = prop.getProperty(SYNC_MAPPING_SEPARATOR);
+		if(StringUtils.isNotEmpty(val)) {
+			if (val.length() == 1)
+				return val;
+			else{
+				throw new RuntimeException("More than one character found in RegEx Separator");
+			}
+		}
+		return DEFAULT_MAPPING_SEPARATOR;
 	}
 
 

--- a/ugsync/src/main/java/org/apache/ranger/usergroupsync/RegEx.java
+++ b/ugsync/src/main/java/org/apache/ranger/usergroupsync/RegEx.java
@@ -39,15 +39,17 @@ public class RegEx extends AbstractMapper {
 		logger.info("Initializing for " + baseProperty);
 		try {
 			List<String> regexPatterns = config.getAllRegexPatterns(baseProperty);
-			populateReplacementPatterns(baseProperty, regexPatterns);
+			String regexSeparator = config.getRegexSeparator();
+			populateReplacementPatterns(baseProperty, regexPatterns, regexSeparator);
 		} catch (Throwable t) {
 			logger.error("Failed to initialize " + baseProperty, t.fillInStackTrace());
 		}
 	}
 
-	protected void populateReplacementPatterns(String baseProperty, List<String> regexPatterns) throws Throwable{
+	protected void populateReplacementPatterns(String baseProperty, List<String> regexPatterns, String regexSeparator) throws Throwable {
 		replacementPattern = new LinkedHashMap<String, String>();
-		Pattern p = Pattern.compile("s/([^/]*)/([^/]*)/(g)?");
+		String regex = String.format("s%s([^%s]*)%s([^%s]*)%s(g)?", regexSeparator, regexSeparator, regexSeparator, regexSeparator, regexSeparator);
+		Pattern p = Pattern.compile(regex);
 		for (String regexPattern : regexPatterns) {
 			Matcher m = p.matcher(regexPattern);
 			if (!m.matches()) {
@@ -72,15 +74,11 @@ public class RegEx extends AbstractMapper {
 		String result = attrValue;
 		try {
 			if (replacementPattern != null && !replacementPattern.isEmpty()) {
-				for (String matchPattern : replacementPattern.keySet()) {
+				for (String matchPattern: replacementPattern.keySet()) {
+					String replacement = replacementPattern.get(matchPattern);
 					Pattern p = Pattern.compile(matchPattern);
 					Matcher m = p.matcher(result);
-					if (m.find()) {
-						String replacement = replacementPattern.get(matchPattern);
-						if (replacement != null) {
-							result = m.replaceAll(replacement);
-						}
-					}
+					result    = m.replaceAll(replacement);
 				}
 			}
 		} catch (Throwable t) {

--- a/ugsync/src/test/java/org/apache/ranger/usergroupsync/TestRegEx.java
+++ b/ugsync/src/test/java/org/apache/ranger/usergroupsync/TestRegEx.java
@@ -22,6 +22,7 @@ package org.apache.ranger.usergroupsync;
 import static org.junit.Assert.*;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.Before;
@@ -99,6 +100,28 @@ public class TestRegEx {
             userNameRegEx.populateReplacementPatterns(userNameBaseProperty, userRegexPatterns, separator);
             assertEquals("DE/dark_knight_admin", userNameRegEx.transform("dark_knight_admin"));
         }
+    }
+
+    @Test
+    public void testUsernamePrefix() throws Throwable {
+        // appends PR/ to the beginning
+        String separator = "#";
+        userRegexPatterns = Collections.singletonList("s#^(.*)#PR/$1#g");
+        userNameRegEx.populateReplacementPatterns(userNameBaseProperty, userRegexPatterns, separator);
+        assertEquals("PR/mew_two", userNameRegEx.transform("mew_two"));
+        assertEquals("PR/dragoon", userNameRegEx.transform("dragoon"));
+        assertEquals("PR/pikachu", userNameRegEx.transform("pikachu"));
+        assertEquals("PR/dialga", userNameRegEx.transform("dialga"));
+    }
+
+    @Test
+    public void testUsernameSuffix() throws Throwable {
+        // appends _ty to the end
+        String separator = "#";
+        userRegexPatterns = Collections.singletonList("s#^(.*)#$1_ty#g");
+        userNameRegEx.populateReplacementPatterns(userNameBaseProperty, userRegexPatterns, separator);
+        assertEquals("mew_ty", userNameRegEx.transform("mew"));
+        assertEquals("onix_ty", userNameRegEx.transform("onix"));
     }
 
 }

--- a/ugsync/src/test/java/org/apache/ranger/usergroupsync/TestRegEx.java
+++ b/ugsync/src/test/java/org/apache/ranger/usergroupsync/TestRegEx.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 public class TestRegEx {
 	protected String userNameBaseProperty = "ranger.usersync.mapping.username.regex";
     protected String groupNameBaseProperty = "ranger.usersync.mapping.groupname.regex";
+    protected String mappingSeparator = "/";
     protected RegEx userNameRegEx = null;
     protected RegEx groupNameRegEx = null;
     List<String> userRegexPatterns = null;
@@ -47,46 +48,57 @@ public class TestRegEx {
 
 	@Test
     public void testUserNameTransform() throws Throwable {
-            userRegexPatterns.add("s/\\s/_/");
-            userNameRegEx.populateReplacementPatterns(userNameBaseProperty, userRegexPatterns);
-            assertEquals("test_user", userNameRegEx.transform("test user"));
+        userRegexPatterns.add("s/\\s/_/");
+        userNameRegEx.populateReplacementPatterns(userNameBaseProperty, userRegexPatterns, mappingSeparator);
+        assertEquals("test_user", userNameRegEx.transform("test user"));
     }
 
     @Test
     public void testGroupNameTransform() throws Throwable {
-            groupRegexPatterns.add("s/\\s/_/g");
-            groupRegexPatterns.add("s/_/\\$/g");
-            groupNameRegEx.populateReplacementPatterns(groupNameBaseProperty, groupRegexPatterns);
-            assertEquals("ldap$grp", groupNameRegEx.transform("ldap grp"));
+        groupRegexPatterns.add("s/\\s/_/g");
+        groupRegexPatterns.add("s/_/\\$/g");
+        groupNameRegEx.populateReplacementPatterns(groupNameBaseProperty, groupRegexPatterns, mappingSeparator);
+        assertEquals("ldap$grp", groupNameRegEx.transform("ldap grp"));
     }
 
     @Test
     public void testEmptyTransform() {
-            assertEquals("test user", userNameRegEx.transform("test user"));
-            assertEquals("ldap grp", groupNameRegEx.transform("ldap grp"));
+        assertEquals("test user", userNameRegEx.transform("test user"));
+        assertEquals("ldap grp", groupNameRegEx.transform("ldap grp"));
     }
 
     @Test
     public void testTransform() throws Throwable {
-            userRegexPatterns.add("s/\\s/_/g");
-            groupRegexPatterns.add("s/\\s/_/g");
-            userNameRegEx.populateReplacementPatterns(userNameBaseProperty, userRegexPatterns);
-            groupNameRegEx.populateReplacementPatterns(groupNameBaseProperty, groupRegexPatterns);
-            assertEquals("test_user", userNameRegEx.transform("test user"));
-            assertEquals("ldap_grp", groupNameRegEx.transform("ldap grp"));
+        userRegexPatterns.add("s/\\s/_/g");
+        groupRegexPatterns.add("s/\\s/_/g");
+        userNameRegEx.populateReplacementPatterns(userNameBaseProperty, userRegexPatterns, mappingSeparator);
+        groupNameRegEx.populateReplacementPatterns(groupNameBaseProperty, groupRegexPatterns, mappingSeparator);
+        assertEquals("test_user", userNameRegEx.transform("test user"));
+        assertEquals("ldap_grp", groupNameRegEx.transform("ldap grp"));
     }
 
     @Test
     public void testTransform1() throws Throwable {
-            userRegexPatterns.add("s/\\\\/ /g");
-            userRegexPatterns.add("s//_/g");
-            userNameRegEx.populateReplacementPatterns(userNameBaseProperty, userRegexPatterns);
-            groupRegexPatterns.add("s/\\s/\\$/g");
-            groupRegexPatterns.add("s/\\s");
-            groupRegexPatterns.add("s/\\$//g");
-            groupNameRegEx.populateReplacementPatterns(groupNameBaseProperty, groupRegexPatterns);
-            assertEquals("test user", userNameRegEx.transform("test\\user"));
-            assertEquals("ldapgrp", groupNameRegEx.transform("ldap grp"));
+        userRegexPatterns.add("s/\\\\/ /g");
+        userRegexPatterns.add("s//_/g");
+        userNameRegEx.populateReplacementPatterns(userNameBaseProperty, userRegexPatterns, mappingSeparator);
+        groupRegexPatterns.add("s/\\s/\\$/g");
+        groupRegexPatterns.add("s/\\s");
+        groupRegexPatterns.add("s/\\$//g");
+        groupNameRegEx.populateReplacementPatterns(groupNameBaseProperty, groupRegexPatterns, mappingSeparator);
+        assertEquals("test user", userNameRegEx.transform("test\\user"));
+        assertEquals("ldapgrp", groupNameRegEx.transform("ldap grp"));
+    }
+
+    @Test
+    public void testTransformWithSeparators() throws Throwable {
+        String[] separators = {"%", "#", "&", "!", "@", "-", "~", "=", ",", " "};
+        for (String separator : separators) {
+            userRegexPatterns = new ArrayList<String>();
+            userRegexPatterns.add(String.format("s%sdark%sDE/dark%sg", separator, separator, separator));
+            userNameRegEx.populateReplacementPatterns(userNameBaseProperty, userRegexPatterns, separator);
+            assertEquals("DE/dark_knight_admin", userNameRegEx.transform("dark_knight_admin"));
+        }
     }
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?


Ranger usersync regards the forward slash ('/') as a separator character in the regex so it ignores it if you actually want to use it in your groupname. e.g. RRR/group_name_suffix (/ can be potentially used as a domain separator in AD groups)


Using a different character like + in the regex works to get something like RRR+group_name_suffix but not RRR/group_name_suffix.

## How was this patch tested?

Added unit tests for the new feature.
mvn clean package on ugsync module.

Tested the changes on a cluster with these additional usersync configs with LDAP sync source:

name: ranger.usersync.mapping.regex.separator
value: #

name: ranger.usersync.mapping.username.regex
value: s#^(.*)#DE/$1#g
