### PR TITLE
Simplifies the dependency of `gethostname4j` for the ranger client

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -248,7 +248,6 @@ This product includes ES5 15.5.4.20 (https://github.com/kriskowal/es5-shim ), Co
 This product includes PURE CSS GUI ICONS 1.0.1(http://nicolasgallagher.com/pure-css-gui-icons/ - Dual licensed under MIT and GNU GPLv2), by Nicolas Gallagher
 This product includes libpam4j 1.8 (https://github.com/kohsuke/libpam4j ), Copyright Kohsuke Kawaguchi.
 This product bundles VisualSearch.js 0.4.0 (http://documentcloud.github.io/visualsearch/docs/visualsearch.html ), © 2011 Samuel Clay, @samuelclay, DocumentCloud Inc.
-This product bundles gethostname4j 0.0.2 (https://github.com/mattsheppard/gethostname4j ), Copyright (c) 2017 Matt Sheppard.
 
 
 All rights reserved.

--- a/agents-common/pom.xml
+++ b/agents-common/pom.xml
@@ -138,21 +138,6 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>net.java.dev.jna</groupId>
-            <artifactId>jna</artifactId>
-            <version>${jna.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>net.java.dev.jna</groupId>
-            <artifactId>jna-platform</artifactId>
-            <version>${jna-platform.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.kstruct</groupId>
-            <artifactId>gethostname4j</artifactId>
-            <version>${kstruct.gethostname4j.version}</version>
-        </dependency>
-        <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
         </dependency>

--- a/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerRESTUtils.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerRESTUtils.java
@@ -26,7 +26,6 @@ import java.net.UnknownHostException;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.kstruct.gethostname4j.Hostname;
 
 /**
  * Since this class does not retain any state.  It isn't a singleton for testability.
@@ -91,7 +90,7 @@ public class RangerRESTUtils {
 
 	static {
 		try {
-			hostname = Hostname.getHostname();
+			hostname = InetAddress.getLocalHost().getHostName();
 		}
 		catch(Exception e) {
 			LOG.error("ERROR: Unable to find hostname for the agent ", e);

--- a/distro/src/main/assembly/admin-web.xml
+++ b/distro/src/main/assembly/admin-web.xml
@@ -255,9 +255,6 @@
           <include>org.codehaus.woodstox:stax2-api:jar:${codehaus.woodstox.stax2api.version}</include>
           <include>org.apache.commons:commons-configuration2:jar:${commons.configuration.version}</include>
           <include>org.apache.commons:commons-lang3:jar:${commons.lang3.version}</include>
-          <include>com.kstruct:gethostname4j:jar:${kstruct.gethostname4j.version}</include>
-          <include>net.java.dev.jna:jna:jar:${jna.version}</include>
-          <include>net.java.dev.jna:jna-platform:jar:${jna-platform.version}</include>
           <include>org.apache.ranger:credentialbuilder</include>
           <include>org.elasticsearch.client:elasticsearch-rest-client</include>
           <include>org.elasticsearch.client:elasticsearch-rest-high-level-client</include>

--- a/distro/src/main/assembly/hbase-agent.xml
+++ b/distro/src/main/assembly/hbase-agent.xml
@@ -61,9 +61,6 @@
           <include>org.noggit:noggit:jar:${noggit.version}</include>
           <include>org.apache.solr:solr-solrj:jar:${solr.version}</include>
           <include>com.google.guava:guava:jar:${google.guava.version}</include>
-          <include>com.kstruct:gethostname4j:jar:${kstruct.gethostname4j.version}</include>
-          <include>net.java.dev.jna:jna:jar:${jna.version}</include>
-          <include>net.java.dev.jna:jna-platform:jar:${jna-platform.version}</include>
           <include>org.elasticsearch:elasticsearch</include>
           <include>org.elasticsearch:elasticsearch-core</include>
           <include>org.elasticsearch:elasticsearch-x-content</include>

--- a/distro/src/main/assembly/hdfs-agent.xml
+++ b/distro/src/main/assembly/hdfs-agent.xml
@@ -90,9 +90,6 @@
           <include>org.apache.httpcomponents:httpcore:jar:${httpcomponents.httpcore.version}</include>
           <include>org.noggit:noggit:jar:${noggit.version}</include>
           <include>org.apache.solr:solr-solrj:jar:${solr.version}</include>
-          <include>com.kstruct:gethostname4j:jar:${kstruct.gethostname4j.version}</include>
-          <include>net.java.dev.jna:jna:jar:${jna.version}</include>
-          <include>net.java.dev.jna:jna-platform:jar:${jna-platform.version}</include>
           <include>org.elasticsearch:elasticsearch</include>
           <include>org.elasticsearch:elasticsearch-core</include>
           <include>org.elasticsearch:elasticsearch-x-content</include>

--- a/distro/src/main/assembly/hive-agent.xml
+++ b/distro/src/main/assembly/hive-agent.xml
@@ -59,9 +59,6 @@
           <include>org.apache.httpcomponents:httpcore:jar:${httpcomponents.httpcore.version}</include>
           <include>org.noggit:noggit:jar:${noggit.version}</include>
           <include>org.apache.solr:solr-solrj:jar:${solr.version}</include>
-          <include>com.kstruct:gethostname4j:jar:${kstruct.gethostname4j.version}</include>
-          <include>net.java.dev.jna:jna:jar:${jna.version}</include>
-          <include>net.java.dev.jna:jna-platform:jar:${jna-platform.version}</include>
           <include>org.elasticsearch:elasticsearch</include>
           <include>org.elasticsearch:elasticsearch-core</include>
           <include>org.elasticsearch:elasticsearch-x-content</include>

--- a/distro/src/main/assembly/kms.xml
+++ b/distro/src/main/assembly/kms.xml
@@ -206,9 +206,6 @@
                     <include>org.apache.htrace:htrace-core4:jar:${htrace-core.version}</include>
                     <include>org.apache.solr:solr-solrj:jar:${solr.version}</include>
                     <include>org.apache.ranger:ranger-plugins-common</include>
-                    <include>com.kstruct:gethostname4j:jar:${kstruct.gethostname4j.version}</include>
-                    <include>net.java.dev.jna:jna:jar:${jna.version}</include>
-                    <include>net.java.dev.jna:jna-platform:jar:${jna-platform.version}</include>
                     <include>org.apache.ranger:credentialbuilder</include>
                     <include>org.apache.commons:commons-compress:jar:${commons.compress.version}</include>
                     <include>org.apache.commons:commons-lang3</include>
@@ -300,9 +297,6 @@
                             <include>org.noggit:noggit:jar:${noggit.version}</include>
                             <include>org.apache.zookeeper:zookeeper:jar:${zookeeper.version}</include>
                             <include>org.apache.solr:solr-solrj:jar:${solr.version}</include>
-                            <include>com.kstruct:gethostname4j:jar:${kstruct.gethostname4j.version}</include>
-                            <include>net.java.dev.jna:jna:jar:${jna.version}</include>
-                            <include>net.java.dev.jna:jna-platform:jar:${jna-platform.version}</include>
                             <include>org.elasticsearch:elasticsearch</include>
                             <include>org.elasticsearch:elasticsearch-core</include>
                             <include>org.elasticsearch:elasticsearch-x-content</include>

--- a/distro/src/main/assembly/knox-agent.xml
+++ b/distro/src/main/assembly/knox-agent.xml
@@ -68,9 +68,6 @@
           <include>org.codehaus.jackson:jackson-core-asl:jar:${codehaus.jackson.version}</include>
           <include>org.codehaus.jackson:jackson-mapper-asl:jar:${codehaus.jackson.version}</include>
           <include>org.apache.solr:solr-solrj:jar:${solr.version}</include>
-          <include>com.kstruct:gethostname4j:jar:${kstruct.gethostname4j.version}</include>
-          <include>net.java.dev.jna:jna:jar:${jna.version}</include>
-          <include>net.java.dev.jna:jna-platform:jar:${jna-platform.version}</include>
           <include>org.elasticsearch:elasticsearch</include>
           <include>org.elasticsearch:elasticsearch-core</include>
           <include>org.elasticsearch:elasticsearch-x-content</include>

--- a/distro/src/main/assembly/plugin-atlas.xml
+++ b/distro/src/main/assembly/plugin-atlas.xml
@@ -64,9 +64,6 @@
           <include>org.codehaus.jackson:jackson-core-asl</include>
           <include>org.codehaus.jackson:jackson-mapper-asl</include>
           <include>org.codehaus.jackson:jackson-xc</include>
-          <include>com.kstruct:gethostname4j:jar:${kstruct.gethostname4j.version}</include>
-          <include>net.java.dev.jna:jna:jar:${jna.version}</include>
-          <include>net.java.dev.jna:jna-platform:jar:${jna-platform.version}</include>
           <include>org.apache.htrace:htrace-core4:jar:${htrace-core.version}</include>
           <include>com.fasterxml.woodstox:woodstox-core:jar:${fasterxml.woodstox.version}</include>
           <include>org.codehaus.woodstox:stax2-api:jar:${codehaus.woodstox.stax2api.version}</include>

--- a/distro/src/main/assembly/plugin-elasticsearch.xml
+++ b/distro/src/main/assembly/plugin-elasticsearch.xml
@@ -80,9 +80,6 @@
           <include>org.codehaus.jackson:jackson-xc</include>
           <include>org.apache.solr:solr-solrj:jar:${solr.version}</include>
           <include>commons-codec:commons-codec</include>
-          <include>com.kstruct:gethostname4j:jar:${kstruct.gethostname4j.version}</include>
-          <include>net.java.dev.jna:jna:jar:${jna.version}</include>
-          <include>net.java.dev.jna:jna-platform:jar:${jna-platform.version}</include>
           <include>org.elasticsearch:elasticsearch</include>
           <include>org.elasticsearch:elasticsearch-core</include>
           <include>org.elasticsearch:elasticsearch-x-content</include>

--- a/distro/src/main/assembly/plugin-kafka.xml
+++ b/distro/src/main/assembly/plugin-kafka.xml
@@ -75,9 +75,6 @@
 					<include>commons-codec:commons-codec</include>
 					<include>org.codehaus.woodstox:stax2-api</include>
 					<include>com.fasterxml.woodstox:woodstox-core</include>
-					<include>com.kstruct:gethostname4j:jar:${kstruct.gethostname4j.version}</include>
-					<include>net.java.dev.jna:jna:jar:${jna.version}</include>
-					<include>net.java.dev.jna:jna-platform:jar:${jna-platform.version}</include>
 					<include>org.elasticsearch:elasticsearch</include>
 					<include>org.elasticsearch:elasticsearch-core</include>
 					<include>org.elasticsearch:elasticsearch-x-content</include>

--- a/distro/src/main/assembly/plugin-kms.xml
+++ b/distro/src/main/assembly/plugin-kms.xml
@@ -66,9 +66,6 @@
           <include>org.noggit:noggit:jar:${noggit.version}</include>
           <include>org.apache.zookeeper:zookeeper:jar:${zookeeper.version}</include>
           <include>org.apache.solr:solr-solrj:jar:${solr.version}</include>
-          <include>com.kstruct:gethostname4j:jar:${kstruct.gethostname4j.version}</include>
-          <include>net.java.dev.jna:jna:jar:${jna.version}</include>
-          <include>net.java.dev.jna:jna-platform:jar:${jna-platform.version}</include>
         </includes>
       </binaries>
     </moduleSet>

--- a/distro/src/main/assembly/plugin-kylin.xml
+++ b/distro/src/main/assembly/plugin-kylin.xml
@@ -63,9 +63,6 @@
               <include>org.apache.httpcomponents:httpcore:jar:${httpcomponents.httpcore.version}</include>
               <include>org.noggit:noggit:jar:${noggit.version}</include>
               <include>org.apache.solr:solr-solrj:jar:${solr.version}</include>
-              <include>com.kstruct:gethostname4j:jar:${kstruct.gethostname4j.version}</include>
-              <include>net.java.dev.jna:jna:jar:${jna.version}</include>
-              <include>net.java.dev.jna:jna-platform:jar:${jna-platform.version}</include>
               <include>org.elasticsearch:elasticsearch</include>
               <include>org.elasticsearch:elasticsearch-core</include>
               <include>org.elasticsearch:elasticsearch-x-content</include>

--- a/distro/src/main/assembly/plugin-ozone.xml
+++ b/distro/src/main/assembly/plugin-ozone.xml
@@ -66,9 +66,6 @@
                     <include>com.sun.jersey:jersey-client</include>
                     <include>com.sun.jersey:jersey-bundle</include>
                     <include>org.apache.htrace:htrace-core4:jar:${htrace-core.version}</include>
-                    <include>com.kstruct:gethostname4j</include>
-                    <include>net.java.dev.jna:jna</include>
-                    <include>net.java.dev.jna:jna-platform</include>
                 </includes>
             </binaries>
         </moduleSet>
@@ -110,9 +107,6 @@
 		            <include>com.sun.xml.bind:jaxb-impl</include>
                     <include>org.apache.htrace:htrace-core4:jar:${htrace-core.version}</include>
                     <include>commons-lang:commons-lang</include>
-                    <include>com.kstruct:gethostname4j</include>
-                    <include>net.java.dev.jna:jna</include>
-                    <include>net.java.dev.jna:jna-platform</include>
                     <include>org.elasticsearch:elasticsearch</include>
                     <include>org.elasticsearch:elasticsearch-core</include>
                     <include>org.elasticsearch:elasticsearch-x-content</include>

--- a/distro/src/main/assembly/plugin-presto.xml
+++ b/distro/src/main/assembly/plugin-presto.xml
@@ -102,9 +102,6 @@
                     <include>org.codehaus.jackson:jackson-mapper-asl</include>
                     <include>org.codehaus.jackson:jackson-xc</include>
                     <include>org.apache.zookeeper:zookeeper:jar:${zookeeper.version}</include>
-                    <include>net.java.dev.jna:jna</include>
-                    <include>net.java.dev.jna:jna-platform</include>
-                    <include>com.kstruct:gethostname4j</include>
                     <include>org.elasticsearch:elasticsearch</include>
                     <include>org.elasticsearch:elasticsearch-core</include>
                     <include>org.elasticsearch:elasticsearch-x-content</include>

--- a/distro/src/main/assembly/plugin-solr.xml
+++ b/distro/src/main/assembly/plugin-solr.xml
@@ -55,9 +55,6 @@
           <include>org.codehaus.jackson:jackson-jaxrs</include>
           <include>org.codehaus.jackson:jackson-mapper-asl</include>
           <include>org.codehaus.jackson:jackson-xc</include>
-          <include>com.kstruct:gethostname4j:jar:${kstruct.gethostname4j.version}</include>
-          <include>net.java.dev.jna:jna:jar:${jna.version}</include>
-          <include>net.java.dev.jna:jna-platform:jar:${jna-platform.version}</include>
           <include>org.elasticsearch:elasticsearch</include>
           <include>org.elasticsearch:elasticsearch-core</include>
           <include>org.elasticsearch:elasticsearch-x-content</include>

--- a/distro/src/main/assembly/plugin-sqoop.xml
+++ b/distro/src/main/assembly/plugin-sqoop.xml
@@ -59,9 +59,6 @@
           <include>org.apache.httpcomponents:httpcore:jar:${httpcomponents.httpcore.version}</include>
           <include>org.noggit:noggit:jar:${noggit.version}</include>
           <include>org.apache.solr:solr-solrj:jar:${solr.version}</include>
-          <include>com.kstruct:gethostname4j:jar:${kstruct.gethostname4j.version}</include>
-          <include>net.java.dev.jna:jna:jar:${jna.version}</include>
-          <include>net.java.dev.jna:jna-platform:jar:${jna-platform.version}</include>
           <include>org.elasticsearch:elasticsearch</include>
           <include>org.elasticsearch:elasticsearch-core</include>
           <include>org.elasticsearch:elasticsearch-x-content</include>

--- a/distro/src/main/assembly/plugin-trino.xml
+++ b/distro/src/main/assembly/plugin-trino.xml
@@ -110,9 +110,6 @@
                     <include>org.codehaus.jackson:jackson-mapper-asl</include>
                     <include>org.codehaus.jackson:jackson-xc</include>
                     <include>org.apache.zookeeper:zookeeper:jar:${zookeeper.version}</include>
-                    <include>net.java.dev.jna:jna</include>
-                    <include>net.java.dev.jna:jna-platform</include>
-                    <include>com.kstruct:gethostname4j</include>
                     <include>org.elasticsearch:elasticsearch</include>
                     <include>org.elasticsearch:elasticsearch-core</include>
                     <include>org.elasticsearch:elasticsearch-x-content</include>

--- a/distro/src/main/assembly/plugin-yarn.xml
+++ b/distro/src/main/assembly/plugin-yarn.xml
@@ -60,9 +60,6 @@
           <include>org.apache.httpcomponents:httpcore:jar:${httpcomponents.httpcore.version}</include>
           <include>org.noggit:noggit:jar:${noggit.version}</include>
           <include>org.apache.solr:solr-solrj:jar:${solr.version}</include>
-          <include>com.kstruct:gethostname4j:jar:${kstruct.gethostname4j.version}</include>
-          <include>net.java.dev.jna:jna:jar:${jna.version}</include>
-          <include>net.java.dev.jna:jna-platform:jar:${jna-platform.version}</include>
           <include>org.elasticsearch:elasticsearch</include>
           <include>org.elasticsearch:elasticsearch-core</include>
           <include>org.elasticsearch:elasticsearch-x-content</include>

--- a/distro/src/main/assembly/ranger-tools.xml
+++ b/distro/src/main/assembly/ranger-tools.xml
@@ -68,9 +68,6 @@
               <include>com.fasterxml.woodstox:woodstox-core:jar:${fasterxml.woodstox.version}</include>
               <include>org.apache.ranger:ranger-plugins-common</include>
               <include>org.apache.ranger:ranger-plugins-audit</include>
-              <include>com.kstruct:gethostname4j:jar:${kstruct.gethostname4j.version}</include>
-              <include>net.java.dev.jna:jna:jar:${jna.version}</include>
-              <include>net.java.dev.jna:jna-platform:jar:${jna-platform.version}</include>
               <include>org.slf4j:slf4j-api</include>
             </includes>
           </dependencySet>

--- a/distro/src/main/assembly/sample-client.xml
+++ b/distro/src/main/assembly/sample-client.xml
@@ -63,9 +63,6 @@
                     <include>org.codehaus.jackson:jackson-mapper-asl</include>
                     <include>org.codehaus.jackson:jackson-xc</include>
                     <include>org.apache.ranger:ranger-plugins-audit</include>
-                    <include>com.kstruct:gethostname4j:jar:${kstruct.gethostname4j.version}</include>
-                    <include>net.java.dev.jna:jna:jar:${jna.version}</include>
-                    <include>net.java.dev.jna:jna-platform:jar:${jna-platform.version}</include>
                     <include>com.fasterxml.woodstox:woodstox-core:jar:${fasterxml.woodstox.version}</include>
                     <include>org.codehaus.woodstox:stax2-api:jar:${codehaus.woodstox.stax2api.version}</include>
                 </includes>

--- a/distro/src/main/assembly/storm-agent.xml
+++ b/distro/src/main/assembly/storm-agent.xml
@@ -80,9 +80,6 @@
               <include>org.codehaus.jackson:jackson-mapper-asl</include>
               <include>org.apache.solr:solr-solrj:jar:${solr.version}</include>
               <include>commons-codec:commons-codec</include>
-              <include>com.kstruct:gethostname4j:jar:${kstruct.gethostname4j.version}</include>
-              <include>net.java.dev.jna:jna:jar:${jna.version}</include>
-              <include>net.java.dev.jna:jna-platform:jar:${jna-platform.version}</include>
               <include>org.elasticsearch:elasticsearch</include>
               <include>org.elasticsearch:elasticsearch-core</include>
               <include>org.elasticsearch:elasticsearch-x-content</include>

--- a/distro/src/main/assembly/tagsync.xml
+++ b/distro/src/main/assembly/tagsync.xml
@@ -84,9 +84,6 @@
 							<include>org.codehaus.woodstox:stax2-api</include>
 							<include>com.fasterxml.woodstox:woodstox-core</include>
 							<include>org.apache.htrace:htrace-core4</include>
-							<include>com.kstruct:gethostname4j:jar:${kstruct.gethostname4j.version}</include>
-							<include>net.java.dev.jna:jna:jar:${jna.version}</include>
-							<include>net.java.dev.jna:jna-platform:jar:${jna-platform.version}</include>
 							<include>com.fasterxml.woodstox:woodstox-core:jar:${fasterxml.woodstox.version}</include>
 							<include>org.codehaus.woodstox:stax2-api:jar:${codehaus.woodstox.stax2api.version}</include>
 							<include>org.apache.commons:commons-configuration2:jar:${commons.configuration.version}</include>

--- a/distro/src/main/assembly/usersync.xml
+++ b/distro/src/main/assembly/usersync.xml
@@ -59,9 +59,6 @@
 							<include>org.apache.ranger:ranger-plugins-common</include>
 							<include>org.apache.ranger:ugsync-util</include>
 							<include>org.apache.htrace:htrace-core4</include>
-							<include>com.kstruct:gethostname4j:jar:${kstruct.gethostname4j.version}</include>
-							<include>net.java.dev.jna:jna:jar:${jna.version}</include>
-							<include>net.java.dev.jna:jna-platform:jar:${jna-platform.version}</include>
 							<include>com.fasterxml.woodstox:woodstox-core:jar:${fasterxml.woodstox.version}</include>
 							<include>org.codehaus.woodstox:stax2-api:jar:${codehaus.woodstox.stax2api.version}</include>
 							<include>org.apache.commons:commons-configuration2:jar:${commons.configuration.version}</include>

--- a/pom.xml
+++ b/pom.xml
@@ -211,9 +211,7 @@
         <fasterxml.woodstox.version>5.0.3</fasterxml.woodstox.version>
         <fasterxml.jackson.version>2.14.0</fasterxml.jackson.version>
         <fasterxml.jackson.databind.version>2.14.0</fasterxml.jackson.databind.version>
-        <kstruct.gethostname4j.version>1.0.0</kstruct.gethostname4j.version>
         <jna.version>5.7.0</jna.version>
-        <jna-platform.version>5.7.0</jna-platform.version>
         <!-- presto plugin deps -->
         <presto.airlift.version>0.192</presto.airlift.version>
         <presto.bval-jsr.version>2.0.0</presto.bval-jsr.version>

--- a/ranger-examples/distro/src/main/assembly/sample-client.xml
+++ b/ranger-examples/distro/src/main/assembly/sample-client.xml
@@ -58,9 +58,6 @@
                     <include>org.codehaus.jackson:jackson-mapper-asl</include>
                     <include>org.codehaus.jackson:jackson-xc</include>
                     <include>org.apache.ranger:ranger-plugins-audit</include>
-                    <include>com.kstruct:gethostname4j:jar:${kstruct.gethostname4j.version}</include>
-                    <include>net.java.dev.jna:jna:jar:${jna.version}</include>
-                    <include>net.java.dev.jna:jna-platform:jar:${jna-platform.version}</include>
                     <include>com.fasterxml.woodstox:woodstox-core:jar:${fasterxml.woodstox.version}</include>
                     <include>org.codehaus.woodstox:stax2-api:jar:${codehaus.woodstox.stax2api.version}</include>
                 </includes>

--- a/ranger-presto-plugin-shim/pom.xml
+++ b/ranger-presto-plugin-shim/pom.xml
@@ -140,27 +140,9 @@
         </dependency>
 
         <dependency>
-            <groupId>net.java.dev.jna</groupId>
-            <artifactId>jna</artifactId>
-            <version>${jna.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>net.java.dev.jna</groupId>
-            <artifactId>jna-platform</artifactId>
-            <version>${jna-platform.version}</version>
-        </dependency>
-
-        <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
             <version>${commons.codec.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.kstruct</groupId>
-            <artifactId>gethostname4j</artifactId>
-            <version>${kstruct.gethostname4j.version}</version>
         </dependency>
 
         <dependency>

--- a/ranger-trino-plugin-shim/pom.xml
+++ b/ranger-trino-plugin-shim/pom.xml
@@ -140,27 +140,9 @@
         </dependency>
 
         <dependency>
-            <groupId>net.java.dev.jna</groupId>
-            <artifactId>jna</artifactId>
-            <version>${jna.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>net.java.dev.jna</groupId>
-            <artifactId>jna-platform</artifactId>
-            <version>${jna-platform.version}</version>
-        </dependency>
-
-        <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
             <version>${commons.codec.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.kstruct</groupId>
-            <artifactId>gethostname4j</artifactId>
-            <version>${kstruct.gethostname4j.version}</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Currently, `ranger-plugin-commons` module relies on `gethostname4j`, `jna ` and `jna-platform` to get the native hostname, which is for `AuthzAuditEvent` only.

`gethostname4j`, `jna ` and `jna-platform` is too onerous, it doesn't seem worthwhile to maintain the three jars to get the hostname, and `gethostname4j`, `jna ` and `jna-platform` relies on the native lib, which prevents users from doing shade.