### PR TITLE
RANGER-4355: fix the issue that elasticsearch plugin can't generate audit logs!

### DIFF
--- a/plugin-elasticsearch/src/main/java/org/apache/ranger/authorization/elasticsearch/authorizer/RangerElasticsearchAuthorizer.java
+++ b/plugin-elasticsearch/src/main/java/org/apache/ranger/authorization/elasticsearch/authorizer/RangerElasticsearchAuthorizer.java
@@ -99,6 +99,12 @@ public class RangerElasticsearchAuthorizer implements RangerElasticsearchAccessC
 			if (result != null && result.getIsAllowed()) {
 				ret = true;
 			}
+
+			RangerElasticsearchAuditHandler auditHandler = (RangerElasticsearchAuditHandler) elasticsearchPlugin.getResultProcessor();
+			if (auditHandler != null) {
+				auditHandler.flushAudit();
+			}
+
 		}
 
 		if (LOG.isDebugEnabled()) {


### PR DESCRIPTION

 fix the issue that elasticsearch plugin can't generate audit logs!
JIRA:
https://issues.apache.org/jira/browse/RANGER-4355

elasticsearch audit logs issue, how to test:
1. enable elasticsearch plugin
2. enable audit:
set ranger-elasticsearch-audit file 
xasecure.audit.is.enabled=true
xasecure.audit.destination.solr=true
3.operate elasticsearch 
curl esip:9200/_cat/indices
and observe the audit log by ranger admin ui