### PR TITLE
[RANGER-4179] Running dba_script.py fails because the useSSL flag was not explicitly set when installing Ranger.

### DIFF
--- a/security-admin/scripts/dba_script.py
+++ b/security-admin/scripts/dba_script.py
@@ -180,7 +180,7 @@ class MysqlConf(BaseDB):
 	def get_jisql_cmd(self, user, password ,db_name):
 		#TODO: User array for forming command
 		path = RANGER_ADMIN_HOME
-		db_ssl_param=''
+		db_ssl_param='?useSSL=false'
 		db_ssl_cert_param=''
 		if self.db_ssl_enabled == 'true':
 			db_ssl_param="?useSSL=%s&requireSSL=%s&verifyServerCertificate=%s" %(self.db_ssl_enabled,self.db_ssl_required,self.db_ssl_verifyServerCertificate)


### PR DESCRIPTION
Running dba_script.py fails because the useSSL flag was not explicitly set when installing Ranger 2.4.0.

I found a similar issue to this, but it doesn't seem to be resolved. 
(https://issues.apache.org/jira/browse/RANGER-3880)

The fail log is below.
```
2023-04-10 03:14:15,379  [JISQL] /usr/lib/jvm/java-openjdk/bin/java  -cp /opt/mysql-connector-java.jar:/opt/ranger_admin/jisql/lib/* org.apache.util.sql.Jisql -driver mysqlconj -cstring jdbc:mysql://localhost/mysql -u admin -p '********' -noheader -trim -c \; -query "SELECT version();"
Mon Apr 10 03:14:15 UTC 2023 WARN: Establishing SSL connection without server's identity verification is not recommended. According to MySQL 5.5.45+, 5.6.26+ and 5.7.6+ requirements SSL connection must be established by default if explicit option isn't set. For compliance with existing applications not using SSL the verifyServerCertificate property is set to 'false'. You need either to explicitly disable SSL by setting useSSL=false, or set useSSL=true and provide truststore for server certificate verification.
SQLException : SQL state: 08S01 com.mysql.jdbc.exceptions.jdbc4.CommunicationsException: Communications link failure 
```
I think JDBC connector url has to be included "useSSL" flag like this.
```
2023-04-10 03:14:15,379  [JISQL] /usr/lib/jvm/java-openjdk/bin/java  -cp /opt/mysql-connector-java.jar:/opt/ranger_admin/jisql/lib/* org.apache.util.sql.Jisql -driver mysqlconj -cstring jdbc:mysql://localhost/mysql?useSSL=false -u admin -p '********' -noheader -trim -c \; -query "SELECT version();" 
```
So, I just modified dba_script.py a little bit for use.
(ranger/security-admin/scripts/dba_script.py)

```
class MysqlConf(BaseDB):
    def get_jisql_cmd(self, user, password ,db_name):
       path = RANGER_ADMIN_HOME	
       db_ssl_param='?useSSL=false'	# default value changed	
       db_ssl_cert_param='' 
```

In my case, it works after modification.
Thank you :)