### PR TITLE
RANGER-4931:Handling Unknown column 'rangerusersyncID' in 'field list'

### DIFF
--- a/security-admin/db/mysql/patches/070-add-gds-perm.sql
+++ b/security-admin/db/mysql/patches/070-add-gds-perm.sql
@@ -41,6 +41,8 @@ CREATE PROCEDURE `insertRangerPrerequisiteGDSEntries`()
 BEGIN
 DECLARE adminID bigint;
 DECLARE moduleIdGovernedDataSharing bigint;
+DECLARE rangerusersyncID bigint;
+DECLARE rangertagsyncID bigint;
 
 call getXportalUIdByLoginId('admin', adminID);
 call getXportalUIdByLoginId('rangerusersync', rangerusersyncID);


### PR DESCRIPTION
## What changes were proposed in this pull request?
Proposed cahnges are mentioned at [RANGER-4931](https://issues.apache.org/jira/browse/RANGER-4931)


## How was this patch tested?
tested this patch on my local cluster during the migration of ranger from 2.3.0 to 2.5.0, and with proposed changes, able to fix this issue.
