### PR TITLE
fix: mismatch the value of access_type and action

### DIFF
--- a/agents-common/src/main/java/org/apache/ranger/plugin/audit/RangerDefaultAuditHandler.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/audit/RangerDefaultAuditHandler.java
@@ -124,10 +124,10 @@ public class RangerDefaultAuditHandler implements RangerAccessResultProcessor {
 			ret.setRequestData(request.getRequestData());
 			ret.setEventTime(request.getAccessTime() != null ? request.getAccessTime() : new Date());
 			ret.setUser(request.getUser());
-			ret.setAction(request.getAccessType());
+			ret.setAction(request.getAction());
 			ret.setAccessResult((short) (result.getIsAllowed() ? 1 : 0));
 			ret.setPolicyId(result.getPolicyId());
-			ret.setAccessType(request.getAction());
+			ret.setAccessType(request.getAccessType());
 			ret.setClientIP(request.getClientIPAddress());
 			ret.setClientType(request.getClientType());
 			ret.setSessionId(request.getSessionId());


### PR DESCRIPTION
When I try to use the ranger audit logs to analysis the access info, the value of Access Type and Permission on the ranger web page confuses me. After readed the source code, I found the problem that mismatch the value of Access Type and Permission.