### PR TITLE
RANGER-4915:Fix the default SSL Ciphers are too weak issue for user sync service

### DIFF
--- a/unixauthservice/scripts/ranger-usersync-services.sh
+++ b/unixauthservice/scripts/ranger-usersync-services.sh
@@ -113,7 +113,7 @@ if [ "${action}" == "START" ]; then
         fi
     fi
 	SLEEP_TIME_AFTER_START=5
-	nohup java -Dproc_rangerusersync -Dlogback.configurationFile=file:${USERSYNC_CONF_DIR}/logback.xml ${JAVA_OPTS} -Duser=${USER} -Dhostname=${HOSTNAME} -Dlogdir="${logdir}" -cp "${cp}" org.apache.ranger.authentication.UnixAuthenticationService -enableUnixAuth > ${logdir}/auth.log 2>&1 &
+	nohup java -Dproc_rangerusersync -Djdk.tls.ephemeralDHKeySize=2048 -Dlogback.configurationFile=file:${USERSYNC_CONF_DIR}/logback.xml ${JAVA_OPTS} -Duser=${USER} -Dhostname=${HOSTNAME} -Dlogdir="${logdir}" -cp "${cp}" org.apache.ranger.authentication.UnixAuthenticationService -enableUnixAuth > ${logdir}/auth.log 2>&1 &
 	VALUE_OF_PID=$!
     echo "Starting Apache Ranger Usersync Service"
     sleep $SLEEP_TIME_AFTER_START


### PR DESCRIPTION
…ync service

## What changes were proposed in this pull request?

Fix the default SSL Ciphers are too weak issue for user sync service.


## How was this patch tested?

I think this is a common java configuration setting change, so do not need additional testing for this simple fix.
