### PR TITLE
RANGER-4887: Change default configuration values for column masking and row-level filtering on hive policy

### DIFF
--- a/agents-common/src/main/resources/service-defs/ranger-servicedef-hive.json
+++ b/agents-common/src/main/resources/service-defs/ranger-servicedef-hive.json
@@ -354,26 +354,23 @@
 			{
 				"name": "database",
 				"matcherOptions": {
-					"wildCard": "false"
+					"wildCard": "true"
 				},
-				"lookupSupported": true,
-				"uiHint":"{ \"singleValue\":true }"
+				"lookupSupported": true
 			},
 			{
 				"name": "table",
 				"matcherOptions": {
-					"wildCard": "false"
+					"wildCard": "true"
 				},
-				"lookupSupported": true,
-				"uiHint":"{ \"singleValue\":true }"
+				"lookupSupported": true
 			},
 			{
 				"name": "column",
 				"matcherOptions": {
-					"wildCard": "false"
+					"wildCard": "true"
 				},
-				"lookupSupported": true,
-				"uiHint":"{ \"singleValue\":true }"
+				"lookupSupported": true
 			}
 		],
 		"maskTypes": [
@@ -391,14 +388,14 @@
 				"name": "MASK_SHOW_LAST_4",
 				"label": "Partial mask: show last 4",
 				"description": "Show last 4 characters; replace rest with 'x'",
-				"transformer": "mask_show_last_n({col}, 4, 'x', 'x', 'x', -1, '1')"
+				"transformer": "mask_show_last_n({col}, 4, 'x', 'x', 'x', 'x', 1)"
 			},
 			{
 				"itemId": 3,
 				"name": "MASK_SHOW_FIRST_4",
 				"label": "Partial mask: show first 4",
 				"description": "Show first 4 characters; replace rest with 'x'",
-				"transformer": "mask_show_first_n({col}, 4, 'x', 'x', 'x', -1, '1')"
+				"transformer": "mask_show_first_n({col}, 4, 'x', 'x', 'x', 'x', 1)"
 			},
 			{
 				"itemId": 4,
@@ -444,20 +441,18 @@
 			{
 				"name": "database",
 				"matcherOptions": {
-					"wildCard": "false"
+					"wildCard": "true"
 				},
 				"lookupSupported": true,
-				"mandatory": true,
-				"uiHint": "{ \"singleValue\":true }"
+				"mandatory": true
 			},
 			{
 				"name": "table",
 				"matcherOptions": {
-					"wildCard": "false"
+					"wildCard": "true"
 				},
 				"lookupSupported": true,
-				"mandatory": true,
-				"uiHint": "{ \"singleValue\":true }"
+				"mandatory": true
 			}
 		]
 	}


### PR DESCRIPTION


## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix. Create an issue in ASF JIRA before opening a pull request and
set the title of the pull request which starts with
the corresponding JIRA issue number. (e.g. RANGER-XXXX: Fix a typo in YYY))

Please refer to https://issues.apache.org/jira/browse/RANGER-4887.


## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)
Manually tested on private hadoop cluster.