### PR TITLE
Change the http client of the knox plug-in to avoid conne…

### DIFF
--- a/knox-agent/pom.xml
+++ b/knox-agent/pom.xml
@@ -102,6 +102,16 @@
             <version>${protobuf-java.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${commons.lang3.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>${commons.compress.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-hdfs</artifactId>
             <version>${hadoop.version}</version>
@@ -203,6 +213,13 @@
             <version>${commons.text.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>${httpcomponents.httpclient.version}</version>
+        </dependency>
+
         <dependency>
             <groupId>ch.qos.reload4j</groupId>
             <artifactId>reload4j</artifactId>

--- a/knox-agent/src/main/java/org/apache/ranger/services/knox/client/HttpClientUtil.java
+++ b/knox-agent/src/main/java/org/apache/ranger/services/knox/client/HttpClientUtil.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ranger.services.knox.client;
+
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.ssl.SSLContextBuilder;
+
+import javax.net.ssl.SSLContext;
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+
+/**
+ * @author zhaoshuaihua
+ * 2023/12/11 14:13
+ **/
+public class HttpClientUtil {
+
+    public static CloseableHttpClient buildNoSslHttpClient(String userName, String password) {
+
+        try {
+            SSLContext sslContext = null;
+            sslContext = SSLContextBuilder.create().loadTrustMaterial((chain, authType) -> true).build();
+
+            // 创建Basic认证的CredentialsProvider
+            CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+            credentialsProvider.setCredentials(AuthScope.ANY,
+                    new UsernamePasswordCredentials(userName, password));
+
+            // 创建CloseableHttpClient并设置SSLContext和主机名验证器
+            return HttpClients.custom()
+                    .setSSLContext(sslContext)
+                    .setSSLHostnameVerifier(NoopHostnameVerifier.INSTANCE)
+                    .setDefaultCredentialsProvider(credentialsProvider)
+                    .build();
+        } catch (NoSuchAlgorithmException | KeyManagementException | KeyStoreException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}


### PR DESCRIPTION
…ctivity failure caused by SSL links.

## What changes were proposed in this pull request?

The ranger knox plug-in will report SSLHandhakeException during the connectivity test. SSL should not be required for the plug-in, so the http client is changed to avoid errors caused by the SSL handshake.
The error is reported as follows：
![image](https://github.com/apache/ranger/assets/50791733/7659684f-a973-4f66-b2d6-cf65da24dc02)
![image](https://github.com/apache/ranger/assets/50791733/eafe6943-0173-4095-93b4-6f382841c882)

## How was this patch tested?
After changing the http client, the test is as follows:
![image](https://github.com/apache/ranger/assets/50791733/f58dba66-1a33-4ba7-a080-e1f63f78ccab)
![image](https://github.com/apache/ranger/assets/50791733/22bddfe1-46c0-41a2-85cc-2f86b5d5e7af)
![image](https://github.com/apache/ranger/assets/50791733/6345596c-32a1-4193-8e79-8861d685580f)
![image](https://github.com/apache/ranger/assets/50791733/ec8e4ce3-04e6-4b76-9b55-213cb54a2e37)

