### PR TITLE
RANGER-4247: auditPolicyEvaluators should be set before logging it

### DIFF
--- a/agents-common/src/main/java/org/apache/ranger/plugin/policyengine/RangerPolicyRepository.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/policyengine/RangerPolicyRepository.java
@@ -230,8 +230,6 @@ public class RangerPolicyRepository {
             LOG.debug("RangerPolicyRepository : building policy-repository for service[" + serviceName + "], and zone:[" + zoneName + "] with auditMode[" + auditModeEnum + "]");
         }
 
-        init(options);
-
         if (StringUtils.isEmpty(zoneName)) {
             this.contextEnrichers = buildContextEnrichers(options);
             this.auditPolicyEvaluators = buildAuditPolicyEvaluators(servicePolicies.getServiceConfig());
@@ -239,6 +237,8 @@ public class RangerPolicyRepository {
             this.contextEnrichers = null;
             this.auditPolicyEvaluators = Collections.emptyList();
         }
+
+        init(options);
 
         if (options.disableTrieLookupPrefilter) {
             policyResourceTrie      = null;
@@ -284,8 +284,6 @@ public class RangerPolicyRepository {
             LOG.debug("RangerPolicyRepository : building tag-policy-repository for tag service:[" + serviceName +"], with auditMode[" + auditModeEnum +"]");
         }
 
-        init(options);
-
         if (StringUtils.isEmpty(zoneName)) {
             this.contextEnrichers = buildContextEnrichers(options);
             this.auditPolicyEvaluators = buildAuditPolicyEvaluators(tagPolicies.getServiceConfig());
@@ -293,6 +291,8 @@ public class RangerPolicyRepository {
             this.contextEnrichers = null;
             this.auditPolicyEvaluators = Collections.emptyList();
         }
+
+        init(options);
 
         if (options.disableTrieLookupPrefilter) {
             policyResourceTrie      = null;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Initialize `auditPolicyEvaluators` before calling `init()`. It is necessary to log `auditPolicyEvaluators` when debug logging mode is enabled.


## How was this patch tested?

Manual tests on on-premise Hadoop cluster.
