### PR TITLE
RANGER-4914: Tagsync support for Ozone OFS paths

### DIFF
--- a/tagsync/src/test/java/org/apache/ranger/tagsync/process/TestOzoneResourceMapper.java
+++ b/tagsync/src/test/java/org/apache/ranger/tagsync/process/TestOzoneResourceMapper.java
@@ -23,9 +23,11 @@ import org.apache.ranger.plugin.model.RangerServiceResource;
 import org.apache.ranger.tagsync.source.atlas.AtlasOzoneResourceMapper;
 import org.apache.ranger.tagsync.source.atlasrest.RangerAtlasEntity;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.Collections;
+import java.util.Properties;
 
 import static org.apache.ranger.tagsync.source.atlas.AtlasOzoneResourceMapper.*;
 import static org.apache.ranger.tagsync.source.atlas.AtlasResourceMapper.ENTITY_ATTRIBUTE_QUALIFIED_NAME;
@@ -37,13 +39,24 @@ public class TestOzoneResourceMapper {
     private static final String KEY_QUALIFIED_NAME          = "o3fs://mybucket.myvolume.ozone1/mykey.txt@cl1" ;
     private static final String KEY_PATH_QUALIFIED_NAME     = "o3fs://mybucket.myvolume.ozone1/mykey/key1/@cl1";
 
+    private static final String VOLUME_QUALIFIED_NAME_OFS   = "ofs://myvolume@cl1";
+    private static final String BUCKET_QUALIFIED_NAME_OFS   = "ofs://myvolume.mybucket@cl1";
+    private static final String KEY_QUALIFIED_NAME_OFS      = "ofs://ozone1/myvolume/mybucket/mykey.txt@cl1";
+    private static final String KEY_PATH_QUALIFIED_NAME_OFS = "ofs://ozone1/myvolume/mybucket/mykey/key1/@cl1";
+
     private static final String SERVICE_NAME                = "cl1_ozone";
     private static final String VOLUME_NAME                 = "myvolume";
     private static final String BUCKET_NAME                 = "mybucket";
     private static final String KEY_NAME                    = "mykey.txt";
     private static final String KEY_PATH                    = "mykey/key1/";
 
-    AtlasOzoneResourceMapper resourceMapper = new AtlasOzoneResourceMapper();
+
+    static AtlasOzoneResourceMapper resourceMapper = new AtlasOzoneResourceMapper();
+
+    @BeforeClass
+    public static void init(){
+        resourceMapper.initialize(new Properties());
+    }
 
     @Test
     public void testVolumeEntity() throws Exception {
@@ -54,7 +67,15 @@ public class TestOzoneResourceMapper {
         assertResourceElementCount(resource, 1);
         assertResourceElementValue(resource, RANGER_TYPE_OZONE_VOLUME, VOLUME_NAME);
     }
+    @Test
+    public void testVolumeEntityOFS() throws Exception {
+        RangerAtlasEntity     entity   = getEntity(ENTITY_TYPE_OZONE_VOLUME, VOLUME_QUALIFIED_NAME_OFS);
+        RangerServiceResource resource = resourceMapper.buildResource(entity);
 
+        Assert.assertEquals(SERVICE_NAME, resource.getServiceName());
+        assertResourceElementCount(resource, 1);
+        assertResourceElementValue(resource, RANGER_TYPE_OZONE_VOLUME, VOLUME_NAME);
+    }
     @Test
     public void testBucketEntity() throws Exception {
         RangerAtlasEntity     entity   = getEntity(ENTITY_TYPE_OZONE_BUCKET, BUCKET_QUALIFIED_NAME);
@@ -65,7 +86,16 @@ public class TestOzoneResourceMapper {
         assertResourceElementValue(resource, RANGER_TYPE_OZONE_VOLUME, VOLUME_NAME);
         assertResourceElementValue(resource, RANGER_TYPE_OZONE_BUCKET, BUCKET_NAME);
     }
+    @Test
+    public void testBucketEntityOFS() throws Exception {
+        RangerAtlasEntity     entity   = getEntity(ENTITY_TYPE_OZONE_BUCKET, BUCKET_QUALIFIED_NAME_OFS);
+        RangerServiceResource resource = resourceMapper.buildResource(entity);
 
+        Assert.assertEquals(SERVICE_NAME, resource.getServiceName());
+        assertResourceElementCount(resource, 2);
+        assertResourceElementValue(resource, RANGER_TYPE_OZONE_VOLUME, VOLUME_NAME);
+        assertResourceElementValue(resource, RANGER_TYPE_OZONE_BUCKET, BUCKET_NAME);
+    }
     @Test
     public void testKeyEntity() throws Exception {
         RangerAtlasEntity     entity   = getEntity(ENTITY_TYPE_OZONE_KEY, KEY_QUALIFIED_NAME);
@@ -77,7 +107,17 @@ public class TestOzoneResourceMapper {
         assertResourceElementValue(resource, RANGER_TYPE_OZONE_BUCKET, BUCKET_NAME);
         assertResourceElementValue(resource, RANGER_TYPE_OZONE_KEY, KEY_NAME);
     }
+    @Test
+    public void testKeyEntityOFS() throws Exception {
+        RangerAtlasEntity     entity   = getEntity(ENTITY_TYPE_OZONE_KEY, KEY_QUALIFIED_NAME_OFS);
+        RangerServiceResource resource = resourceMapper.buildResource(entity);
 
+        Assert.assertEquals(SERVICE_NAME, resource.getServiceName());
+        assertResourceElementCount(resource, 3);
+        assertResourceElementValue(resource, RANGER_TYPE_OZONE_VOLUME, VOLUME_NAME);
+        assertResourceElementValue(resource, RANGER_TYPE_OZONE_BUCKET, BUCKET_NAME);
+        assertResourceElementValue(resource, RANGER_TYPE_OZONE_KEY, KEY_NAME);
+    }
     @Test
     public void testKey2Entity() throws Exception {
         RangerAtlasEntity     entity   = getEntity(ENTITY_TYPE_OZONE_KEY, KEY_PATH_QUALIFIED_NAME);
@@ -89,7 +129,101 @@ public class TestOzoneResourceMapper {
         assertResourceElementValue(resource, RANGER_TYPE_OZONE_BUCKET, BUCKET_NAME);
         assertResourceElementValue(resource, RANGER_TYPE_OZONE_KEY, KEY_PATH);
     }
-
+    @Test
+    public void testKey2EntityOFS() throws Exception {
+        RangerAtlasEntity     entity   = getEntity(ENTITY_TYPE_OZONE_KEY, KEY_PATH_QUALIFIED_NAME_OFS);
+        RangerServiceResource resource = resourceMapper.buildResource(entity);
+        Assert.assertEquals(SERVICE_NAME, resource.getServiceName());
+        assertResourceElementCount(resource, 3);
+        assertResourceElementValue(resource, RANGER_TYPE_OZONE_VOLUME, VOLUME_NAME);
+        assertResourceElementValue(resource, RANGER_TYPE_OZONE_BUCKET, BUCKET_NAME);
+        assertResourceElementValue(resource, RANGER_TYPE_OZONE_KEY, KEY_PATH);
+    }
+    @Test
+    public void testKeyEntityOFSLegacyDotDelimiter() throws Exception {
+        AtlasOzoneResourceMapper legacyResourceMapper = new AtlasOzoneResourceMapper();
+        Properties legacyProperties = new Properties();
+        legacyProperties.setProperty(PROP_LEGACY_PARSING, "true");
+        legacyResourceMapper.initialize(legacyProperties);
+        String qualifiedName = "ofs://mybucket.myvolume.ozone1/mykey.txt@cl1";
+        RangerAtlasEntity     entity   = getEntity(ENTITY_TYPE_OZONE_KEY, qualifiedName);
+        RangerServiceResource resource = legacyResourceMapper.buildResource(entity);
+        Assert.assertEquals(SERVICE_NAME, resource.getServiceName());
+        assertResourceElementCount(resource, 3);
+        assertResourceElementValue(resource, RANGER_TYPE_OZONE_VOLUME, VOLUME_NAME);
+        assertResourceElementValue(resource, RANGER_TYPE_OZONE_BUCKET, BUCKET_NAME);
+        assertResourceElementValue(resource, RANGER_TYPE_OZONE_KEY, KEY_NAME);
+    }
+    @Test
+    public void testInvalidKeyEntityOFSLegacyDotDelimiter() throws Exception {
+        AtlasOzoneResourceMapper legacyResourceMapper = new AtlasOzoneResourceMapper();
+        Properties legacyProperties = new Properties();
+        legacyProperties.setProperty(PROP_LEGACY_PARSING, "true");
+        legacyResourceMapper.initialize(legacyProperties);
+        RangerAtlasEntity     entity   = getEntity(ENTITY_TYPE_OZONE_KEY, KEY_PATH_QUALIFIED_NAME_OFS);
+        try {
+            RangerServiceResource resource = legacyResourceMapper.buildResource(entity);
+            Assert.assertFalse("Expected buildResource() to fail. But it returned " + resource+". "
+                + "'/' not supported as delimiter when legacy flag is enabled", true);
+        } catch (Exception excp) {
+            System.out.println("Exception was as expected: "+ KEY_PATH_QUALIFIED_NAME_OFS+
+                " cannot be parsed when property"+ PROP_LEGACY_PARSING +" is true");
+        }
+    }
+    @Test
+    public void testVolumeEntityWithDotOFS() throws Exception {
+        String qualifiedName = "ofs://myvolume.volpostfix@cl1";
+        String expectedVolumeName = "myvolume.volpostfix";
+        RangerAtlasEntity     entity   = getEntity(ENTITY_TYPE_OZONE_VOLUME, qualifiedName);
+        RangerServiceResource resource = resourceMapper.buildResource(entity);
+        Assert.assertEquals(SERVICE_NAME, resource.getServiceName());
+        assertResourceElementCount(resource, 1);
+        assertResourceElementValue(resource, RANGER_TYPE_OZONE_VOLUME, expectedVolumeName);
+    }
+    @Test
+    public void testBucketEntityWithDotOFS() throws Exception {
+        String qualifiedName = "ofs://myvolume.bucketprefix.mybucket.bucketpostfix@cl1";
+        String expectedVolumeName = "myvolume";
+        String expectedBucketName = "bucketprefix.mybucket.bucketpostfix";
+        RangerAtlasEntity     entity   = getEntity(ENTITY_TYPE_OZONE_BUCKET, qualifiedName);
+        RangerServiceResource resource = resourceMapper.buildResource(entity);
+        Assert.assertEquals(SERVICE_NAME, resource.getServiceName());
+        assertResourceElementCount(resource, 2);
+        assertResourceElementValue(resource, RANGER_TYPE_OZONE_VOLUME, expectedVolumeName);
+        assertResourceElementValue(resource, RANGER_TYPE_OZONE_BUCKET, expectedBucketName);
+    }
+    @Test
+    public void testKeyEntityWithDotOFS() throws Exception {
+        String qualifiedName = "ofs://ozone1/myvolume.volumepostfix/mybucket.bucketpostfix/keypath/keyprefix.mykey.txt@cl1";
+        String expectedVolumeName = "myvolume.volumepostfix";
+        String expectedBucketName = "mybucket.bucketpostfix";
+        String expectedKeyName = "keypath/keyprefix.mykey.txt";
+        RangerAtlasEntity     entity   = getEntity(ENTITY_TYPE_OZONE_KEY, qualifiedName);
+        RangerServiceResource resource = resourceMapper.buildResource(entity);
+        Assert.assertEquals(SERVICE_NAME, resource.getServiceName());
+        assertResourceElementCount(resource, 3);
+        assertResourceElementValue(resource, RANGER_TYPE_OZONE_VOLUME, expectedVolumeName);
+        assertResourceElementValue(resource, RANGER_TYPE_OZONE_BUCKET, expectedBucketName);
+        assertResourceElementValue(resource, RANGER_TYPE_OZONE_KEY, expectedKeyName);
+    }
+    @Test
+    public void testBucketEntityWithSlashOFS() throws Exception {
+        //future work : scenario when atlas fixes the bucket delimiter from "." to "/";
+        AtlasOzoneResourceMapper afterDelimiterFixResourceMapper = new AtlasOzoneResourceMapper();
+        Properties properties = new Properties();
+        properties.setProperty(PROP_OFS_BUCKET_DELIMITER, "/");
+        afterDelimiterFixResourceMapper.initialize(properties);
+        //both volume and bucket name could have a "." in it after this fix
+        String qualifiedName = "ofs://myvolume.volumepostfix/mybucket.bucketpostfix@cl1";
+        String expectedVolumeName = "myvolume.volumepostfix";
+        String expectedBucketName = "mybucket.bucketpostfix";
+        RangerAtlasEntity     entity   = getEntity(ENTITY_TYPE_OZONE_BUCKET, qualifiedName);
+        RangerServiceResource resource = afterDelimiterFixResourceMapper.buildResource(entity);
+        Assert.assertEquals(SERVICE_NAME, resource.getServiceName());
+        assertResourceElementCount(resource, 2);
+        assertResourceElementValue(resource, RANGER_TYPE_OZONE_VOLUME, expectedVolumeName);
+        assertResourceElementValue(resource, RANGER_TYPE_OZONE_BUCKET, expectedBucketName);
+    }
     @Test
     public void testInvalidEntityType() {
         assertException(getEntity("Unknown", KEY_PATH_QUALIFIED_NAME), "unrecognized entity-type");


### PR DESCRIPTION
## What changes were proposed in this pull request?

OFS support in tagsync allowing OFS entities to be tagged in Atlas.
Currently only o3fs entities are supported.
Various configurations such as reverting to old behavior or configuring a custom delimiter for key or bucket have been added for future fixes when done by atlas.

Limitations of the patch: 
No "." in volume name (this is because of how atlas is creating qualifiedName for ofs bucket entites)



## How was this patch tested?

Unit tests have been added for the addressed scenarios. Manual testing in cluster was also done.
