### PR TITLE
RANGER-4313:fix syntax typo in DefaultSchemaRegistryClient to achieve mvn test

### DIFF
--- a/plugin-schema-registry/src/main/java/org/apache/ranger/services/schema/registry/client/connection/DefaultSchemaRegistryClient.java
+++ b/plugin-schema-registry/src/main/java/org/apache/ranger/services/schema/registry/client/connection/DefaultSchemaRegistryClient.java
@@ -33,7 +33,7 @@ import javax.net.ssl.SSLContext;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;;
+import javax.ws.rs.core.Response;
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URLEncoder;


### PR DESCRIPTION

## What changes were proposed in this pull request?

fix java syntax typo, otherwise `mvn test` will fail..

![image](https://github.com/apache/ranger/assets/19356579/ad026276-feae-4240-be04-7fb125d85675)


## How was this patch tested?

manual tests
