### PR TITLE
property ranger.accesslog.rotate.rename_on_rotate, the de…

### DIFF
--- a/security-admin/src/main/resources/conf.dist/ranger-admin-default-site.xml
+++ b/security-admin/src/main/resources/conf.dist/ranger-admin-default-site.xml
@@ -352,7 +352,7 @@
 
 	<property>
 		<name>ranger.accesslog.rotate.rename_on_rotate</name>
-		<value>15</value>
+		<value>false</value>
 	</property>
 
 	<property>


### PR DESCRIPTION
…fault value is false, not 15

## What changes were proposed in this pull request?

Fix the default value of ranger.accesslog.rotate.rename_on_rotate configuration in ranger--admin-default-site.xml. The default value of this configuration is false instead of 15.
![image](https://github.com/apache/ranger/assets/50791733/4dbadd0b-0c89-411f-84bf-9f173dcdfd4c)
![image](https://github.com/apache/ranger/assets/50791733/a72f6e18-fcee-4f8d-8155-fa7cb9eb76e4)

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)
