### PR TITLE
RANGER-4026: Allow sync source updates for existing users & groups synced via different sync sources

### DIFF
--- a/ugsync/src/main/java/org/apache/ranger/unixusersync/config/UserGroupSyncConfig.java
+++ b/ugsync/src/main/java/org/apache/ranger/unixusersync/config/UserGroupSyncConfig.java
@@ -289,6 +289,8 @@ public class UserGroupSyncConfig  {
 	private static final boolean DEFAULT_UGSYNC_NAME_VALIDATION_ENABLED = false;
 	private static final long UGSYNC_INIT_SLEEP_TIME_IN_MILLIS_BETWEEN_CYCLE_MIN_VALUE_FOR_HA = 5000L;
 	public static final String UGSYNC_SERVER_HA_ENABLED_PARAM = "ranger-ugsync.server.ha.enabled";
+	public static final String UGSYNC_SYNC_SOURCE_VALIDATION_ENABLED = "ranger.usersync.syncsource.validation.enabled";
+	private static final boolean DEFAULT_UGSYNC_SYNC_SOURCE_VALIDATION_ENABLED = true;
 
     private Properties prop = new Properties();
 	private Configuration userGroupConfig = null;
@@ -1385,5 +1387,14 @@ public class UserGroupSyncConfig  {
 		}
 
 		return ret;
+	}
+
+	public boolean isSyncSourceValidationEnabled() {
+		boolean isSyncSourceValidationEnabled = DEFAULT_UGSYNC_SYNC_SOURCE_VALIDATION_ENABLED;
+		String val = prop.getProperty(UGSYNC_SYNC_SOURCE_VALIDATION_ENABLED);
+		if(StringUtils.isNotEmpty(val)) {
+			isSyncSourceValidationEnabled = Boolean.parseBoolean(val);
+		}
+		return isSyncSourceValidationEnabled;
 	}
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

[RANGER-3254](https://issues.apache.org/jira/browse/RANGER-3254) implemented a change in user/group mapping so that sync source is taken into account when a group name matches multiple sources. LDAP users belonging to a group like "CN=mygroup" will not be synced in Ranger if there is an existing "mygroup" that was imported by UnixUserGroupBuilder.

This breaks a very common use case where posix users and groups are synced to the OS from an LDAP backend. In those cases, both the linux OS and LDAP/AD are using the same identity repository. If Ranger imported a set of users and groups from one sync source, and then later switches to another, group mappings break and users don't get all of their groups.

Provide an option to treat users/groups from multiple sync sources as same for updating group memberships.

## How was this patch tested?

Tested changes by changing sync source & restarting usersync.

<img width="938" alt="sync_source_change_on_restart" src="https://github.com/apache/ranger/assets/16475454/708e18c9-d1d7-4f0e-a4ae-009ae8afa6bd">

## Additional Config
Below is required to enable this feature(when set to false).  

	<property>
		<name>ranger.usersync.syncsource.validation.enabled</name>
		<value>false</value>
	</property>
