### PR TITLE
RANGER-4278:Update query not working on column level access for Trino…

### DIFF
--- a/agents-common/src/main/resources/service-defs/ranger-servicedef-trino.json
+++ b/agents-common/src/main/resources/service-defs/ranger-servicedef-trino.json
@@ -288,7 +288,8 @@
         "revoke",
         "show",
         "impersonate",
-        "execute"
+        "execute",
+        "update"
       ]
     },
     {
@@ -296,6 +297,11 @@
       "name": "execute",
       "label": "execute",
       "category": "READ"
+    },{
+      "itemId": 14,
+      "name": "update",
+      "label": "update",
+      "category": "UPDATE"
     }
   ],
   "configs": [

--- a/plugin-trino/src/main/java/org/apache/ranger/authorization/trino/authorizer/RangerSystemAccessControl.java
+++ b/plugin-trino/src/main/java/org/apache/ranger/authorization/trino/authorizer/RangerSystemAccessControl.java
@@ -633,6 +633,16 @@ public class RangerSystemAccessControl
     }
   }
 
+  @Override
+  public void checkCanUpdateTableColumns(SystemSecurityContext securityContext, CatalogSchemaTableName table, Set<String> updatedColumnNames) {
+    for (RangerTrinoResource res : createResource(table, updatedColumnNames)) {
+      if (!hasPermission(res, securityContext, TrinoAccessType.UPDATE)) {
+        LOG.debug("RangerSystemAccessControl.checkCanUpdateTableColumns(" +table.getSchemaTableName().getTableName() + ") denied");
+        AccessDeniedException.denyUpdateTableColumns(table.getSchemaTableName().getTableName(), updatedColumnNames);
+      }
+    }
+  }
+
   /**
    * This is a NOOP, no filtering is applied
    */
@@ -910,5 +920,5 @@ class RangerTrinoAccessRequest
 }
 
 enum TrinoAccessType {
-  CREATE, DROP, SELECT, INSERT, DELETE, USE, ALTER, ALL, GRANT, REVOKE, SHOW, IMPERSONATE, EXECUTE;
+  CREATE, DROP, SELECT, INSERT, DELETE, USE, ALTER, ALL, GRANT, REVOKE, SHOW, IMPERSONATE, EXECUTE, UPDATE;
 }

--- a/ranger-trino-plugin-shim/src/main/java/org/apache/ranger/authorization/trino/authorizer/RangerSystemAccessControl.java
+++ b/ranger-trino-plugin-shim/src/main/java/org/apache/ranger/authorization/trino/authorizer/RangerSystemAccessControl.java
@@ -238,6 +238,17 @@ public class RangerSystemAccessControl
   }
 
   @Override
+  public void checkCanUpdateTableColumns(SystemSecurityContext securityContext, CatalogSchemaTableName table, Set<String> updatedColumnNames)
+  {
+    try {
+      activatePluginClassLoader();
+      systemAccessControlImpl.checkCanUpdateTableColumns(securityContext, table, updatedColumnNames);
+    } finally {
+      deactivatePluginClassLoader();
+    }
+  }
+
+  @Override
   public void checkCanInsertIntoTable(SystemSecurityContext context, CatalogSchemaTableName table) {
     try {
       activatePluginClassLoader();


### PR DESCRIPTION
… plugin

## What changes were proposed in this pull request?
Fix  Update query not working on column level access for Trino


## How was this patch tested?

you should add 'update' policy first by Ranger UI, and you can test  SQL like 'update table1 set col2='bbb' where col1 = 1 ' 
<img width="1386" alt="image" src="https://github.com/apache/ranger/assets/36159052/2dc7d2f8-f85e-4c57-aa75-5e05a5ee630a">