### PR TITLE
RANGER-4385: Fix role filtering logic in RolePredicateUtil

### DIFF
--- a/agents-common/src/main/java/org/apache/ranger/plugin/store/RolePredicateUtil.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/store/RolePredicateUtil.java
@@ -67,7 +67,7 @@ public class RolePredicateUtil extends AbstractPredicateUtil {
                         List<RangerRole.RoleMember> roles = role.getRoles();
 
                         for (RangerRole.RoleMember member : roles) {
-                            ret = StringUtils.equals(role.getName(), roleName);
+                            ret = StringUtils.equals(member.getName(), roleName);
 
                             if (ret) {
                                 break;
@@ -109,7 +109,7 @@ public class RolePredicateUtil extends AbstractPredicateUtil {
                         List<RangerRole.RoleMember> roles = role.getRoles();
 
                         for (RangerRole.RoleMember member : roles) {
-                            ret = StringUtils.containsIgnoreCase(role.getName(), roleNamePartial);
+                            ret = StringUtils.containsIgnoreCase(member.getName(), roleNamePartial);
 
                             if (ret) {
                                 break;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix role filtering logic in RolePredicateUtil


## How was this patch tested?

1. Create a new user with role USER in Ranger Admin
2. Create a role like this table

|Role Name|Users|Groups|Roles|
|-|-|-|-|
|role_second|test|--|role_first|

3. use this account to query through the role name parameter role_first
