### PR TITLE
RANGER-4623:Change the http client of the knox plug-in to avoid conne…

### DIFF
--- a/knox-agent/pom.xml
+++ b/knox-agent/pom.xml
@@ -102,6 +102,16 @@
             <version>${protobuf-java.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${commons.lang3.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>${commons.compress.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-hdfs</artifactId>
             <version>${hadoop.version}</version>
@@ -203,6 +213,13 @@
             <version>${commons.text.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>${httpcomponents.httpclient.version}</version>
+        </dependency>
+
         <dependency>
             <groupId>ch.qos.reload4j</groupId>
             <artifactId>reload4j</artifactId>

--- a/knox-agent/src/main/java/org/apache/ranger/services/knox/client/HttpClientUtil.java
+++ b/knox-agent/src/main/java/org/apache/ranger/services/knox/client/HttpClientUtil.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ranger.services.knox.client;
+
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.ssl.SSLContextBuilder;
+
+import javax.net.ssl.SSLContext;
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+
+/**
+ * @author zhaoshuaihua
+ * 2023/12/11 14:13
+ **/
+public class HttpClientUtil {
+
+    public static CloseableHttpClient buildNoSslHttpClient(String userName, String password) {
+
+        try {
+            SSLContext sslContext = null;
+            sslContext = SSLContextBuilder.create().loadTrustMaterial((chain, authType) -> true).build();
+
+            // 创建Basic认证的CredentialsProvider
+            CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+            credentialsProvider.setCredentials(AuthScope.ANY,
+                    new UsernamePasswordCredentials(userName, password));
+
+            // 创建CloseableHttpClient并设置SSLContext和主机名验证器
+            return HttpClients.custom()
+                    .setSSLContext(sslContext)
+                    .setSSLHostnameVerifier(NoopHostnameVerifier.INSTANCE)
+                    .setDefaultCredentialsProvider(credentialsProvider)
+                    .build();
+        } catch (NoSuchAlgorithmException | KeyManagementException | KeyStoreException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}


### PR DESCRIPTION
…ctivity failure caused by SSL links.

## What changes were proposed in this pull request?
The ranger plug-in client does not need SSL handshake when calling knox, so it is replaced with apache http client to solve the SSL handshake problem and adjust the knox interface.
The ranger knox test connection error is : 
Unable to retrieve any files using given parameters, You can still save the repository and start creating policies, but you would not be able to use autocomplete for resource names. Check ranger_admin.log for more info.

org.apache.ranger.plugin.client.HadoopException: Exception on REST call to KnoxUrl : https://xxx:8443/gateway/admin/api/v1/topologies..
javax.net.ssl.SSLHandshakeException: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target.
PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target.

## How was this patch tested?
Click ranger knox service connectivity test, and pull down to view policy files, etc.
You can see it : https://issues.apache.org/jira/projects/RANGER/issues/RANGER-4623?filter=allissues