### PR TITLE
RANGER-4676: OpenSearch destination implementation

### DIFF
--- a/agents-audit/pom.xml
+++ b/agents-audit/pom.xml
@@ -406,5 +406,15 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.opensearch.client</groupId>
+            <artifactId>opensearch-java</artifactId>
+            <version>${opensearch-java.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.opensearch.client</groupId>
+            <artifactId>opensearch-rest-client</artifactId>
+            <version>${opensearch-rest-client.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/agents-audit/src/main/java/org/apache/ranger/audit/destination/OpenSearchAuditDestination.java
+++ b/agents-audit/src/main/java/org/apache/ranger/audit/destination/OpenSearchAuditDestination.java
@@ -1,0 +1,351 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.audit.destination;
+
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch.core.BulkRequest;
+import org.opensearch.client.opensearch.core.BulkResponse;
+import org.opensearch.client.opensearch.core.bulk.BulkResponseItem;
+import org.opensearch.client.opensearch.indices.OpenRequest;
+import org.opensearch.client.json.jackson.JacksonJsonpMapper;
+import org.opensearch.client.transport.OpenSearchTransport;
+import org.opensearch.client.transport.rest_client.RestClientTransport;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.apache.commons.lang.StringUtils;
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthSchemeProvider;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.config.AuthSchemes;
+import org.apache.http.config.Lookup;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.impl.auth.SPNegoSchemeFactory;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
+import org.apache.ranger.audit.model.AuditEventBase;
+import org.apache.ranger.audit.model.AuthzAuditEvent;
+import org.apache.ranger.audit.provider.MiscUtil;
+import org.apache.ranger.authorization.credutils.CredentialsProviderUtil;
+import org.apache.ranger.authorization.credutils.kerberos.KerberosCredentialsProvider;
+import org.opensearch.client.RestClient;
+import org.opensearch.client.RestClientBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.security.auth.Subject;
+import javax.security.auth.kerberos.KerberosTicket;
+import java.io.File;
+import java.security.PrivilegedActionException;
+import java.util.*;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class OpenSearchAuditDestination extends AuditDestination {
+    public static final String CONFIG_URLS = "urls";
+    public static final String CONFIG_PORT = "port";
+    public static final String CONFIG_USER = "user";
+    public static final String CONFIG_PWRD = "password";
+    public static final String CONFIG_PROTOCOL = "protocol";
+    public static final String CONFIG_INDEX = "index";
+    public static final String CONFIG_PREFIX = "ranger.audit.opensearch";
+    public static final String DEFAULT_INDEX = "ranger_audits";
+    private static final Logger LOG = LoggerFactory.getLogger(OpenSearchAuditDestination.class);
+    private final AtomicLong lastLoggedAt = new AtomicLong(0);
+    private String index = "index";
+    private volatile OpenSearchClient client = null;
+    private String protocol;
+    private String user;
+    private int port;
+    private String password;
+    private String hosts;
+    private Subject subject;
+
+
+    public OpenSearchAuditDestination() {
+        propPrefix = CONFIG_PREFIX;
+    }
+
+    public static RestClientBuilder getRestClientBuilder(String urls, String protocol, String user, String password, int port) {
+        RestClientBuilder restClientBuilder = RestClient.builder(
+                MiscUtil.toArray(urls, ",").stream()
+                        .map(x -> new HttpHost(x, port, protocol))
+                        .<HttpHost>toArray(i -> new HttpHost[i])
+        );
+        ThreadFactory clientThreadFactory = new ThreadFactoryBuilder()
+                .setNameFormat("OpenSearch rest client %s")
+                .setDaemon(true)
+                .build();
+        if (StringUtils.isNotBlank(user) && StringUtils.isNotBlank(password) && !user.equalsIgnoreCase("NONE") && !password.equalsIgnoreCase("NONE")) {
+            if (password.contains("keytab") && new File(password).exists()) {
+                final KerberosCredentialsProvider credentialsProvider =
+                        CredentialsProviderUtil.getKerberosCredentials(user, password);
+                Lookup<AuthSchemeProvider> authSchemeRegistry = RegistryBuilder.<AuthSchemeProvider>create()
+                        .register(AuthSchemes.SPNEGO, new SPNegoSchemeFactory()).build();
+                restClientBuilder.setHttpClientConfigCallback(clientBuilder -> {
+                    clientBuilder.setThreadFactory(clientThreadFactory);
+                    clientBuilder.setDefaultCredentialsProvider(credentialsProvider);
+                    clientBuilder.setDefaultAuthSchemeRegistry(authSchemeRegistry);
+                    return clientBuilder;
+                });
+            } else {
+                final CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+                credentialsProvider.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials(user, password));
+                restClientBuilder.setHttpClientConfigCallback(new RestClientBuilder.HttpClientConfigCallback() {
+                    @Override
+                    public HttpAsyncClientBuilder customizeHttpClient(HttpAsyncClientBuilder httpClientBuilder) {
+                        return httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider);
+                    }
+                });
+                restClientBuilder.setHttpClientConfigCallback(clientBuilder -> {
+                    clientBuilder.setThreadFactory(clientThreadFactory);
+                    clientBuilder.setDefaultCredentialsProvider(credentialsProvider);
+                    return clientBuilder;
+                });
+            }
+        } else {
+            LOG.error("OpenSearch Credentials not provided!!");
+            final CredentialsProvider credentialsProvider = null;
+            restClientBuilder.setHttpClientConfigCallback(clientBuilder -> {
+                clientBuilder.setThreadFactory(clientThreadFactory);
+                clientBuilder.setDefaultCredentialsProvider(credentialsProvider);
+                return clientBuilder;
+            });
+        }
+        return restClientBuilder;
+    }
+
+    @Override
+    public void init(Properties props, String propPrefix) {
+        super.init(props, propPrefix);
+        this.protocol = getStringProperty(props, propPrefix + "." + CONFIG_PROTOCOL, "http");
+        this.user = getStringProperty(props, propPrefix + "." + CONFIG_USER, "");
+        this.password = getStringProperty(props, propPrefix + "." + CONFIG_PWRD, "");
+        this.port = MiscUtil.getIntProperty(props, propPrefix + "." + CONFIG_PORT, 9200);
+        this.index = getStringProperty(props, propPrefix + "." + CONFIG_INDEX, DEFAULT_INDEX);
+        this.hosts = getHosts();
+        LOG.info("Connecting to OpenSearch: " + connectionString());
+        getClient(); // Initialize client
+    }
+
+    private String connectionString() {
+        return String.format(Locale.ROOT, "User:%s, %s://%s:%s/%s", user, protocol, hosts, port, index);
+    }
+
+    @Override
+    public void stop() {
+        super.stop();
+        logStatus();
+    }
+
+    @Override
+    public boolean log(Collection<AuditEventBase> events) {
+        boolean ret = false;
+        try {
+            logStatusIfRequired();
+            addTotalCount(events.size());
+
+            OpenSearchClient client = getClient();
+            if (null == client) {
+                // OpenSearch is still not initialized. So need return error
+                addDeferredCount(events.size());
+                return ret;
+            }
+
+            ArrayList<AuditEventBase> eventList = new ArrayList<>(events);
+            BulkRequest.Builder br = new BulkRequest.Builder();
+            try {
+                for (AuditEventBase event : eventList) {
+                    AuthzAuditEvent authzEvent = (AuthzAuditEvent) event;
+                    String id = authzEvent.getEventId();
+                    Map<String, Object> doc = toDoc(authzEvent);
+                    br.operations(op -> op.index(idx -> idx.index(index).id(id).document(doc)));
+                }
+            } catch (Exception ex) {
+                addFailedCount(eventList.size());
+                logFailedEvent(eventList, ex);
+            }
+            BulkResponse response = client.bulk(br.build());
+            if (response.errors()) {
+                addFailedCount(eventList.size());
+                StringBuilder err = new StringBuilder();
+                for (BulkResponseItem item : response.items()) {
+                    if (item.error() != null) {
+                        err.append(item.error().reason());
+                    }
+                }
+                logFailedEvent(eventList, "HTTP " + err);
+            } else {
+                List<BulkResponseItem> items = response.items();
+                for (int i = 0; i < items.size(); i++) {
+                    AuditEventBase itemRequest = eventList.get(i);
+                    BulkResponseItem itemResponse = items.get(i);
+                    if (itemResponse.error() != null) {
+                        addFailedCount(1);
+                        logFailedEvent(Arrays.asList(itemRequest), itemResponse.error().reason());
+                    } else {
+                        if (LOG.isDebugEnabled()) {
+                            LOG.debug(String.format("Indexed %s", itemRequest.getEventKey()));
+                        }
+                        addSuccessCount(1);
+                        ret = true;
+                    }
+                }
+            }
+        } catch (Throwable t) {
+            addDeferredCount(events.size());
+            logError("Error sending message to OpenSearch", t);
+        }
+        return ret;
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.apache.ranger.audit.provider.AuditProvider#flush()
+     */
+    @Override
+    public void flush() {
+
+    }
+
+    public boolean isAsync() {
+        return true;
+    }
+
+    synchronized OpenSearchClient getClient() {
+        if (client == null) {
+            synchronized (OpenSearchAuditDestination.class) {
+                if (client == null) {
+                    client = newClient();
+                }
+            }
+        }
+        if (subject != null) {
+            KerberosTicket ticket = CredentialsProviderUtil.getTGT(subject);
+            try {
+                if (new Date().getTime() > ticket.getEndTime().getTime()) {
+                    client = null;
+                    CredentialsProviderUtil.ticketExpireTime80 = 0;
+                    newClient();
+                } else if (CredentialsProviderUtil.ticketWillExpire(ticket)) {
+                    subject = CredentialsProviderUtil.login(user, password);
+                }
+            } catch (PrivilegedActionException e) {
+                LOG.error("PrivilegedActionException:", e);
+                throw new RuntimeException(e);
+            }
+        }
+        return client;
+    }
+
+    private OpenSearchClient newClient() {
+        try {
+            if (StringUtils.isNotBlank(user) && StringUtils.isNotBlank(password) && password.contains("keytab") && new File(password).exists()) {
+                subject = CredentialsProviderUtil.login(user, password);
+            }
+            RestClientBuilder restClientBuilder = getRestClientBuilder(hosts, protocol, user, password, port);
+            // Create a transmission task by using JSON ObjectMapper.
+            OpenSearchTransport transport = new RestClientTransport(restClientBuilder.build(), new JacksonJsonpMapper());
+            OpenSearchClient esClient = new OpenSearchClient(transport);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Initialized client");
+            }
+            boolean exits = false;
+            try {
+                exits = esClient.indices().open(new OpenRequest.Builder().index(this.index).build()).shardsAcknowledged();
+            } catch (Exception e) {
+                LOG.warn("Error validating index " + this.index);
+            }
+            if (exits) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Index exists");
+                }
+            } else {
+                LOG.info("Index does not exist");
+            }
+            return esClient;
+        } catch (Throwable t) {
+            lastLoggedAt.updateAndGet(lastLoggedAt -> {
+                long now = System.currentTimeMillis();
+                long elapsed = now - lastLoggedAt;
+                if (elapsed > TimeUnit.MINUTES.toMillis(1)) {
+                    LOG.error("Can't connect to OpenSearch server: " + connectionString(), t);
+                    return now;
+                } else {
+                    return lastLoggedAt;
+                }
+            });
+            return null;
+        }
+    }
+
+    private String getHosts() {
+        String urls = MiscUtil.getStringProperty(props, propPrefix + "." + CONFIG_URLS);
+        if (urls != null) {
+            urls = urls.trim();
+        }
+        if ("NONE".equalsIgnoreCase(urls)) {
+            urls = null;
+        }
+        return urls;
+    }
+
+    private String getStringProperty(Properties props, String propName, String defaultValue) {
+        String value = MiscUtil.getStringProperty(props, propName);
+        if (null == value) {
+            return defaultValue;
+        }
+        return value;
+    }
+
+    Map<String, Object> toDoc(AuthzAuditEvent auditEvent) {
+        Map<String, Object> doc = new HashMap<String, Object>();
+        doc.put("id", auditEvent.getEventId());
+        doc.put("access", auditEvent.getAccessType());
+        doc.put("enforcer", auditEvent.getAclEnforcer());
+        doc.put("agent", auditEvent.getAgentId());
+        doc.put("repo", auditEvent.getRepositoryName());
+        doc.put("sess", auditEvent.getSessionId());
+        doc.put("reqUser", auditEvent.getUser());
+        doc.put("reqData", auditEvent.getRequestData());
+        doc.put("resource", auditEvent.getResourcePath());
+        doc.put("cliIP", auditEvent.getClientIP());
+        doc.put("logType", auditEvent.getLogType());
+        doc.put("result", auditEvent.getAccessResult());
+        doc.put("policy", auditEvent.getPolicyId());
+        doc.put("repoType", auditEvent.getRepositoryType());
+        doc.put("resType", auditEvent.getResourceType());
+        doc.put("reason", auditEvent.getResultReason());
+        doc.put("action", auditEvent.getAction());
+        doc.put("evtTime", auditEvent.getEventTime());
+        doc.put("seq_num", auditEvent.getSeqNum());
+        doc.put("event_count", auditEvent.getEventCount());
+        doc.put("event_dur_ms", auditEvent.getEventDurationMS());
+        doc.put("tags", auditEvent.getTags());
+        doc.put("cluster", auditEvent.getClusterName());
+        doc.put("zoneName", auditEvent.getZoneName());
+        doc.put("agentHost", auditEvent.getAgentHostname());
+        doc.put("policyVersion", auditEvent.getPolicyVersion());
+        return doc;
+    }
+
+}

