### PR TITLE
RANGER-4137: relative path delimiter should not be included at beginning of key path

### DIFF
--- a/tagsync/src/main/java/org/apache/ranger/tagsync/source/atlas/AtlasOzoneResourceMapper.java
+++ b/tagsync/src/main/java/org/apache/ranger/tagsync/source/atlas/AtlasOzoneResourceMapper.java
@@ -160,7 +160,7 @@ public class AtlasOzoneResourceMapper extends AtlasResourceMapper {
 						ret[IDX_VOLUME]     = resources.length > 1 ? resources[1] : null;
 						int idxRelativePath = qualifiedName.indexOf(SEP_RELATIVE_PATH, idxResourceStart);
 						if (idxRelativePath != -1) {
-							ret[IDX_KEY] = qualifiedName.substring(idxRelativePath, idxClusterNameSep);
+							ret[IDX_KEY] = qualifiedName.substring(idxRelativePath+1, idxClusterNameSep);
 						}
 					}
 				}

--- a/tagsync/src/test/java/org/apache/ranger/tagsync/process/TestOzoneResourceMapper.java
+++ b/tagsync/src/test/java/org/apache/ranger/tagsync/process/TestOzoneResourceMapper.java
@@ -40,8 +40,8 @@ public class TestOzoneResourceMapper {
     private static final String SERVICE_NAME                = "cl1_ozone";
     private static final String VOLUME_NAME                 = "myvolume";
     private static final String BUCKET_NAME                 = "mybucket";
-    private static final String KEY_NAME                    = "/mykey.txt";
-    private static final String KEY_PATH                    = "/mykey/key1/";
+    private static final String KEY_NAME                    = "mykey.txt";
+    private static final String KEY_PATH                    = "mykey/key1/";
 
     AtlasOzoneResourceMapper resourceMapper = new AtlasOzoneResourceMapper();
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Issue:
1. Resource-based policy for ozone key are working fine
2. Ozone bucket and volume based tag policies are working as expected
3. Tag policies are downloaded but the deny permissions for ozone key classification don't work

Changes:
Logic for parsing ozone qualified name changed such that '/' is not included in the key name which was causing issue previously.

## How was this patch tested?

After changes, ozone key based policies are properly enforced and deny permissions work as expected.