### PR TITLE
RANGER-4746: Change default docker build to use JDK 8

### DIFF
--- a/dev-support/ranger-docker/.env
+++ b/dev-support/ranger-docker/.env
@@ -6,7 +6,7 @@ PROFILE=
 BUILD_OPTS=
 
 # To build Trino plugins package, use following PROFILE
-PROFILE=ranger-jdk11,!all,!linux
+# PROFILE=ranger-jdk11,!all,!linux
 
 # Java version for RangerBase image.
 # This image gets used as base docker image for all images.
@@ -16,7 +16,7 @@ RANGER_BASE_JAVA_VERSION=8
 # Java version to use to build Apache Ranger
 # Valid values: 8, 11, 17
 # Trino builds on jdk 11 and above
-RANGER_BUILD_JAVA_VERSION=11
+RANGER_BUILD_JAVA_VERSION=8
 
 # Java version to use to run Ranger Admin server
 # Valid values: 8, 11, 17

--- a/dev-support/ranger-docker/README.md
+++ b/dev-support/ranger-docker/README.md
@@ -66,14 +66,18 @@ Docker files in this folder create docker images and run them to build Apache Ra
          ~~~
 7. To enable file based sync source for usersync execute: ```export ENABLE_FILE_SYNC_SOURCE=true```
 
-8. Execute following command to start Ranger, Ranger enabled HDFS/YARN/HBase/Hive/Kafka/Knox and dependent services (Solr, DB) in containers:
+8. Execute following command to start Ranger, Ranger Usersync, Ranger Tagsync, Ranger enabled HDFS/YARN/HBase/Hive/Kafka/Knox and dependent services (Solr, DB) in containers:
    ~~~
-   docker-compose -f docker-compose.ranger-base.yml -f docker-compose.ranger.yml -f docker-compose.ranger-${RANGER_DB_TYPE}.yml -f docker-compose.ranger-usersync.yml -f docker-compose.ranger-tagsync.yml -f docker-compose.ranger-kms.yml -f docker-compose.ranger-hadoop.yml -f docker-compose.ranger-hbase.yml -f docker-compose.ranger-kafka.yml -f docker-compose.ranger-hive.yml -f docker-compose.ranger-trino.yml -f docker-compose.ranger-knox.yml up -d
+   docker-compose -f docker-compose.ranger-base.yml -f docker-compose.ranger.yml -f docker-compose.ranger-${RANGER_DB_TYPE}.yml -f docker-compose.ranger-usersync.yml -f docker-compose.ranger-tagsync.yml -f docker-compose.ranger-kms.yml -f docker-compose.ranger-hadoop.yml -f docker-compose.ranger-hbase.yml -f docker-compose.ranger-kafka.yml -f docker-compose.ranger-hive.yml -f docker-compose.ranger-knox.yml up -d
    ~~~
 
 	- valid values for RANGER_DB_TYPE: mysql or postgres
+9. To run ranger enabled Trino in containers (Requires docker build with JDK 11):
+   ~~~
+   docker-compose -f docker-compose.ranger-base.yml -f docker-compose.ranger.yml -f docker-compose.ranger-${RANGER_DB_TYPE}.yml -f docker-compose.ranger-trino.yml up -d
+   ~~~
 
-9. To rebuild specific images and start containers with the new image, use following command:
+10. To rebuild specific images and start containers with the new image, use following command:
    ~~~
    docker-compose -f docker-compose.ranger-base.yml -f docker-compose.ranger.yml -f docker-compose.ranger-usersync.yml -f docker-compose.ranger-tagsync.yml -f docker-compose.ranger-kms.yml -f docker-compose.ranger-hadoop.yml -f docker-compose.ranger-hbase.yml -f docker-compose.ranger-kafka.yml -f docker-compose.ranger-hive.yml -f docker-compose.ranger-trino.yml -f docker-compose.ranger-knox.yml up -d --no-deps --force-recreate --build <service-1> <service-2>
    ~~~


### PR DESCRIPTION
## What changes were proposed in this pull request?

Default build currently uses JDK 11, changing the default to refer to JDK 8.

## How was this patch tested?

Tested the changes in docker with default configuration in .env and with the following changes as well:
```
PROFILE=ranger-jdk11,!all,!linux
RANGER_BUILD_JAVA_VERSION=11
```
