### PR TITLE
RANGER-4762:Prevent duplicate values for resource while validating policy

### DIFF
--- a/agents-common/src/main/java/org/apache/ranger/plugin/errors/ValidationErrorCode.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/errors/ValidationErrorCode.java
@@ -107,6 +107,7 @@ public enum ValidationErrorCode {
     POLICY_VALIDATION_ERR_NULL_POLICY_ITEM_USER(3053, "policy items user was null"),
     POLICY_VALIDATION_ERR_NULL_POLICY_ITEM_GROUP(3054, "policy items group was null"),
     POLICY_VALIDATION_ERR_NULL_POLICY_ITEM_ROLE(3055, "policy items role was null"),
+    POLICY_VALIDATION_ERR_DUPLICATE_VALUES_FOR_RESOURCE(3056, "Values for the resource={0} contained a duplicate value={1}. Ensure all values for a resource are unique"),
     POLICY_VALIDATION_ERR_INVALID_SERVICE_TYPE(4009," Invalid service type [{0}] provided for service [{1}]"),
 
     // SECURITY_ZONE Validations

--- a/agents-common/src/main/java/org/apache/ranger/plugin/model/validation/RangerPolicyValidator.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/model/validation/RangerPolicyValidator.java
@@ -882,18 +882,18 @@ public class RangerPolicyValidator extends RangerValidator {
 		for (Map.Entry<String, RangerPolicyResource> entry : resourceMap.entrySet()) {
 			String name = entry.getKey();
 			RangerPolicyResource policyResource = entry.getValue();
-			Set<String> resources = null;
+			Set<String> resources = new HashSet<>();
+			String duplicateValue = "";
 			if(policyResource != null) {
 				if(CollectionUtils.isNotEmpty(policyResource.getValues())) {
-					resources = new HashSet<>(policyResource.getValues());
+					duplicateValue = populateSetAndGetDuplicate(resources, policyResource.getValues());
 					for (String aValue : resources) {
 						if (StringUtils.isBlank(aValue)) {
 							policyResource.getValues().remove(aValue);
 						}
 					}
 				}
-				if (resources!=null && resources.size() < policyResource.getValues().size()){
-					String duplicateValue = getDuplicateInList(policyResource.getValues());
+				if (!StringUtils.isBlank(duplicateValue)){
 					ValidationErrorCode error = ValidationErrorCode.POLICY_VALIDATION_ERR_DUPLICATE_VALUES_FOR_RESOURCE;
 					if (LOG.isDebugEnabled()){
 						LOG.debug(String.format("Duplicate values found for the resource name[%s] value[%s] service-def-name[%s]",name, duplicateValue,serviceDef.getName()));
@@ -951,15 +951,15 @@ public class RangerPolicyValidator extends RangerValidator {
 		return valid;
 	}
 
-	private String getDuplicateInList(List<String> values) {
-		HashSet<String> existing = new HashSet<>();
+	private String populateSetAndGetDuplicate(Set<String> set, List<String> values) {
+		String duplicate = "";
 		for (String value : values){
-			if (existing.contains(value)){
-				return value;
+			if (set.contains(value) && !StringUtils.isBlank(value)){
+				duplicate = value;
 			}
-			existing.add(value);
+			set.add(value);
 		}
-		return "";
+		return duplicate;
 	}
 
 	boolean isValidPolicyItems(List<RangerPolicyItem> policyItems, List<ValidationFailureDetails> failures, RangerServiceDef serviceDef) {

--- a/agents-common/src/test/java/org/apache/ranger/plugin/model/validation/TestRangerPolicyValidator.java
+++ b/agents-common/src/test/java/org/apache/ranger/plugin/model/validation/TestRangerPolicyValidator.java
@@ -140,6 +140,16 @@ public class TestRangerPolicyValidator {
 			{"extra", new String[] { "extra1", "extra2" }, null, null } // spurious "extra" specified
 	};
 
+	private final Object[][] policyResourceMap_bad_duplicate_values = new Object[][]{
+			// resource-name, values, excludes, recursive
+			{ "db", new String[] {"db1", "db2" }, null, true},
+			{ "tbl", new String[] {"tbl1", "tbl1"}, null, null} // invalid: there should not be any duplicates for any resource value
+	};
+	private final Object[][] policyResourceMap_good_duplicate_values = new Object[][]{
+			// resource-name, values, excludes, recursive
+			{ "db", new String[] {"db1", "db2" }, null, true},
+			{ "tbl", new String[] {"tbl1", "tbl2"}, null, null} // valid: there should not be any duplicates for any resource value
+	};
 	private final Object[][] policyResourceMap_bad_multiple_hierarchies = new Object[][] {
 			// resource-name, values, excludes, recursive
 			{  "db", new String[] { "db1", "db2" }, null, true },
@@ -533,6 +543,14 @@ public class TestRangerPolicyValidator {
 		
 		policyResources = _utils.createPolicyResourceMap(policyResourceMap_good);
 		Assert.assertTrue(_validator.isValidResourceValues(policyResources, _failures, _serviceDef));
+
+		policyResources = _utils.createPolicyResourceMap(policyResourceMap_bad_duplicate_values);
+		Assert.assertFalse(_validator.isValidResourceValues(policyResources, _failures, _serviceDef));
+		_utils.checkFailureForSemanticError(_failures, "resource-values", "tbl");
+
+		policyResources = _utils.createPolicyResourceMap(policyResourceMap_good_duplicate_values);
+		Assert.assertTrue(_validator.isValidResourceValues(policyResources, _failures, _serviceDef));
+
 	}
 	
 	@Test


### PR DESCRIPTION
Previously: Via REST, policy creation possible when duplicate values specified for a resource as a list e.g. for a resource, multiple dbs can be mentioned like db:[test_db1,test_db1] and this policy is considered different from a policy already created for the resource [test_db1]
The same scenario is already prevented by Ranger UI as it prevents duplicate values for a resource (in a given policy)

## What changes were proposed in this pull request?

After this patch: Error is thrown for duplicate resource values like [test_db1,test_db1] - {"statusCode":1,"msgDesc":"(0) Validation failure: error code[3056], reason[Values for the resource=database contained a duplicate value=test_db1. Ensure all values for a resource are unique], field[resource-values], subfield[database], type[semantically incorrect] "}

## How was this patch tested?

Unit tests added for the scenario
Manually tested via REST end points for policy creation that duplicate resource values for a resource throws above error. 
