### PR TITLE
CI: Cache downloaded archives

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -78,14 +78,28 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: target-8
+      
       - name: Copy artifacts for docker build
         run: |
           cp ranger-*.tar.gz dev-support/ranger-docker/dist
           cp version dev-support/ranger-docker/dist
-      - name: Build all ranger-service images
+      
+      - name: Cache downloaded archives
+        uses: actions/cache@v3
+        with:
+          path: dev-support/ranger-docker/downloads
+          key: ${{ runner.os }}-ranger-downloads-${{ hashFiles('dev-support/ranger-docker/.env') }}
+          restore-keys: |
+            ${{ runner.os }}-ranger-downloads-
+
+      - name: Run download-archives.sh
         run: |
           cd dev-support/ranger-docker
           chmod +x download-archives.sh && ./download-archives.sh
+      
+      - name: Build all ranger-service images
+        run: |
+          cd dev-support/ranger-docker
           docker compose -f docker-compose.ranger-base.yml build
           export DOCKER_BUILDKIT=1
           export COMPOSE_DOCKER_CLI_BUILD=1


### PR DESCRIPTION
## What changes were proposed in this pull request?

Cache downloaded archives (as part of docker build) in CI runs.

Reduces CI - docker build time.


## How was this patch tested?

CI Run 1:
<img width="1297" alt="ci_run_1" src="https://github.com/user-attachments/assets/bda226d2-2593-46e6-8d23-25104ddae40a">
CI Run 2:
<img width="1307" alt="ci_run_2" src="https://github.com/user-attachments/assets/078ec476-5a78-42b5-a713-d8761526ac7a">