--- a/agents-audit/src/main/java/org/apache/ranger/audit/provider/AuditProviderFactory.java
+++ b/agents-audit/src/main/java/org/apache/ranger/audit/provider/AuditProviderFactory.java
@@ -421,6 +421,8 @@ public class AuditProviderFactory {
 				provider = new SolrAuditDestination();
 			} else if (providerName.equalsIgnoreCase("elasticsearch")) {
 				provider = new ElasticSearchAuditDestination();
+			} else if (providerName.equalsIgnoreCase("opensearch")) {
+				provider = new OpenSearchAuditDestination();
 			} else if (providerName.equalsIgnoreCase("amazon_cloudwatch")) {
 				provider = new AmazonCloudWatchAuditDestination();
 			} else if (providerName.equalsIgnoreCase("kafka")) {

--- a/pom.xml
+++ b/pom.xml
@@ -180,6 +180,8 @@
         <mysql-connector-java.version>5.1.49</mysql-connector-java.version>
         <netty-all.version>4.1.94.Final</netty-all.version>
         <noggit.version>0.8</noggit.version>
+        <opensearch-java.version>2.6.0</opensearch-java.version>
+        <opensearch-rest-client.version>2.9.0</opensearch-rest-client.version>
         <orc.core.version>1.6.7</orc.core.version>
         <owasp-java-html-sanitizer.version>20211018.2</owasp-java-html-sanitizer.version>
         <paranamer.version>2.3</paranamer.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

OpenSearch has its own java library to connect with and is not fully compatible with bulk requests using elasticsearch library (at least v7). So let's implement another destination.

With current elasticsearch destination I can see problems with response parsing:

```
23/09/22 10:13:20 ERROR BaseAuditHandler: Error sending message to ElasticSearch
java.io.IOException: Unable to parse response body for Response{requestLine=POST /_bulk?timeout=1m HTTP/1.1, host=http://nia-spark-fedchenkov.ru-central1.internal:9200, response=HTTP/1.1 200 OK}
	at org.elasticsearch.client.RestHighLevelClient.internalPerformRequest(RestHighLevelClient.java:1651)
	at org.elasticsearch.client.RestHighLevelClient.performRequest(RestHighLevelClient.java:1602)
	at org.elasticsearch.client.RestHighLevelClient.performRequestAndParseEntity(RestHighLevelClient.java:1572)
	at org.elasticsearch.client.RestHighLevelClient.bulk(RestHighLevelClient.java:537)
	at org.apache.ranger.audit.destination.ElasticSearchAuditDestination.log(ElasticSearchAuditDestination.java:141)
	at org.apache.ranger.audit.queue.AuditBatchQueue.runLogAudit(AuditBatchQueue.java:309)
	at org.apache.ranger.audit.queue.AuditBatchQueue.run(AuditBatchQueue.java:215)
	at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: java.lang.NullPointerException
	at java.base/java.util.Objects.requireNonNull(Objects.java:221)
	at org.elasticsearch.action.DocWriteResponse.<init>(DocWriteResponse.java:127)
	at org.elasticsearch.action.index.IndexResponse.<init>(IndexResponse.java:54)
	at org.elasticsearch.action.index.IndexResponse.<init>(IndexResponse.java:39)
	at org.elasticsearch.action.index.IndexResponse$Builder.build(IndexResponse.java:107)
	at org.elasticsearch.action.index.IndexResponse$Builder.build(IndexResponse.java:104)
	at org.elasticsearch.action.bulk.BulkItemResponse.fromXContent(BulkItemResponse.java:159)
	at org.elasticsearch.action.bulk.BulkResponse.fromXContent(BulkResponse.java:188)
	at org.elasticsearch.client.RestHighLevelClient.parseEntity(RestHighLevelClient.java:1911)
	at org.elasticsearch.client.RestHighLevelClient.lambda$performRequestAndParseEntity$8(RestHighLevelClient.java:1573)
	at org.elasticsearch.client.RestHighLevelClient.internalPerformRequest(RestHighLevelClient.java:1649)
	... 7 more

```

## How was this patch tested?

manual test with `opensearchproject/opensearch:2.9.0`
