### PR TITLE
Exclude all io.netty from hive-agent tests

### DIFF
--- a/hive-agent/pom.xml
+++ b/hive-agent/pom.xml
@@ -212,7 +212,7 @@
                 </exclusion>
                 <exclusion>
                     <groupId>io.netty</groupId>
-                    <artifactId>netty</artifactId>
+                    <artifactId>*</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>log4j</groupId>


### PR DESCRIPTION
Exclude all io.netty from hive-agent tests

Even if that dependency was in test scope, its transitive dependencies
were marked in compile scope. It used 4.1.77 version for io.netty which
is flagged for CVEs.
