### PR TITLE
RANGER-4322: Fix enable-atlas-plugin.sh failure

### DIFF
--- a/distro/src/main/assembly/plugin-atlas.xml
+++ b/distro/src/main/assembly/plugin-atlas.xml
@@ -121,6 +121,8 @@
           <include>com.fasterxml.woodstox:woodstox-core:jar:${fasterxml.woodstox.version}</include>
           <include>org.codehaus.woodstox:stax2-api:jar:${codehaus.woodstox.stax2api.version}</include>
           <include>org.apache.commons:commons-configuration2:jar:${commons.configuration.version}</include>
+          <include>org.apache.commons:commons-lang3:jar:${commons.lang3.version}</include>
+          <include>org.apache.commons:commons-compress:jar:${commons.compress.version}</include>
         </includes>
       </binaries>
     </moduleSet>


### PR DESCRIPTION
## What changes were proposed in this pull request?

`enable-atlas-plugin.sh` script was failing due to missing jars in `install/lib` directory. This patch fixes that.
JIRA issue: https://issues.apache.org/jira/browse/RANGER-4322 


## How was this patch tested?

Tested manually 
