### PR TITLE
Update libthrift to 0.14.0

### DIFF
--- a/hive-agent/pom.xml
+++ b/hive-agent/pom.xml
@@ -156,11 +156,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.thrift</groupId>
-            <artifactId>libfb303</artifactId>
-            <version>${libfb303.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.thrift</groupId>
             <artifactId>libthrift</artifactId>
             <version>${libthrift.version}</version>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -132,8 +132,7 @@
         <hbase-shaded-protobuf>4.1.7</hbase-shaded-protobuf>
         <hbase-shaded-netty>4.1.7</hbase-shaded-netty>
         <hbase-shaded-miscellaneous>4.1.7</hbase-shaded-miscellaneous>
-        <libfb303.version>0.9.3</libfb303.version>
-        <libthrift.version>0.13.0</libthrift.version>
+        <libthrift.version>0.14.0</libthrift.version>
         <htrace-core.version>4.1.0-incubating</htrace-core.version>
         <httpcomponents.httpclient.version>4.5.13</httpcomponents.httpclient.version>
         <httpcomponents.httpcore.version>4.4.14</httpcomponents.httpcore.version>

--- a/ranger-hive-plugin-shim/pom.xml
+++ b/ranger-hive-plugin-shim/pom.xml
@@ -52,6 +52,10 @@
                     <groupId>org.apache.commons</groupId>
                     <artifactId>commons-compress</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.thrift</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -78,6 +82,10 @@
                 <exclusion>
                     <groupId>org.glassfish</groupId>
                     <artifactId>javax.el</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.thrift</groupId>
+                    <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -106,6 +114,10 @@
                     <groupId>org.apache.commons</groupId>
                     <artifactId>commons-compress</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.thrift</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -129,6 +141,10 @@
                     <groupId>org.apache.logging.log4j</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.thrift</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -139,6 +155,10 @@
                 <exclusion>
                     <groupId>org.glassfish</groupId>
                     <artifactId>javax.el</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.thrift</groupId>
+                    <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -151,6 +171,10 @@
                 <exclusion>
                     <groupId>org.glassfish</groupId>
                     <artifactId>javax.el</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.thrift</groupId>
+                    <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/security-admin/pom.xml
+++ b/security-admin/pom.xml
@@ -476,11 +476,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.thrift</groupId>
-            <artifactId>libfb303</artifactId>
-            <version>${libfb303.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.thrift</groupId>
             <artifactId>libthrift</artifactId>
             <version>${libthrift.version}</version>
             <exclusions>


### PR DESCRIPTION
Update libthrift to 0.14.0

This addresses https://github.com/advisories/GHSA-g2fg-mr77-6vrm
