### PR TITLE
RANGER-4734: Trino Ranger Integration in Docker

### DIFF
--- a/agents-common/scripts/enable-agent.sh
+++ b/agents-common/scripts/enable-agent.sh
@@ -222,7 +222,7 @@ elif [ "${HCOMPONENT_NAME}" = "presto" ]; then
     fi
 elif [ "${HCOMPONENT_NAME}" = "trino" ]; then
     HCOMPONENT_LIB_DIR=${HCOMPONENT_INSTALL_DIR}/plugin/ranger
-	#Configure ranger plugin location for trino docker environment
+	  #Configure ranger plugin location for trino docker environment
     if [ "${INSTALL_ENV}" = "docker" ];then
 	   HCOMPONENT_LIB_DIR=/usr/lib/trino/plugin/ranger
     fi
@@ -263,7 +263,7 @@ elif [ "${HCOMPONENT_NAME}" = "presto" ]; then
     HCOMPONENT_CONF_DIR=${HCOMPONENT_INSTALL_DIR}/etc
 elif [ "${HCOMPONENT_NAME}" = "trino" ]; then
     HCOMPONENT_CONF_DIR=${HCOMPONENT_INSTALL_DIR}/etc
-	if [ "${INSTALL_ENV}" = "docker" ];then
+	  if [ "${INSTALL_ENV}" = "docker" ];then
 	   HCOMPONENT_CONF_DIR=${HCOMPONENT_INSTALL_DIR}
     fi
 fi

--- a/dev-support/ranger-docker/.dockerignore
+++ b/dev-support/ranger-docker/.dockerignore
@@ -11,5 +11,6 @@
 !dist/ranger-*-hbase-plugin.tar.gz
 !dist/ranger-*-kafka-plugin.tar.gz
 !dist/ranger-*-knox-plugin.tar.gz
