### PR TITLE
RANGER-4307 Allow the synchronization time interval of LDAP users to …

### DIFF
--- a/ugsync/src/main/java/org/apache/ranger/unixusersync/config/UserGroupSyncConfig.java
+++ b/ugsync/src/main/java/org/apache/ranger/unixusersync/config/UserGroupSyncConfig.java
@@ -529,7 +529,16 @@ public class UserGroupSyncConfig  {
 			long ret = Long.parseLong(val);
 			long min_interval;
 			if (LGSYNC_SOURCE_CLASS.equals(className)) {
-				min_interval = UGSYNC_SLEEP_TIME_IN_MILLIS_BETWEEN_CYCLE_LDAP_DEFAULT_VALUE;
+				try {
+					min_interval = Long.parseLong(val);
+				} catch (Exception e) {
+					LOG.warn("invalid config, param ranger.usersync.sleeptimeinmillisbetweensynccycle must be");
+					min_interval = UGSYNC_SLEEP_TIME_IN_MILLIS_BETWEEN_CYCLE_LDAP_DEFAULT_VALUE;
+				}
+				if (min_interval < UGSYNC_SLEEP_TIME_IN_MILLIS_BETWEEN_CYCLE_MIN_VALUE) {
+					LOG.warn("Sleep Time Between Cycle can not be lower than [" + UGSYNC_SLEEP_TIME_IN_MILLIS_BETWEEN_CYCLE_MIN_VALUE + "] millisec. resetting to min value.");
+				}
+				min_interval = Math.max(min_interval, UGSYNC_SLEEP_TIME_IN_MILLIS_BETWEEN_CYCLE_MIN_VALUE);
 			}else if(UGSYNC_SOURCE_CLASS.equals(className)){
 				min_interval = UGSYNC_SLEEP_TIME_IN_MILLIS_BETWEEN_CYCLE_UNIX_DEFAULT_VALUE;
 			} else {


### PR DESCRIPTION
I think it can be modified in the following way：reuse the config param "ranger.usersync.sleeptimeinmillisbetweensynccycle" in the config file，rather than just using him as a criterion.
