### PR TITLE
RANGER-4808 : Enhance KafkaAuditProvider for Audit V3

### DIFF
--- a/agents-audit/src/main/java/org/apache/ranger/audit/provider/kafka/KafkaAuditProvider.java
+++ b/agents-audit/src/main/java/org/apache/ranger/audit/provider/kafka/KafkaAuditProvider.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Properties;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.ranger.audit.destination.AuditDestination;
 import org.apache.ranger.audit.model.AuditEventBase;
@@ -35,10 +36,8 @@ import org.slf4j.LoggerFactory;
 public class KafkaAuditProvider extends AuditDestination {
 	private static final Logger LOG = LoggerFactory.getLogger(KafkaAuditProvider.class);
 
-	public static final String AUDIT_MAX_QUEUE_SIZE_PROP = "xasecure.audit.kafka.async.max.queue.size";
-	public static final String AUDIT_MAX_FLUSH_INTERVAL_PROP = "xasecure.audit.kafka.async.max.flush.interval.ms";
-	public static final String AUDIT_KAFKA_BROKER_LIST = "xasecure.audit.kafka.broker_list";
 	public static final String AUDIT_KAFKA_TOPIC_NAME = "xasecure.audit.kafka.topic_name";
+	public static final String KAFKA_PROP_PREFIX = "xasecure.audit.kafka";
 	boolean initDone = false;
 
 	Producer<String, String> producer = null;
@@ -47,7 +46,7 @@ public class KafkaAuditProvider extends AuditDestination {
 	@Override
 	public void init(Properties props) {
 		LOG.info("init() called");
-		super.init(props);
+		super.init(props, null);
 
 		topic = MiscUtil.getStringProperty(props,
 				AUDIT_KAFKA_TOPIC_NAME);
@@ -57,27 +56,15 @@ public class KafkaAuditProvider extends AuditDestination {
 
 		try {
 			if (!initDone) {
-				String brokerList = MiscUtil.getStringProperty(props,
-						AUDIT_KAFKA_BROKER_LIST);
-				if (brokerList == null || brokerList.isEmpty()) {
-					brokerList = "localhost:9092";
-				}
-
-				final Map<String, Object> kakfaProps = new HashMap<String,Object>();
-				kakfaProps.put("metadata.broker.list", brokerList);
-				kakfaProps.put("serializer.class",
-						"kafka.serializer.StringEncoder");
-				// kakfaProps.put("partitioner.class",
-				// "example.producer.SimplePartitioner");
-				kakfaProps.put("request.required.acks", "1");
+				final Map<String, Object> kafkaProps = buildKafkaProducerProperties(props);
 
 				LOG.info("Connecting to Kafka producer using properties:"
-						+ kakfaProps.toString());
+						+ kafkaProps.toString());
 
 				producer  = MiscUtil.executePrivilegedAction(new PrivilegedAction<Producer<String, String>>() {
 					@Override
 					public Producer<String, String> run(){
-						Producer<String, String> producer = new KafkaProducer<String, String>(kakfaProps);
+						Producer<String, String> producer = new KafkaProducer<String, String>(kafkaProps);
 						return producer;
 					};
 				});
@@ -87,6 +74,12 @@ public class KafkaAuditProvider extends AuditDestination {
 		} catch (Throwable t) {
 			LOG.error("Error initializing kafka:", t);
 		}
+	}
+
+	@Override
+	public void init(Properties props, String basePropertyName) {
+		LOG.info("init(props, basePropertyName) called");
+		init(props);
 	}
 
 	@Override
@@ -201,4 +194,21 @@ public class KafkaAuditProvider extends AuditDestination {
 		return true;
 	}
 
+	private Map<String, Object> buildKafkaProducerProperties(Properties props) {
+		Map<String, Object> kafkaProps = new HashMap<>();
+
+		// default properties for Kafka producer
+		kafkaProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+		kafkaProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer");
+		kafkaProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer");
+		kafkaProps.put(ProducerConfig.ACKS_CONFIG, "1");
+
+		// only add properties that start with "xasecure.audit.kafka" & properties that are in ProducerConfig
+		props.stringPropertyNames().stream()
+				.filter(name -> name.startsWith(KAFKA_PROP_PREFIX))
+				.filter(name -> ProducerConfig.configNames().contains(name.substring(KAFKA_PROP_PREFIX.length() + 1)))
+				.forEach(name -> kafkaProps.put(name.substring(KAFKA_PROP_PREFIX.length() + 1), props.getProperty(name)));
+
+		return kafkaProps;
+	}
 }

--- a/agents-audit/src/test/java/org/apache/ranger/audit/provider/kafka/KafkaAuditProviderTest.java
+++ b/agents-audit/src/test/java/org/apache/ranger/audit/provider/kafka/KafkaAuditProviderTest.java
@@ -1,0 +1,65 @@
+package org.apache.ranger.audit.provider.kafka;
+
+import org.apache.kafka.clients.producer.Producer;
+import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class KafkaAuditProviderTest {
+
+    @Mock
+    private Producer<String, String> mockProducer;
+
+    private KafkaAuditProvider kafkaAuditProvider;
+
+    @BeforeEach
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+        kafkaAuditProvider = new KafkaAuditProvider();
+        kafkaAuditProvider.producer = mockProducer;
+    }
+
+    @Test
+    public void testInit() {
+        Properties props = new Properties();
+        props.setProperty(KafkaAuditProvider.AUDIT_KAFKA_TOPIC_NAME, "test_topic");
+
+        kafkaAuditProvider.init(props, null);
+
+        assertNotNull(KafkaAuditProvider.producer, "Producer should be initialized");
+        assertEquals("test_topic", KafkaAuditProvider.topic, "Topic should be set correctly");
+    }
+
+    @Test
+    public void testBuildKafkaProducerProperties() throws Exception {
+        Properties props = new Properties();
+
+        props.setProperty("xasecure.audit.kafka.bootstrap.servers", "localhost:9092");
+        props.setProperty("xasecure.audit.kafka.acks", "all");
+        props.setProperty("xasecure.audit.kafka.key.serializer", "org.apache.kafka.common.serialization.StringSerializer");
+        props.setProperty("xasecure.audit.kafka.value.serializer", "org.apache.kafka.common.serialization.StringSerializer");
+        props.setProperty("xasecure.audit.kafka.compression.type", "gzip");
+        props.setProperty("xasecure.audit.kafka.invalid.config", "shouldBeIgnored");
+
+        Method method = KafkaAuditProvider.class.getDeclaredMethod("buildKafkaProducerProperties", Properties.class);
+        method.setAccessible(true);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> kafkaProps = (Map<String, Object>) method.invoke(kafkaAuditProvider, props);
+
+        assertEquals("localhost:9092", kafkaProps.get("bootstrap.servers"), "Bootstrap servers should be set correctly");
+        assertEquals("all", kafkaProps.get("acks"), "Acks should be set correctly");
+        assertEquals("org.apache.kafka.common.serialization.StringSerializer", kafkaProps.get("key.serializer"), "Key serializer should be set correctly");
+        assertEquals("org.apache.kafka.common.serialization.StringSerializer", kafkaProps.get("value.serializer"), "Value serializer should be set correctly");
+        assertEquals("gzip", kafkaProps.get("compression.type"), "Compression type should be set correctly");
+        assertFalse(kafkaProps.containsKey("invalid.config"), "Invalid config should not be set");
+    }
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?
- https://issues.apache.org/jira/browse/RANGER-4808



## How was this patch tested?
I wrote some test code to check it out, and built and tested it on my internal Hadoop cluster. In the internal cluster, we are producing Impala ranger audit logs to a Kafka cluster.

The Hadoop environment is as follows
- Hadoop: 3.3.4
- Ranger : 2.3.0
- Impala : 4.1.1