### PR TITLE
RANGER-4746: Fix ranger-jdk11 profile to only have the required modules

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -108,31 +108,9 @@
                                 <configuration>
                                     <skipAssembly>false</skipAssembly>
                                     <descriptors>
-                                        <descriptor>src/main/assembly/hdfs-agent.xml</descriptor>
-                                        <descriptor>src/main/assembly/hive-agent.xml</descriptor>
-                                        <descriptor>src/main/assembly/hbase-agent.xml</descriptor>
-                                        <descriptor>src/main/assembly/knox-agent.xml</descriptor>
-                                        <descriptor>src/main/assembly/storm-agent.xml</descriptor>
-                                        <descriptor>src/main/assembly/plugin-kafka.xml</descriptor>
-                                        <descriptor>src/main/assembly/plugin-yarn.xml</descriptor>
-                                        <descriptor>src/main/assembly/plugin-ozone.xml</descriptor>
-                                        <descriptor>src/main/assembly/plugin-solr.xml</descriptor>
                                         <descriptor>src/main/assembly/admin-web.xml</descriptor>
                                         <descriptor>src/main/assembly/solr_audit_conf.xml</descriptor>
-                                        <descriptor>src/main/assembly/usersync.xml</descriptor>
-                                        <descriptor>src/main/assembly/tagsync.xml</descriptor>
-                                        <descriptor>src/main/assembly/migration-util.xml</descriptor>
-                                        <descriptor>src/main/assembly/kms.xml</descriptor>
-                                        <descriptor>src/main/assembly/ranger-tools.xml</descriptor>
-                                        <descriptor>src/main/assembly/ranger-src.xml</descriptor>
-                                        <descriptor>src/main/assembly/plugin-atlas.xml</descriptor>
-                                        <descriptor>src/main/assembly/plugin-sqoop.xml</descriptor>
-                                        <descriptor>src/main/assembly/plugin-kylin.xml</descriptor>
-                                        <descriptor>src/main/assembly/plugin-elasticsearch.xml</descriptor>
-                                        <descriptor>src/main/assembly/plugin-schema-registry.xml</descriptor>
-                                        <descriptor>src/main/assembly/plugin-presto.xml</descriptor>
                                         <descriptor>src/main/assembly/plugin-trino.xml</descriptor>
-                                        <descriptor>src/main/assembly/sample-client.xml</descriptor>
                                     </descriptors>
                                 </configuration>
                             </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -339,70 +339,29 @@
                <jdk>11</jdk>
             </activation>
             <modules>
-                <module>jisql</module>
+                <!--  ranger-admin requirements  -->
+                <module>security-admin</module>
                 <module>agents-audit</module>
                 <module>agents-common</module>
                 <module>agents-cred</module>
-                <module>intg</module>
-                <module>agents-installer</module>
-                <module>credentialbuilder</module>
+                <module>jisql</module>
                 <module>embeddedwebserver</module>
-		<module>ranger-common-ha</module>
-                <module>kms</module>
-                <module>hbase-agent</module>
-                <module>hdfs-agent</module>
-                <module>hive-agent</module>
-                <module>knox-agent</module>
-                <module>storm-agent</module>
-                <module>plugin-yarn</module>
-                <module>plugin-ozone</module>
-                <module>security-admin</module>
-                <module>plugin-kafka</module>
-                <module>plugin-solr</module>
-                <module>plugin-nestedstructure</module>
-                <module>plugin-nifi</module>
-                <module>plugin-nifi-registry</module>
-                <module>plugin-presto</module>
-                <module>plugin-trino</module>
-                <module>plugin-kudu</module>
-                <module>ugsync-util</module>
-                <module>ugsync</module>
-                <module>ugsync/ldapconfigchecktool/ldapconfigcheck</module>
-                <module>unixauthclient</module>
-                <module>unixauthservice</module>
-                <module>unixauthnative</module>
+                <module>credentialbuilder</module>
                 <module>ranger-util</module>
-                <module>plugin-kms</module>
-                <module>tagsync</module>
-                <module>ranger-hdfs-plugin-shim</module>
+                <module>ugsync-util</module>
+                <module>unixauthclient</module>
                 <module>ranger-plugin-classloader</module>
-                <module>ranger-hive-plugin-shim</module>
-                <module>ranger-hbase-plugin-shim</module>
-                <module>ranger-knox-plugin-shim</module>
-                <module>ranger-yarn-plugin-shim</module>
-                <module>ranger-ozone-plugin-shim</module>
-                <module>ranger-storm-plugin-shim</module>
-                <module>ranger-kafka-plugin-shim</module>
-                <module>ranger-solr-plugin-shim</module>
-                <module>ranger-atlas-plugin-shim</module>
-                <module>ranger-kms-plugin-shim</module>
-                <module>ranger-presto-plugin-shim</module>
-                <module>ranger-trino-plugin-shim</module>
-                <module>ranger-examples</module>
-                <module>ranger-tools</module>
-                <module>plugin-atlas</module>
-                <module>plugin-schema-registry</module>
-                <module>plugin-sqoop</module>
-                <module>ranger-sqoop-plugin-shim</module>
-                <module>plugin-kylin</module>
-                <module>ranger-kylin-plugin-shim</module>
-                <module>plugin-elasticsearch</module>
-                <module>ranger-elasticsearch-plugin-shim</module>
                 <module>ranger-authn</module>
                 <module>ranger-metrics</module>
+                <!-- trino-plugin requirements -->
+                <module>agents-installer</module>
+                <module>plugin-trino</module>
+                <module>ranger-trino-plugin-shim</module>
+                <!-- nested-structure-plugin requirements -->
+                <module>plugin-nestedstructure</module>
                 <!--
                    'distro' should be the last module. If a module gets inserted after
-                   ranger-elasticsearch-plugin-shim, make sure to update dependency in distro/pom.xml
+                   plugin-nestedstructure, make sure to update dependency in distro/pom.xml
                 -->
                 <module>distro</module>
             </modules>


### PR DESCRIPTION
## What changes were proposed in this pull request?

The ranger profile `ranger-jdk11` has been added to build trino with jdk 11 as currently trino plugin is the only plugin to have a compile time dependency on jdk 11. However, it currently builds the full ranger repo. The PR aims to fix this. When modules have a jdk 11 requirement they can be added to this profile.

## How was this patch tested?
- Bring up the containers
  - Build with JDK 11: `mvn clean package -DskipTests -P ranger-jdk11`
  - `cp target/ranger-admin.tar.gz dev-support/ranger-docker/dist`
  - `cp target/ranger-trino-plugin.tar.gz dev-support/ranger-docker/dist/`
  - `cd dev-support/ranger-docker`
  - `docker-compose -f docker-compose.ranger.yml -f docker-compose.ranger-postgres.yml -f docker-compose.ranger-trino.yml build`
  - `docker-compose -f docker-compose.ranger.yml -f docker-compose.ranger-postgres.yml up -d`
  - `docker-compose -f docker-compose.ranger.yml -f docker-compose.ranger-postgres.yml -f docker-compose.ranger-trino.yml up -d`
 - Verified ranger and ranger-trino are successfully up in containers.
 - Verified ranger policy creation, policies created for trino are working.
 - Verified audits to Solr are visible in ranger UI.
