### PR TITLE
RANGER-4135: Fix uri for getDeletedGroups() in PolicyMgrUserGroupBuilder

### DIFF
--- a/ugsync/src/main/java/org/apache/ranger/unixusersync/process/PolicyMgrUserGroupBuilder.java
+++ b/ugsync/src/main/java/org/apache/ranger/unixusersync/process/PolicyMgrUserGroupBuilder.java
@@ -84,6 +84,7 @@ public class PolicyMgrUserGroupBuilder extends AbstractUserGroupSource implement
 	public static final String PM_UPDATE_USERS_ROLES_URI  = "/service/xusers/users/roleassignments";	// PUT
 
 	private static final String PM_UPDATE_DELETED_USERS_URI = "/service/xusers/ugsync/users/visibility";	// POST
+	private static final String PM_UPDATE_DELETED_GROUPS_URI = "/service/xusers/ugsync/groups/visibility";	// POST
 	private static final Pattern USER_OR_GROUP_NAME_VALIDATION_REGEX =
 			Pattern.compile("^([A-Za-z0-9_]|[\u00C0-\u017F])([a-zA-Z0-9\\s,._\\-+/@= ]|[\u00C0-\u017F])+$", Pattern.CASE_INSENSITIVE);
 
@@ -1803,11 +1804,11 @@ public class PolicyMgrUserGroupBuilder extends AbstractUserGroupSource implement
 		ClientResponse clientRes = null;
 
 		if(isRangerCookieEnabled){
-			response = cookieBasedUploadEntity(deletedGroups.keySet(), PM_AUDIT_INFO_URI);
+			response = cookieBasedUploadEntity(deletedGroups.keySet(), PM_UPDATE_DELETED_GROUPS_URI);
 		}
 		else {
 			try {
-				clientRes = ldapUgSyncClient.post(PM_AUDIT_INFO_URI, null, deletedGroups.keySet());
+				clientRes = ldapUgSyncClient.post(PM_UPDATE_DELETED_GROUPS_URI, null, deletedGroups.keySet());
 				if (clientRes != null) {
 					response = clientRes.getEntity(String.class);
 				}


### PR DESCRIPTION
## What changes were proposed in this pull request?

https://issues.apache.org/jira/browse/RANGER-3920 causes bugs wherein delete doesn't grey out the deleted user/group. This was due to incorrect uri in getDeletedGroups i.e. PM_AUDIT_INFO_URI which has now been corrected to PM_UPDATE_DELETED_GROUPS_URI

## How was this patch tested?

Added test user in unix
Enabled delete user in usersync
Deleted the test user
Checked if deleted user in greyed out in ranger admin
<img width="1546" alt="Screenshot 2023-03-21 at 11 32 16 AM" src="https://user-images.githubusercontent.com/12212643/226719170-33007640-cdbe-4e8d-8830-5b3525179d16.png">
