### PR TITLE
RANGER-4828: Fix issue in Checks if the GC log directory exists, if not, create it

### DIFF
--- a/embeddedwebserver/scripts/ranger-admin-services.sh
+++ b/embeddedwebserver/scripts/ranger-admin-services.sh
@@ -54,11 +54,9 @@ then
 	RANGER_ADMIN_LOG_DIR=${XAPOLICYMGR_EWS_DIR}/logs
 fi
 
-LOG_GC_DIR=${XAPOLICYMGR_EWS_DIR}/logs/
-
 # Checks if the GC log directory exists, if not, create it
-if [ ! -d "$LOG_GC_DIR" ]; then
-    mkdir -p "$LOG_GC_DIR"
+if [ ! -d "$RANGER_ADMIN_LOG_DIR" ]; then
+    mkdir -p "$RANGER_ADMIN_LOG_DIR"
     if [ $? -ne 0 ]; then
         echo "Error creating log directory for GC. Make sure you have the proper permissions."
     fi

--- a/embeddedwebserver/scripts/ranger-admin-services.sh
+++ b/embeddedwebserver/scripts/ranger-admin-services.sh
@@ -61,10 +61,7 @@ if [ ! -d "$LOG_GC_DIR" ]; then
     mkdir -p "$LOG_GC_DIR"
     if [ $? -ne 0 ]; then
         echo "Error creating log directory for GC. Make sure you have the proper permissions."
-        exit 1
     fi
-else
-    echo "The log directory already exists."
 fi
 
 JAVA_OPTS=" ${JAVA_OPTS} -XX:MetaspaceSize=100m -XX:MaxMetaspaceSize=200m -Xmx${ranger_admin_max_heap_size} -Xms1g -Xloggc:${RANGER_ADMIN_LOG_DIR}/gc-worker.log -verbose:gc -XX:+PrintGCDetails"

--- a/embeddedwebserver/scripts/ranger-admin-services.sh
+++ b/embeddedwebserver/scripts/ranger-admin-services.sh
@@ -54,6 +54,19 @@ then
 	RANGER_ADMIN_LOG_DIR=${XAPOLICYMGR_EWS_DIR}/logs
 fi
 
+LOG_GC_DIR=${XAPOLICYMGR_EWS_DIR}/logs/
+
+# Checks if the GC log directory exists, if not, create it
+if [ ! -d "$LOG_GC_DIR" ]; then
+    mkdir -p "$LOG_GC_DIR"
+    if [ $? -ne 0 ]; then
+        echo "Error creating log directory for GC. Make sure you have the proper permissions."
+        exit 1
+    fi
+else
+    echo "The log directory already exists."
+fi
+
 JAVA_OPTS=" ${JAVA_OPTS} -XX:MetaspaceSize=100m -XX:MaxMetaspaceSize=200m -Xmx${ranger_admin_max_heap_size} -Xms1g -Xloggc:${RANGER_ADMIN_LOG_DIR}/gc-worker.log -verbose:gc -XX:+PrintGCDetails"
 if [[ ${JAVA_OPTS} != *"-Duser.timezone"* ]] ;then  export JAVA_OPTS=" ${JAVA_OPTS} -Duser.timezone=UTC" ;fi
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

In Apache Ranger Admin with Java 11 the JVM doesn't start because the path directory of the GC log file does not exist. However, with Java 8 the JVM even though the file doesn't exist starts correctly. 

As a result of this, no GC logs are now left unless this condition is met (file -> security-admin/scripts/setup.sh): 
![setup](https://github.com/apache/ranger/assets/17085598/ce21bd6b-4153-462f-8c6a-c7d8aea2c467)


Changes:

- embeddedwebserver/scripts/ranger-admin-services.sh


## How was this patch tested?

I have tested it by building docker images with both java 8 and Java11. As you can see now the log file for the GC is created correctly. 

<img width="1243" alt="Solved" src="https://github.com/apache/ranger/assets/17085598/f2aafb00-db20-4ccd-ae40-e94972c95e5b">
<img width="904" alt="Solved2" src="https://github.com/apache/ranger/assets/17085598/8abb533b-09c5-4622-9e7b-3f77a6d8a144">

Admin UI works correctly. 
![image](https://github.com/apache/ranger/assets/17085598/bbbdb68d-0c40-4414-ab04-df224a682d8f)

