### PR TITLE
RangerKMS adds support for the SM4 encryption algorithm.

### DIFF
--- a/kms/src/main/java/org/apache/hadoop/crypto/key/kms/server/KMS.java
+++ b/kms/src/main/java/org/apache/hadoop/crypto/key/kms/server/KMS.java
@@ -53,6 +53,7 @@ import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.net.URI;
 import java.security.PrivilegedExceptionAction;
+import java.security.Security;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
@@ -65,6 +66,7 @@ import java.util.regex.Pattern;
 import org.apache.ranger.kms.metrics.KMSMetricWrapper;
 import org.apache.ranger.kms.metrics.KMSMetrics;
 import org.apache.ranger.kms.metrics.collector.KMSMetricsCollector;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import static org.apache.hadoop.util.KMSUtil.checkNotEmpty;
@@ -92,6 +94,10 @@ public class KMS {
   private final KMSAudit                   kmsAudit;
 
   private KMSMetricsCollector kmsMetricsCollector;
+
+  static {
+    Security.addProvider(new BouncyCastleProvider());
+  }
 
   public KMS() throws Exception {
     provider = KMSWebApp.getKeyProvider();

--- a/kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKMS.java
+++ b/kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKMS.java
@@ -1,0 +1,37 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.crypto.key.kms.server;
+
+import org.junit.Assert;
+import org.junit.Test;
+import sun.security.jca.GetInstance;
+
+public class TestKMS {
+  @Test
+  public void testSupportSM4(){
+    String algorithm = "SM4";
+
+    Assert.assertEquals(0,
+         GetInstance.getServices("KeyGenerator", algorithm).size());
+
+    // Only for load this class, so that can trigger the static code blocks.
+    Class<KMS> kmsClass = KMS.class;
+    Assert.assertEquals(1,
+         GetInstance.getServices("KeyGenerator", algorithm).size());
+  }
+}


### PR DESCRIPTION
  **SM4 is already supported in recent versions (3.4.0) of hdfs transparent encryption**：
1. Hadoop website: https://apache.github.io/hadoop/hadoop-project-dist/hadoop-hdfs/TransparentEncryption.html
    ![HDFS_SM4](https://github.com/apache/ranger/assets/65019264/81ba2af8-4bd7-4412-acd0-45e403a736e7)
3. Jira(HDFS supported SM4):   https://issues.apache.org/jira/browse/HDFS-15098  


  When I add in the region of the Encryption key used "SM4 / CTR/NoPadding" algorithm, RangerKMS background will print "under Caused by: Java security. **NoSuchAlgorithmException**: **SM4 KeyGenerator not available**"
![SM4_NotAvaliable](https://github.com/apache/ranger/assets/65019264/b139ca33-c7a7-4062-b47a-d227e386318c)

  **So RangerKMS should adapt to this.**