+!dist/ranger-*-trino-plugin.tar.gz
 !downloads/*
 !scripts/*

--- a/dev-support/ranger-docker/.env
+++ b/dev-support/ranger-docker/.env
@@ -11,6 +11,7 @@ RANGER_BASE_JAVA_VERSION=8
 
 # Java version to use to build Apache Ranger
 # Valid values: 8, 11, 17
+# Trino builds on jdk 11 and above
 RANGER_BUILD_JAVA_VERSION=8
 
 # Java version to use to run Ranger Admin server
@@ -32,6 +33,7 @@ HIVE_VERSION=3.1.2
 HIVE_HADOOP_VERSION=3.1.1
 KAFKA_VERSION=2.8.1
 KNOX_VERSION=1.4.0
+TRINO_VERSION=377
 
 # versions of ranger services
 RANGER_VERSION=3.0.0-SNAPSHOT
@@ -46,6 +48,7 @@ HIVE_PLUGIN_VERSION=3.0.0-SNAPSHOT
 HBASE_PLUGIN_VERSION=3.0.0-SNAPSHOT
 KAFKA_PLUGIN_VERSION=3.0.0-SNAPSHOT
 KNOX_PLUGIN_VERSION=3.0.0-SNAPSHOT
+TRINO_PLUGIN_VERSION=3.0.0-SNAPSHOT
 
 # To enable debug logs
 DEBUG_ADMIN=false

--- a/dev-support/ranger-docker/Dockerfile.ranger-trino
+++ b/dev-support/ranger-docker/Dockerfile.ranger-trino
@@ -1,0 +1,70 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG TRINO_VERSION
+FROM trinodb/trino:${TRINO_VERSION}
+
+# trino base image layer has undergone changes in base os image with time.
+##########################################
+#   Trino Versions  |      OS Layer      #
+#    359 - 369      |     centos 11      #
+#    370 - 389      |       ubi8         #
+#    390 - 391      |    azul openjdk    #
+#       392         |       ubi8         #
+#    393 - 431      |   eclipse-temurin  #
+#    432 - current  |       ubi9         #
+##########################################
+
+USER root
+
+ARG TRINO_VERSION
+ARG TRINO_PLUGIN_VERSION
+ENV PLUGIN_DIR=ranger-${TRINO_PLUGIN_VERSION}-trino-plugin
+
+RUN mkdir -p /home/ranger/dist
+RUN mkdir -p /opt/ranger
+RUN mkdir -p /home/ranger/scripts
+RUN groupadd ranger
+RUN useradd -g ranger -ms /bin/bash ranger
+RUN usermod -a -G ranger trino
+RUN chown -R ranger:ranger /home/ranger
+RUN chown -R ranger:ranger /opt/ranger
+
+COPY ./dist/version                                              /home/ranger/dist
+COPY ./dist/ranger-${TRINO_PLUGIN_VERSION}-trino-plugin.tar.gz   /home/ranger/dist
+COPY ./scripts/ranger-trino.sh                                   /home/ranger/scripts
+COPY ./scripts/ranger-trino-plugin-install.properties            /home/ranger/scripts
+
+RUN if [ $TRINO_VERSION -ge 370 ] && [ $TRINO_VERSION -lt 390 ] || [ $TRINO_VERSION -eq 392 ]; then\
+        dnf install -y initscripts;\
+        dnf install -y openssh-clients;\
+        dnf install -y openssh-server;\
+    elif [ $TRINO_VERSION -ge 432 ]; then\
+        microdnf install -y gzip;\
+        microdnf install -y initscripts;\
+        microdnf install -y openssh-clients;\
+        microdnf install -y openssh-server;\
+    else\
+        apt-get update; DEBIAN_FRONTEND="noninteractive" apt-get -y install ssh;\
+    fi
+
+RUN tar xvfz /home/ranger/dist/${PLUGIN_DIR}.tar.gz --directory=/opt/ranger
+RUN ln -s /opt/ranger/${PLUGIN_DIR} /opt/ranger/ranger-trino-plugin
+RUN rm -f /home/ranger/dist/${PLUGIN_DIR}.tar.gz
+RUN cp -f /home/ranger/scripts/ranger-trino-plugin-install.properties /opt/ranger/ranger-trino-plugin/install.properties
+RUN chmod 744 /home/ranger/scripts/ranger-trino.sh
+
+ENTRYPOINT ["/home/ranger/scripts/ranger-trino.sh"]

--- a/dev-support/ranger-docker/docker-compose.ranger-trino.yml
+++ b/dev-support/ranger-docker/docker-compose.ranger-trino.yml
@@ -1,0 +1,29 @@
+version: '3'
+services:
+  trino:
+    build:
+      context: .
+      dockerfile: Dockerfile.ranger-trino
+      args:
+        - TRINO_PLUGIN_VERSION=${TRINO_PLUGIN_VERSION}
+        - TRINO_VERSION=${TRINO_VERSION}
+    image: ranger-trino
+    hostname: ranger-trino
+    user: root
+    container_name: ranger-trino
+    stdin_open: true
+    tty: true
+    networks:
+      - ranger
+    ports:
+      - 8080:8080
+    depends_on:
+      ranger:
+        condition: service_started
+    environment:
+      - TRINO_PLUGIN_VERSION
+      - TRINO_VERSION
+
+networks:
+  ranger:
+    name: rangernw

--- a/dev-support/ranger-docker/scripts/create-ranger-services.py
+++ b/dev-support/ranger-docker/scripts/create-ranger-services.py
@@ -46,8 +46,18 @@ hbase = RangerService({'name': 'dev_hbase', 'type': 'hbase',
                                    'zookeeper.znode.parent': '/hbase'}})
 
 kms = RangerService({'name': 'dev_kms', 'type': 'kms',
-                      'configs': {'username': 'keyadmin', 'password': 'rangerR0cks!',
-                                  'provider': 'http://ranger-kms:9292'}})
+                     'configs': {'username': 'keyadmin', 'password': 'rangerR0cks!',
+                                 'provider': 'http://ranger-kms:9292'}})
+
+trino = RangerService({'name': 'dev_trino',
+                       'type': 'trino',
+                       'displayName': 'trino',
+                       'configs': {
+                           'username': 'trino',
+                           'password': 'trino',
+                           'jdbc.driverClassName': 'io.trino.jdbc.TrinoDriver',
+                           'jdbc.url': 'jdbc:trino://ranger-trino:8080',
+                       }})
 
 if service_not_exists(hdfs):
     ranger_client.create_service(hdfs)
@@ -70,3 +80,6 @@ if service_not_exists(knox):
 if service_not_exists(kms):
     ranger_client.create_service(kms)
     print('KMS service created!')
+if service_not_exists(trino):
+    ranger_client.create_service(trino)
+    print('Trino service created!')

--- a/dev-support/ranger-docker/scripts/ranger-admin-install-mysql.properties
+++ b/dev-support/ranger-docker/scripts/ranger-admin-install-mysql.properties
@@ -47,6 +47,15 @@ audit_store=solr
 audit_solr_urls=http://ranger-solr:8983/solr/ranger_audits
 audit_solr_collection_name=ranger_audits
 
+# audit_store=elasticsearch
+audit_elasticsearch_urls=
+audit_elasticsearch_port=9200
+audit_elasticsearch_protocol=http
+audit_elasticsearch_user=elastic
+audit_elasticsearch_password=elasticsearch
+audit_elasticsearch_index=ranger_audits
+audit_elasticsearch_bootstrap_enabled=true
+
 policymgr_external_url=http://ranger-admin:6080
 policymgr_http_enabled=true
 

--- a/dev-support/ranger-docker/scripts/ranger-admin-install-postgres.properties
+++ b/dev-support/ranger-docker/scripts/ranger-admin-install-postgres.properties
@@ -47,6 +47,15 @@ audit_store=solr
 audit_solr_urls=http://ranger-solr:8983/solr/ranger_audits
 audit_solr_collection_name=ranger_audits
 
+# audit_store=elasticsearch
+audit_elasticsearch_urls=
+audit_elasticsearch_port=9200
+audit_elasticsearch_protocol=http
+audit_elasticsearch_user=elastic
+audit_elasticsearch_password=elasticsearch
+audit_elasticsearch_index=ranger_audits
+audit_elasticsearch_bootstrap_enabled=true
+
 policymgr_external_url=http://ranger-admin:6080
 policymgr_http_enabled=true
 

--- a/dev-support/ranger-docker/scripts/ranger-trino-plugin-install.properties
+++ b/dev-support/ranger-docker/scripts/ranger-trino-plugin-install.properties
@@ -1,0 +1,169 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Location of Policy Manager URL
+#
+POLICY_MGR_URL=http://ranger:6080
+#
+# This is the repository name created within policy manager
+#
+# Example:
+# REPOSITORY_NAME=trinodev
+#
+REPOSITORY_NAME=dev_trino
+# Custom added property to correctly configure ranger plugin for docker environment. This is required because trino uses different directories
+# for plugin and configuration for docker environment
+INSTALL_ENV=docker
+
+# Custom added property to correctly configure ranger plugin for docker environment. This is required because trino uses different directories
+# for plugin and configuration for docker environment
+COMPONENT_PLUGIN_DIR_NAME=/usr/lib/trino/plugin/ranger
+
+# Configure INSTALL_ENV=docker if running trino in docker environment
+#INSTALL_ENV=docker
+#
+# Name of the directory where the component's lib and conf directory exist.
+# This location should be relative to the parent of the directory containing
+# the plugin installation files.
+#
+COMPONENT_INSTALL_DIR_NAME=/etc/trino
+
+# Enable audit logs to Solr
+XAAUDIT.SOLR.ENABLE=true
+XAAUDIT.SOLR.URL=http://ranger-solr:8983/solr/ranger_audits
+XAAUDIT.SOLR.USER=solr
+XAAUDIT.SOLR.PASSWORD=NONE
+XAAUDIT.SOLR.ZOOKEEPER=NONE
+XAAUDIT.SOLR.FILE_SPOOL_DIR=/var/log/trino/audit/solr/spool
+
+# Enable audit logs to ElasticSearch
+XAAUDIT.ELASTICSEARCH.ENABLE=false
+XAAUDIT.ELASTICSEARCH.URL=http://ranger-es:9200
+XAAUDIT.ELASTICSEARCH.USER=elastic
+XAAUDIT.ELASTICSEARCH.PASSWORD=elasticsearch
+XAAUDIT.ELASTICSEARCH.INDEX=ranger_audits
+XAAUDIT.ELASTICSEARCH.PORT=9200
+XAAUDIT.ELASTICSEARCH.PROTOCOL=http
+
+# Enable audit logs to HDFS
+#Example
+#XAAUDIT.HDFS.ENABLE=true
+#XAAUDIT.HDFS.HDFS_DIR=hdfs://node-1.example.com:8020/ranger/audit
+#  If using Azure Blob Storage
+#XAAUDIT.HDFS.HDFS_DIR=wasb[s]://<containername>@<accountname>.blob.core.windows.net/<path>
+#XAAUDIT.HDFS.HDFS_DIR=wasb://ranger_audit_container@my-azure-account.blob.core.windows.net/ranger/audit
+#XAAUDIT.HDFS.FILE_SPOOL_DIR=/var/log/trino/audit/hdfs/spool
+
+XAAUDIT.HDFS.ENABLE=false
+XAAUDIT.HDFS.HDFS_DIR=hdfs://__REPLACE__NAME_NODE_HOST:8020/ranger/audit
+XAAUDIT.HDFS.FILE_SPOOL_DIR=/var/log/trino/audit/hdfs/spool
+
+# Following additional propertis are needed When auditing to Azure Blob Storage via HDFS
+# Get these values from your /etc/hadoop/conf/core-site.xml
+#XAAUDIT.HDFS.HDFS_DIR=wasb[s]://<containername>@<accountname>.blob.core.windows.net/<path>
+XAAUDIT.HDFS.AZURE_ACCOUNTNAME=__REPLACE_AZURE_ACCOUNT_NAME
+XAAUDIT.HDFS.AZURE_ACCOUNTKEY=__REPLACE_AZURE_ACCOUNT_KEY
+XAAUDIT.HDFS.AZURE_SHELL_KEY_PROVIDER=__REPLACE_AZURE_SHELL_KEY_PROVIDER
+XAAUDIT.HDFS.AZURE_ACCOUNTKEY_PROVIDER=__REPLACE_AZURE_ACCOUNT_KEY_PROVIDER
+
+#Log4j Audit Provider
+XAAUDIT.LOG4J.ENABLE=false
+XAAUDIT.LOG4J.IS_ASYNC=false
+XAAUDIT.LOG4J.ASYNC.MAX.QUEUE.SIZE=10240
+XAAUDIT.LOG4J.ASYNC.MAX.FLUSH.INTERVAL.MS=30000
+XAAUDIT.LOG4J.DESTINATION.LOG4J=true
+XAAUDIT.LOG4J.DESTINATION.LOG4J.LOGGER=xaaudit
+
+# Enable audit logs to Amazon CloudWatch Logs
+#Example
+#XAAUDIT.AMAZON_CLOUDWATCH.ENABLE=true
+#XAAUDIT.AMAZON_CLOUDWATCH.LOG_GROUP=ranger_audits
+#XAAUDIT.AMAZON_CLOUDWATCH.LOG_STREAM={instance_id}
+#XAAUDIT.AMAZON_CLOUDWATCH.FILE_SPOOL_DIR=/var/log/hive/audit/amazon_cloudwatch/spool
+
+XAAUDIT.AMAZON_CLOUDWATCH.ENABLE=false
+XAAUDIT.AMAZON_CLOUDWATCH.LOG_GROUP=NONE
+XAAUDIT.AMAZON_CLOUDWATCH.LOG_STREAM_PREFIX=NONE
+XAAUDIT.AMAZON_CLOUDWATCH.FILE_SPOOL_DIR=NONE
+XAAUDIT.AMAZON_CLOUDWATCH.REGION=NONE
+
+# End of V3 properties
+#
+#  Audit to HDFS Configuration
+#
+# If XAAUDIT.HDFS.IS_ENABLED is set to true, please replace tokens
+# that start with __REPLACE__ with appropriate values
+#  XAAUDIT.HDFS.IS_ENABLED=true
+#  XAAUDIT.HDFS.DESTINATION_DIRECTORY=hdfs://__REPLACE__NAME_NODE_HOST:8020/ranger/audit/%app-type%/%time:yyyyMMdd%
+#  XAAUDIT.HDFS.LOCAL_BUFFER_DIRECTORY=__REPLACE__LOG_DIR/trino/audit
+#  XAAUDIT.HDFS.LOCAL_ARCHIVE_DIRECTORY=__REPLACE__LOG_DIR/trino/audit/archive
+#
+# Example:
+#  XAAUDIT.HDFS.IS_ENABLED=true
+#  XAAUDIT.HDFS.DESTINATION_DIRECTORY=hdfs://namenode.example.com:8020/ranger/audit/%app-type%/%time:yyyyMMdd%
+#  XAAUDIT.HDFS.LOCAL_BUFFER_DIRECTORY=/var/log/trino/audit
+#  XAAUDIT.HDFS.LOCAL_ARCHIVE_DIRECTORY=/var/log/trino/audit/archive
+#
+XAAUDIT.HDFS.IS_ENABLED=false
+XAAUDIT.HDFS.DESTINATION_DIRECTORY=hdfs://__REPLACE__NAME_NODE_HOST:8020/ranger/audit/%app-type%/%time:yyyyMMdd%
+XAAUDIT.HDFS.LOCAL_BUFFER_DIRECTORY=__REPLACE__LOG_DIR/trino/audit
+XAAUDIT.HDFS.LOCAL_ARCHIVE_DIRECTORY=__REPLACE__LOG_DIR/trino/audit/archive
+
+XAAUDIT.HDFS.DESTINTATION_FILE=%hostname%-audit.log
+XAAUDIT.HDFS.DESTINTATION_FLUSH_INTERVAL_SECONDS=900
+XAAUDIT.HDFS.DESTINTATION_ROLLOVER_INTERVAL_SECONDS=86400
+XAAUDIT.HDFS.DESTINTATION_OPEN_RETRY_INTERVAL_SECONDS=60
+XAAUDIT.HDFS.LOCAL_BUFFER_FILE=%time:yyyyMMdd-HHmm.ss%.log
+XAAUDIT.HDFS.LOCAL_BUFFER_FLUSH_INTERVAL_SECONDS=60
+XAAUDIT.HDFS.LOCAL_BUFFER_ROLLOVER_INTERVAL_SECONDS=600
+XAAUDIT.HDFS.LOCAL_ARCHIVE_MAX_FILE_COUNT=10
+
+#Solr Audit Provider
+XAAUDIT.SOLR.IS_ENABLED=true
+XAAUDIT.SOLR.MAX_QUEUE_SIZE=1
+XAAUDIT.SOLR.MAX_FLUSH_INTERVAL_MS=1000
+XAAUDIT.SOLR.SOLR_URL=http://ranger-solr:6083/solr/ranger_audits
+
+# End of V2 properties
+
+#
+# SSL Client Certificate Information
+#
+# Example:
+# SSL_KEYSTORE_FILE_PATH=/etc/hadoop/conf/ranger-plugin-keystore.jks
+# SSL_KEYSTORE_PASSWORD=none
+# SSL_TRUSTSTORE_FILE_PATH=/etc/hadoop/conf/ranger-plugin-truststore.jks
+# SSL_TRUSTSTORE_PASSWORD=none
+#
+# You do not need use SSL between agent and security admin tool, please leave these sample value as it is.
+#
+SSL_KEYSTORE_FILE_PATH=/etc/hadoop/conf/ranger-plugin-keystore.jks
+SSL_KEYSTORE_PASSWORD=myKeyFilePassword
+SSL_TRUSTSTORE_FILE_PATH=/etc/hadoop/conf/ranger-plugin-truststore.jks
+SSL_TRUSTSTORE_PASSWORD=changeit
+
+#
+# Custom component user
+# CUSTOM_COMPONENT_USER=<custom-user>
+# keep blank if component user is default
+CUSTOM_USER=root
+
+
+#
+# Custom component group
+# CUSTOM_COMPONENT_GROUP=<custom-group>
+# keep blank if component group is default
+CUSTOM_GROUP=root
+XAAUDIT.SUMMARY.ENABLE=false

--- a/dev-support/ranger-docker/scripts/ranger-trino.sh
+++ b/dev-support/ranger-docker/scripts/ranger-trino.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+ssh-keygen -A
+/usr/sbin/sshd
+
+if [ ! -e "${TRINO_HOME}"/.setupDone ]
+then
+  su -c "ssh-keygen -t rsa -P '' -f ~/.ssh/id_rsa" trino
+  su -c "cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys" trino
+  su -c "chmod 0600 ~/.ssh/authorized_keys" trino
+
+  cat <<EOF > /etc/ssh/ssh_config
+Host *
+   StrictHostKeyChecking no
+   UserKnownHostsFile=/dev/null
+EOF
+
+  cd /opt/ranger/ranger-trino-plugin || exit
+  ./enable-trino-plugin.sh
+
+  touch "${TRINO_HOME}"/.setupDone
+  echo "Ranger Trino Plugin Installation is complete!"
+fi
+
+/usr/lib/trino/bin/run-trino
+
+TRINO_PID=$(ps -ef  | grep -v grep | grep -i "io.trino.server.TrinoServer" | awk '{print $2}')
+
+# prevent the container from exiting
+if [ -z "$TRINO_PID" ]
+then
+  echo "The Trino process probably exited, no process id found!"
+else
+  tail --pid="$TRINO_PID" -f /dev/null
+fi


### PR DESCRIPTION
## What changes were proposed in this pull request?

Introduces Docker Image for Trino in Ranger

## How was this patch tested?
- Bring up the containers
  - Build with JDK 11: `mvn clean package -DskipTests -P ranger-jdk11 -pl '!unixauthnative'`
  - `cp target/ranger-admin.tar.gz dev-support/ranger-docker/dist`
  - `cp target/ranger-trino-plugin.tar.gz dev-support/ranger-docker/dist/`
  - `cd dev-support/ranger-docker`
  - `docker-compose -f docker-compose.ranger.yml -f docker-compose.ranger-postgres.yml -f docker-compose.ranger-trino.yml build`
  - `docker-compose -f docker-compose.ranger.yml -f docker-compose.ranger-postgres.yml up -d`
  - `docker-compose -f docker-compose.ranger.yml -f docker-compose.ranger-postgres.yml -f docker-compose.ranger-trino.yml up -d`

- Audits to Solr visible in Ranger UI for Trino
<img width="1530" alt="trino_audits" src="https://github.com/apache/ranger/assets/16475454/5a6fe81f-ed54-4a97-9579-c1e4371c45c1">

- Policies synced to Plugin
<img width="1580" alt="trino_policy_sync" src="https://github.com/apache/ranger/assets/16475454/8a2eba6a-a45c-406f-abf1-a230d76dd53d">

- Configuring Ranger Policies for Trino and accessing via Trino CLI
 
<img width="1017" alt="trino_cli" src="https://github.com/apache/ranger/assets/16475454/602817b0-2324-4591-a7cc-93f4d8a59597">

