### PR TITLE
RANGER-4747: Add exception handling in docker based service creation

### DIFF
--- a/dev-support/ranger-docker/scripts/create-ranger-services.py
+++ b/dev-support/ranger-docker/scripts/create-ranger-services.py
@@ -66,3 +66,4 @@ for service in services:
             print(f" {service.name} service created!")
     except Exception as e:
         print(f"An exception occured: {e}")
+

--- a/dev-support/ranger-docker/scripts/create-ranger-services.py
+++ b/dev-support/ranger-docker/scripts/create-ranger-services.py
@@ -58,27 +58,11 @@ trino = RangerService({'name': 'dev_trino',
                            'jdbc.url': 'jdbc:trino://ranger-trino:8080',
                        }})
 
-if service_not_exists(hdfs):
-    ranger_client.create_service(hdfs)
-    print('HDFS service created!')
-if service_not_exists(yarn):
-    ranger_client.create_service(yarn)
-    print('Yarn service created!')
-if service_not_exists(hive):
-    ranger_client.create_service(hive)
-    print('Hive service created!')
-if service_not_exists(hbase):
-    ranger_client.create_service(hbase)
-    print('HBase service created!')
-if service_not_exists(kafka):
-    ranger_client.create_service(kafka)
-    print('Kafka service created!')
-if service_not_exists(knox):
-    ranger_client.create_service(knox)
-    print('Knox service created!')
-if service_not_exists(kms):
-    ranger_client.create_service(kms)
-    print('KMS service created!')
-if service_not_exists(trino):
-    ranger_client.create_service(trino)
-    print('Trino service created!')
+services = [hdfs, yarn, hive, hbase, kafka, knox, kms, trino]
+for service in services:
+    try:
+        if service_not_exists(service):
+            ranger_client.create_service(service)
+            print(f" {service.name} service created!")
+    except Exception as e:
+        print(f"An exception occured: {e}")


### PR DESCRIPTION
## What changes were proposed in this pull request?

create-ranger-services.py creates ranger services after ranger is up in a docker container.
If service creation for hdfs fails, subsequent service creation is aborted, the PR aims to fix this behavior.

## How was this patch tested?
Tested the changes by bringing up ranger in a container and below are the installation logs seen when only trino is packaged with ranger.

<img width="1167" alt="Screenshot 2024-03-13 at 12 29 05 PM" src="https://github.com/apache/ranger/assets/16475454/a0b8effe-2fdf-4bea-a19e-f1c274b0784a">
