### PR TITLE
RANGER 4131: Use SessionState to log clientIP in RangerHiveAuthorizer

### DIFF
--- a/hive-agent/src/main/java/org/apache/ranger/authorization/hive/authorizer/RangerHiveAuthorizer.java
+++ b/hive-agent/src/main/java/org/apache/ranger/authorization/hive/authorizer/RangerHiveAuthorizer.java
@@ -20,7 +20,6 @@
 package org.apache.ranger.authorization.hive.authorizer;
 
 import java.io.IOException;
-import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -65,7 +64,6 @@ import org.apache.hadoop.hive.ql.security.authorization.plugin.HivePrivilegeObje
 import org.apache.hadoop.hive.ql.security.authorization.plugin.HiveRoleGrant;
 import org.apache.hadoop.hive.ql.security.authorization.plugin.HiveResourceACLs;
 import org.apache.hadoop.hive.ql.session.SessionState;
-import org.apache.hadoop.ipc.Server;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.ranger.authorization.hadoop.constants.RangerHadoopConstants;
 import org.apache.ranger.authorization.utils.StringUtil;
@@ -2947,10 +2945,13 @@ public class RangerHiveAuthorizer extends RangerHiveAuthorizerBase {
 
 
 	private static String getRemoteIp() {
+		SessionState ss = SessionState.get();
 		String ret = null;
-		InetAddress ip = Server.getRemoteIp();
-		if (ip != null) {
-			ret = ip.getHostAddress();
+		if(ss != null) {
+			ret = ss.getUserIpAddress();
+		}
+		if(LOG.isDebugEnabled()){
+			LOG.debug("RangerHiveAuthorizer.getRemoteIp()="+ret);
 		}
 		return ret;
 	}


### PR DESCRIPTION
## What changes were proposed in this pull request?

ipc.Server when used to fetch clientip does not work.
SessionState works and logs client IP. 

## How was this patch tested?

From beeline enter commands to CREATE ROLE --- client ip is now visible after new patch

<img width="1891" alt="Screenshot 2023-03-13 at 9 07 06 AM" src="https://user-images.githubusercontent.com/12212643/224787198-b63e1191-28a8-42f5-a487-a4ee7377cca9.png">
