### PR TITLE
RANGER-4818: Fix updated users with role assignments from undergoing role reset to ROLE_USER

### DIFF
--- a/security-admin/src/main/java/org/apache/ranger/biz/XUserMgr.java
+++ b/security-admin/src/main/java/org/apache/ranger/biz/XUserMgr.java
@@ -178,6 +178,7 @@ public class XUserMgr extends XUserMgrBase {
 	PlatformTransactionManager txManager;
 
 	static final Logger logger = LoggerFactory.getLogger(XUserMgr.class);
+	static final Set<String> roleAssignmentUpdatedUsers = new HashSet<>();
 
 	public VXUser getXUserByUserName(String userName) {
 		VXUser vXUser=null;
@@ -3023,27 +3024,36 @@ public class XUserMgr extends XUserMgrBase {
 			}
 
 			if (!vXPortalUser.getUserRoleList().contains(userRole)) {
-				//Update the role of the user only if newly computed role is different from the existing role.
+
 				if (logger.isDebugEnabled()) {
-					logger.debug("Updating role for " + userName + " to " + userRole);
+					logger.debug(String.format("Updating role for %s to %s", userName, userRole));
 				}
+				//Update the role of the user only if newly computed role is different from the existing role.
 				String updatedUser = setRolesByUserName(userName, Collections.singletonList(userRole));
 				if (updatedUser != null) {
 					updatedUsers.add(updatedUser);
+				} else {
+					if (logger.isDebugEnabled()) {
+						logger.debug(String.format("Role for %s unchanged: %s", userName, userRole));
+					}
+				}
+
+				if (ugRoleAssignments.isReset()) { // use below data structure only when reset is true
+					roleAssignmentUpdatedUsers.add(userName);
 				}
 			}
 		}
 
-		// Reset the role of any other users that are not part of the updated role assignments rules
-		if (ugRoleAssignments.isReset()) {
-			List<String> exitingNonUserRoleUsers = daoManager.getXXPortalUser().getNonUserRoleExternalUsers();
+		// Reset the role of users that are not part of the updated role assignments rules
+		if (ugRoleAssignments.isReset() && ugRoleAssignments.isLastPage()) {
+			List<String> externalUsersWithNonUserRole = daoManager.getXXPortalUser().getNonUserRoleExternalUsers();
 			if (logger.isDebugEnabled()) {
-				logger.debug("Existing non user role users = " + exitingNonUserRoleUsers);
+				logger.debug("Existing external users with non user role: " + externalUsersWithNonUserRole);
 			}
-			for (String userName : exitingNonUserRoleUsers) {
-				if (!requestedUsers.contains(userName)) {
+			for (String userName : externalUsersWithNonUserRole) {
+				if (!roleAssignmentUpdatedUsers.contains(userName)) {
 					if (logger.isDebugEnabled()) {
-						logger.debug("Resetting to User role for " + userName);
+						logger.debug(String.format("Resetting to User role for %s", userName));
 					}
 					String updatedUser = setRolesByUserName(userName, Collections.singletonList(RangerConstants.ROLE_USER));
 					if (updatedUser != null) {
@@ -3051,6 +3061,7 @@ public class XUserMgr extends XUserMgrBase {
 					}
 				}
 			}
+			roleAssignmentUpdatedUsers.clear();
 		}
 
 		return updatedUsers;

--- a/ugsync-util/src/main/java/org/apache/ranger/ugsyncutil/model/UsersGroupRoleAssignments.java
+++ b/ugsync-util/src/main/java/org/apache/ranger/ugsyncutil/model/UsersGroupRoleAssignments.java
@@ -43,6 +43,13 @@ public class UsersGroupRoleAssignments {
 	Map<String, String> whiteListUserRoleAssignments;
 
 	boolean isReset = false;
+	boolean isLastPage = false;
+	public boolean isLastPage() {
+		return isLastPage;
+	}
+	public void setLastPage(boolean lastPage) {
+		isLastPage = lastPage;
+	}
 
 	public List<String> getUsers() {
 		return users;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Allow role resets for users not part of the group based role assignment rules in the last page of the paged requests from usersync to ranger admin. 

## How was this patch tested?

In Progress