### PR TITLE
RANGER-4932:Handling Specified key was too long; max key length error

### DIFF
--- a/security-admin/db/mysql/patches/073-create-x_trx_log_v2.sql
+++ b/security-admin/db/mysql/patches/073-create-x_trx_log_v2.sql
@@ -35,4 +35,4 @@ CREATE TABLE `x_trx_log_v2` (
   KEY `x_trx_log_v2_FK_added_by_id` (`added_by_id`),
   KEY `x_trx_log_v2_cr_time` (`create_time`),
   KEY `x_trx_log_v2_trx_id` (`trx_id`)
-)ROW_FORMAT=DYNAMIC;
+) DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Proposed changes are mentioned at [RANGER-4932](https://issues.apache.org/jira/browse/RANGER-4932)


## How was this patch tested?

tested this patch on my local cluster during the migration of ranger from 2.3.0 to 2.5.0, and with proposed changes, able to fix this issue.
