### PR TITLE
add dnsjava to solve NoDefClassException

### DIFF
--- a/distro/src/main/assembly/admin-web.xml
+++ b/distro/src/main/assembly/admin-web.xml
@@ -231,6 +231,7 @@
         <directoryMode>755</directoryMode>
         <fileMode>644</fileMode>
         <includes>
+          <include>dnsjava:dnsjava:jar:${dnsjava.version}</include>
           <include>org.apache.tomcat.embed:tomcat-embed*</include>
           <include>org.apache.tomcat:tomcat-annotations-api*</include>
           <include>org.eclipse.jdt.core.compiler:ecj:jar:P20140317-1600</include>

--- a/distro/src/main/assembly/kms.xml
+++ b/distro/src/main/assembly/kms.xml
@@ -184,6 +184,7 @@
                     <include>com.squareup.okhttp:okhttp</include>
                     <!-- ranger common metrics module-->
                             <include>org.apache.ranger:ranger-metrics</include>
+                            <include>dnsjava:dnsjava:jar:${dnsjava.version}</include>
                         </includes>
                     </dependencySet>
                 </dependencySets>

--- a/distro/src/main/assembly/plugin-kafka.xml
+++ b/distro/src/main/assembly/plugin-kafka.xml
@@ -91,6 +91,7 @@
 					<include>org.apache.lucene:lucene-core</include>
 					<include>joda-time:joda-time</include>
 					<include>com.carrotsearch:hppc</include>
+					<include>dnsjava:dnsjava:jar:${dnsjava.version}</include>
 				</includes>
 			</binaries>
 		</moduleSet>

--- a/distro/src/main/assembly/usersync.xml
+++ b/distro/src/main/assembly/usersync.xml
@@ -88,6 +88,7 @@
 							<include>ch.qos.logback:logback-classic:jar:${logback.version}</include>
 							<include>org.slf4j:log4j-over-slf4j:jar:${${slf4j.version}}</include>
 							<include>ch.qos.logback:logback-core:jar:${logback.version}</include>
+							<include>dnsjava:dnsjava:jar:${dnsjava.version}</include>
 						</includes>
 					</dependencySet>
 					<dependencySet>

--- a/kms/pom.xml
+++ b/kms/pom.xml
@@ -580,6 +580,11 @@
             <artifactId>ranger-metrics</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>dnsjava</groupId>
+            <artifactId>dnsjava</artifactId>
+            <version>${dnsjava.version}</version>
+        </dependency>
     </dependencies>
     <build>
         <pluginManagement>

--- a/plugin-kafka/pom.xml
+++ b/plugin-kafka/pom.xml
@@ -141,6 +141,11 @@
             <version>2.10.4</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>dnsjava</groupId>
+            <artifactId>dnsjava</artifactId>
+            <version>${dnsjava.version}</version>
+        </dependency>
     </dependencies>
     <build>
         <testResources>

--- a/security-admin/pom.xml
+++ b/security-admin/pom.xml
@@ -777,6 +777,11 @@
             <artifactId>ranger-metrics</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>dnsjava</groupId>
+            <artifactId>dnsjava</artifactId>
+            <version>${dnsjava.version}</version>
+        </dependency>
     </dependencies>
     <build>
         <pluginManagement>

--- a/ugsync/pom.xml
+++ b/ugsync/pom.xml
@@ -201,6 +201,11 @@
             <artifactId>ranger-common-ha</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>dnsjava</groupId>
+            <artifactId>dnsjava</artifactId>
+            <version>${dnsjava.version}</version>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
## What changes were proposed in this pull request?

when setting "hadoop.security.token.service.use_ip=false"  in core-site.xml (configuration in hadoop) ,we encounter a NoClassDefFoundError of "Could not initialize  class  org.apache.hadoop.security.SecurityUtil".  It is caused by lacking a dependency of dnsjava.  We have already tested that it affects ranger-admin、ranger-kms、ranger-usersync、ranger-kafka-plugin. When start up the server,the problem will be seen.


## How was this patch tested?

After using maven to build project,  the jar 'dnsjava-xxx.jar' should be added to the package
