### PR TITLE
RANGER-4201: fix Hbase master can't start due to ranger-hbase-plugin …

### DIFF
--- a/distro/src/main/assembly/hbase-agent.xml
+++ b/distro/src/main/assembly/hbase-agent.xml
@@ -54,7 +54,6 @@
         <fileMode>644</fileMode>
         <includes>
           <include>com.sun.jersey:jersey-client:jar:${jersey-bundle.version}</include>
-          <include>com.sun.jersey:jersey-core:jar:${jersey-bundle.version}</include>
           <include>org.codehaus.jackson:jackson-jaxrs:jar:${codehaus.jackson.version}</include>
           <include>org.eclipse.jetty:jetty-client:jar:${jetty-client.version}</include>
           <include>org.apache.httpcomponents:httpmime:jar:${httpcomponents.httpmime.version}</include>


### PR DESCRIPTION
## issue:
After integrating ranger2.4 into hbase2.4.13, the class loading order issue of jersey-core-1.9.3.jar causes the HBase master to crash immediately after startup.
## What changes were proposed in this pull request?

 removing jersey-core from distro/src/main/assembly/hbase-agent.xml

The detailed analysis and verification process can be found in this issue.
https://issues.apache.org/jira/browse/RANGER-4201

## How was this patch tested?

1.pass all the unit tests: mvn clean compile package install -Drat.skip=true 

2.After removing jersey-core from distro/src/main/assembly/hbase-agent.xml and compiling, I reinstalled the Hadoop and HBase cluster, integrated Ranger 2.4, configured and enabled Ranger in hbase-site.xml file as follows:

Set hbase.coprocessor.master.classes to org.apache.ranger.authorization.hbase.RangerAuthorizationCoprocessor
Set hbase.coprocessor.region.classes to org.apache.hadoop.hbase.security.access.SecureBulkLoadEndpoint,org.apache.ranger.authorization.hbase.RangerAuthorizationCoprocessor
Set hbase.coprocessor.regionserver.classes to org.apache.ranger.authorization.hbase.RangerAuthorizationCoprocessor

After restarting HBase, no more exception messages were observed and the master is running smoothly.
![image](https://github.com/apache/ranger/assets/18082602/7a918cef-e1c1-4bd9-9fda-0a1634243b30)
![image](https://github.com/apache/ranger/assets/18082602/00647b61-49ac-41d2-9aa7-1e36bb117d51)
![image](https://github.com/apache/ranger/assets/18082602/ddf9a35e-fb0c-4b77-a740-6626fd05de67)

