### PR TITLE
RANGER-4675: Using the ozone service id specified in the config instead of hardcoded value for resource lookup

### DIFF
--- a/plugin-ozone/src/main/java/org/apache/ranger/services/ozone/client/OzoneClient.java
+++ b/plugin-ozone/src/main/java/org/apache/ranger/services/ozone/client/OzoneClient.java
@@ -54,7 +54,8 @@ public class OzoneClient extends BaseClient {
             }
         }
         Subject.doAs(getLoginSubject(), (PrivilegedExceptionAction<Void>) () -> {
-            ozoneClient = OzoneClientFactory.getRpcClient("ozone1", conf);
+            String[] serviceIds = conf.getTrimmedStrings("ozone.om.service.ids", "ozone1");
+            ozoneClient = OzoneClientFactory.getRpcClient(serviceIds[0], conf);
             return null;
         });
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Using the ozone service id specified in the config instead of hardcoded value for resource lookup


## How was this patch tested?

Tested in dev environment. DIfferent values in ozone conf for ozone service id can be used to test.
