### PR TITLE
RANGER-4919: Fix maven build - add jetbrains repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -803,15 +803,11 @@
                 <enabled>false</enabled>
             </snapshots>
         </repository>
-        <!--
-    <repository>
-      <id>repo</id>
-      <url>file://${basedir}/local-repo</url>
-      <snapshots>
-         <enabled>true</enabled>
-      </snapshots>
-  </repository>
-  -->
+    	<repository>
+            <id>jetbrains-pty4j</id>
+            <name>jetbrains-intellij-dependencies</name>
+            <url>https://packages.jetbrains.team/maven/p/ij/intellij-dependencies</url>
+        </repository>
     </repositories>
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
## What changes were proposed in this pull request?
After the `knox.gateway.version` version upgrade  from 1.4.0 to 2.0.0, we see that the below libraries are not getting downloaded from the maven/apache repos.

These libraries:
- org.jetbrains.pty4j:pty4j:jar:0.11.4
- org.jetbrains.pty4j:purejavacomm:jar:0.0.11.1

are pulled in via `knox-gateway-server` in the apache ranger build. 

Adding a new repository to fetch the jars from.

## How was this patch tested?
 CI build
