### PR TITLE
RANGER-4622:property ranger.accesslog.rotate.rename_on_rotate, the de…

### DIFF
--- a/security-admin/src/main/resources/conf.dist/ranger-admin-default-site.xml
+++ b/security-admin/src/main/resources/conf.dist/ranger-admin-default-site.xml
@@ -352,7 +352,7 @@
 
 	<property>
 		<name>ranger.accesslog.rotate.rename_on_rotate</name>
-		<value>15</value>
+		<value>false</value>
 	</property>
 
 	<property>


### PR DESCRIPTION
…fault value is false, not 15

## What changes were proposed in this pull request?
Change the default value of the configuration ranger.accesslog.rotate.rename_on_rotate in ranger-admin-default-site.xml.
The default value of this configuration is false instead of 15.
![image](https://github.com/apache/ranger/assets/50791733/5ca4f300-e5b2-486b-b103-177c9b1bfbeb)
![image](https://github.com/apache/ranger/assets/50791733/103858c8-ba5e-459a-b85a-2f06d863970f)
![image](https://github.com/apache/ranger/assets/50791733/e138c95f-8954-4341-9ef2-82be1e646093)

the issuse links is :https://issues.apache.org/jira/projects/RANGER/issues/RANGER-4622?filter=allissues
