### PR TITLE
RANGER-4783: remove duplicates for users/groups/roles during policy validation

### DIFF
--- a/agents-common/src/main/java/org/apache/ranger/plugin/model/validation/RangerPolicyValidator.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/model/validation/RangerPolicyValidator.java
@@ -958,21 +958,12 @@ public class RangerPolicyValidator extends RangerValidator {
 		}
 		return duplicate;
 	}
-	private void removeDuplicates(List<String> values){
+	private static void removeDuplicates(List<String> values){
 		if (values==null || values.isEmpty()){
 			return;
 		}
-		Iterator<String> itr = values.iterator();
 		HashSet<String> uniqueElements = new HashSet<>();
-		while (itr.hasNext()){
-			String ele = itr.next();
-			if (uniqueElements.contains(ele)){
-				itr.remove();
-			}
-			else{
-				uniqueElements.add(ele);
-			}
-		}
+		values.removeIf(e -> !uniqueElements.add(e));
 	}
 
 	boolean isValidPolicyItems(List<RangerPolicyItem> policyItems, List<ValidationFailureDetails> failures, RangerServiceDef serviceDef) {

--- a/agents-common/src/main/java/org/apache/ranger/plugin/model/validation/RangerPolicyValidator.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/model/validation/RangerPolicyValidator.java
@@ -958,6 +958,22 @@ public class RangerPolicyValidator extends RangerValidator {
 		}
 		return duplicate;
 	}
+	private void removeDuplicates(List<String> values){
+		if (values==null || values.isEmpty()){
+			return;
+		}
+		Iterator<String> itr = values.iterator();
+		HashSet<String> uniqueElements = new HashSet<>();
+		while (itr.hasNext()){
+			String ele = itr.next();
+			if (uniqueElements.contains(ele)){
+				itr.remove();
+			}
+			else{
+				uniqueElements.add(ele);
+			}
+		}
+	}
 
 	boolean isValidPolicyItems(List<RangerPolicyItem> policyItems, List<ValidationFailureDetails> failures, RangerServiceDef serviceDef) {
 		if(LOG.isDebugEnabled()) {
@@ -1030,6 +1046,9 @@ public class RangerPolicyValidator extends RangerValidator {
 						.build());
 				valid = false;
 			} else {
+				removeDuplicates(policyItem.getUsers());
+				removeDuplicates(policyItem.getGroups());
+				removeDuplicates(policyItem.getRoles());
 				if (CollectionUtils.isNotEmpty(policyItem.getUsers()) && CollectionUtils.containsAny(policyItem.getUsers(), invalidItems)) {
 					ValidationErrorCode error = ValidationErrorCode.POLICY_VALIDATION_ERR_NULL_POLICY_ITEM_USER;
 					failures.add(new ValidationFailureDetailsBuilder()


### PR DESCRIPTION


## What changes were proposed in this pull request?
De-duplicate the users/groups/roles during policy validation when policy created/updated via REST (duplicates are prevented via ranger UI already)



## How was this patch tested?
Local Docker container with master branch
Unzip the attached scripts folder - the folder contains some payloads which have duplicate users/groups/roles.
Run `bash create-policies.sh "/service/public/v2/api/policy"` command and wait for the script to finish
Login to Ranger Admin and check policies created in Hive - duplicate users/groups/roles are de-duplicated.
[scripts 3.zip](https://github.com/apache/ranger/files/15121965/scripts.3.zip)

