### PR TITLE
RANGER-4043: Fix 'getent group' command when enumerate groups is enabled

### DIFF
--- a/ugsync/src/main/java/org/apache/ranger/unixusersync/process/UnixUserGroupBuilder.java
+++ b/ugsync/src/main/java/org/apache/ranger/unixusersync/process/UnixUserGroupBuilder.java
@@ -538,7 +538,7 @@ public class UnixUserGroupBuilder implements UserGroupSource {
 
 			for (String group : groups) {
 				String command = String.format(groupCmd, group);
-				String[] cmd = new String[]{"bash", "-c", command + " '" + group + "'"};
+				String[] cmd = new String[]{"bash", "-c", command};
 				if (LOG.isDebugEnabled()) {
 					LOG.debug("Executing: " + Arrays.toString(cmd));
 				}


### PR DESCRIPTION
## What changes were proposed in this pull request?

'getent group' command incorrectly used with 2 parameters which caused command to return null instead of group info. Corrected the command usage

Original command: `String[] cmd = new String[] {"bash", "-c", command + " '" + group + "'"};`
Results in: bash -c getent group test_group1 'test_group1' - incorrect

New changed command: `String[] cmd = new String[] {"bash", "-c", command };`
Results in: bash -c getent group test_group1 - correct

## How was this patch tested?
ranger.usersync.group.enumerategroup property set to "root,wheel,daemon"
Obtained logs suggest getent command successfully got executed:
```
2023-03-01 21:11:58,625 DEBUG org.apache.ranger.unixusersync.process.UnixUserGroupBuilder: Executing: [bash, -c, getent group root]
2023-03-01 21:11:58,630 DEBUG org.apache.ranger.unixusersync.process.UnixUserGroupBuilder: bash -c getent group root for group root returned root:x:0:
2023-03-01 21:11:58,630 DEBUG org.apache.ranger.unixusersync.process.UnixUserGroupBuilder: Executing: [bash, -c, getent group wheel]
2023-03-01 21:11:58,639 DEBUG org.apache.ranger.unixusersync.process.UnixUserGroupBuilder: bash -c getent group wheel for group wheel returned wheel:x:10:jenkins
2023-03-01 21:11:58,639 DEBUG org.apache.ranger.unixusersync.process.UnixUserGroupBuilder: Executing: [bash, -c, getent group daemon]
2023-03-01 21:11:58,647 DEBUG org.apache.ranger.unixusersync.process.UnixUserGroupBuilder: bash -c getent group daemon for group daemon returned daemon:x:2:
2023-03-01 21:11:58,647 DEBUG org.apache.ranger.unixusersync.process.UnixUserGroupBuilder: Done adding extra groups 
```
Verified the obtained log results by executing commands such as "bash -c getent group daemon" which returned consistent results as logs.
