### PR TITLE
RANGER-4390: creating another row batch causes null pointer exception

### DIFF
--- a/agents-audit/src/main/java/org/apache/ranger/audit/utils/ORCFileUtil.java
+++ b/agents-audit/src/main/java/org/apache/ranger/audit/utils/ORCFileUtil.java
@@ -125,11 +125,6 @@ public class ORCFileUtil {
             logger.debug("==> ORCFileUtil.log() : EventSize: " + eventBatchSize + "ORC bufferSize:" + orcBufferSize );
         }
 
-        //increase the batch size according to event size, so it can accomodate all the events.
-        if (eventBatchSize > orcBufferSize) {
-            batch  = schema.createRowBatch(orcBufferSize);
-        }
-
         try {
             for(AuthzAuditEvent event : events) {
                 int row = batch.size++;


### PR DESCRIPTION
Creating another row batch causes null pointer exception as vectorizedRowBatchMap has old batch references and gets garbage collected.

## What changes were proposed in this pull request?
In `log(Writer writer, Collection<AuthzAuditEvent> events)`, creating new row batch causes an exception since the new batch renders references in vectorizedRowBatchMap invalid. 
The creation of new batch is also not necessary as batch of same size was allocated in initORCAuditSchema(). Also, creating a batch larger than orc buffer size is also not useful since the batch is written to writer as soon as its size reaches orc buffer size.

`   if (batch.size == orcBufferSize) {
                    writer.addRowBatch(batch);
                    batch.reset();
                }`

## How was this patch tested?
The unit test case TestAuditQueue.testAuditFileQueueSpoolORC failed when xasecure.audit.destination.hdfs.batch.filequeue.filespool.buffer.size and  xasecure.audit.destination.hdfs.orc.buffersize were unequal. After the fix, the test case passes and now different values (e.g. 10 and 5 respectively as shown below) can be used for these properties. 
 
```
props = {
xasecure.audit.destination.hdfs.orc.buffersize=5, 
xasecure.audit.destination.hdfs.batch.filequeue.filespool.dir=target/spool, xasecure.audit.destination.hdfs.batch.queuetype=filequeue, xasecure.audit.destination.hdfs.batch.filequeue.filespool.buffer.size=10, xasecure.audit.destination.hdfs.batch.filequeue.filetype=orc, xasecure.audit.is.enabled=true, xasecure.audit.destination.hdfs.filename.format=%app-type%_ranger_audit.orc, xasecure.audit.destination.hdfs=enable, xasecure.audit.destination.hdfs.orc.stripesize=10, xasecure.audit.destination.hdfs.dir=target/testAuditFileQueueSpoolORC, xasecure.audit.destination.hdfs.orc.compression=none, xasecure.audit.destination.hdfs.batch.filequeue.filespool.file.rollover.sec=5
}

```
