### PR TITLE
RANGER-4607: Ranger REST API improvements

### DIFF
--- a/security-admin/src/main/java/org/apache/ranger/biz/ServiceDBStore.java
+++ b/security-admin/src/main/java/org/apache/ranger/biz/ServiceDBStore.java
@@ -5067,62 +5067,62 @@ public class ServiceDBStore extends AbstractServiceStore {
 
 		// fetch policies maintained for the roles and groups belonging to the group
 		String groupName = searchFilter.getParam("group");
-		if (!StringUtils.isEmpty(groupName)) {
-			Set<String> groupNames = daoMgr.getXXGroupGroup().findGroupNamesByGroupName(groupName);
-			groupNames.add(RangerConstants.GROUP_PUBLIC);
-			groupNames.add(groupName);
-			Set<Long> processedSvcIdsForGroup = new HashSet<>();
-			Set<String> processedGroupsName = new HashSet<>();
-			List<XXPolicy> xPolList2;
-			for (String grpName : groupNames) {
-				searchFilter.setParam("group", grpName);
-				xPolList2 = policyService.searchResources(searchFilter, policyService.searchFields, policyService.sortFields, retList);
-				if (!CollectionUtils.isEmpty(xPolList2)) {
-					for (XXPolicy xPol2 : xPolList2) {
-						if(xPol2!=null){
-							if (!processedPolicies.contains(xPol2.getId())) {
-								if (!processedSvcIdsForGroup.contains(xPol2.getService())
-										|| !processedGroupsName.contains(groupName)) {
-									loadRangerPolicies(xPol2.getService(), processedSvcIdsForGroup, policyMap, searchFilter);
-									processedGroupsName.add(groupName);
-								}
-								if (policyMap.containsKey(xPol2.getId())) {
-									policyList.add(policyMap.get(xPol2.getId()));
-									processedPolicies.add(xPol2.getId());
-								}
+		if (StringUtils.isBlank(groupName)) {
+			groupName = RangerConstants.GROUP_PUBLIC;
+		}
+		Set<String> groupNames = daoMgr.getXXGroupGroup().findGroupNamesByGroupName(groupName);
+		groupNames.add(groupName);
+		Set<Long> processedSvcIdsForGroup = new HashSet<>();
+		Set<String> processedGroupsName = new HashSet<>();
+		List<XXPolicy> xPolList2;
+		for (String grpName : groupNames) {
+			searchFilter.setParam("group", grpName);
+			xPolList2 = policyService.searchResources(searchFilter, policyService.searchFields, policyService.sortFields, retList);
+			if (!CollectionUtils.isEmpty(xPolList2)) {
+				for (XXPolicy xPol2 : xPolList2) {
+					if(xPol2!=null){
+						if (!processedPolicies.contains(xPol2.getId())) {
+							if (!processedSvcIdsForGroup.contains(xPol2.getService())
+									|| !processedGroupsName.contains(groupName)) {
+								loadRangerPolicies(xPol2.getService(), processedSvcIdsForGroup, policyMap, searchFilter);
+								processedGroupsName.add(groupName);
+							}
+							if (policyMap.containsKey(xPol2.getId())) {
+								policyList.add(policyMap.get(xPol2.getId()));
+								processedPolicies.add(xPol2.getId());
 							}
 						}
 					}
 				}
 			}
+		}
 
-			searchFilter.removeParam("group");
-			XXGroup xxGroup = daoMgr.getXXGroup().findByGroupName(groupName);
-			if (xxGroup != null) {
-				Set<Long> allContainedRoles = new HashSet<>();
-				List<XXRole> xxRoles = daoMgr.getXXRole().findByGroupId(xxGroup.getId());
-				for (XXRole xxRole : xxRoles) {
-					getContainingRoles(xxRole.getId(), allContainedRoles);
-				}
-				Set<String> roleNames = getRoleNames(allContainedRoles);
-				Set<String> processedRoleName = new HashSet<>();
-				List<XXPolicy> xPolList3;
-				for (String roleName : roleNames) {
-					searchFilter.setParam("role", roleName);
-					xPolList3 = policyService.searchResources(searchFilter, policyService.searchFields, policyService.sortFields, retList);
-					if (!CollectionUtils.isEmpty(xPolList3)) {
-						for (XXPolicy xPol3 : xPolList3) {
-							if (xPol3 != null) {
-								if (!processedPolicies.contains(xPol3.getId())) {
-									if (!processedSvcIdsForRole.contains(xPol3.getService())
-											|| !processedRoleName.contains(roleName)) {
-										loadRangerPolicies(xPol3.getService(), processedSvcIdsForRole, policyMap, searchFilter);
-										processedRoleName.add(roleName);
-									}
-									if (policyMap.containsKey(xPol3.getId())) {
-										policyList.add(policyMap.get(xPol3.getId()));
-										processedPolicies.add(xPol3.getId());
-									}
+		searchFilter.removeParam("group");
+		XXGroup xxGroup = daoMgr.getXXGroup().findByGroupName(groupName);
+		if (xxGroup != null) {
+			Set<Long> allContainedRoles = new HashSet<>();
+			List<XXRole> xxRoles = daoMgr.getXXRole().findByGroupId(xxGroup.getId());
+			for (XXRole xxRole : xxRoles) {
+				getContainingRoles(xxRole.getId(), allContainedRoles);
+			}
+			Set<String> roleNames = getRoleNames(allContainedRoles);
+			Set<String> processedRoleName = new HashSet<>();
+			List<XXPolicy> xPolList3;
+			for (String roleName : roleNames) {
+				searchFilter.setParam("role", roleName);
+				xPolList3 = policyService.searchResources(searchFilter, policyService.searchFields, policyService.sortFields, retList);
+				if (!CollectionUtils.isEmpty(xPolList3)) {
+					for (XXPolicy xPol3 : xPolList3) {
+						if (xPol3 != null) {
+							if (!processedPolicies.contains(xPol3.getId())) {
+								if (!processedSvcIdsForRole.contains(xPol3.getService())
+										|| !processedRoleName.contains(roleName)) {
+									loadRangerPolicies(xPol3.getService(), processedSvcIdsForRole, policyMap, searchFilter);
+									processedRoleName.add(roleName);
+								}
+								if (policyMap.containsKey(xPol3.getId())) {
+									policyList.add(policyMap.get(xPol3.getId()));
+									processedPolicies.add(xPol3.getId());
 								}
 							}
 						}

--- a/security-admin/src/main/java/org/apache/ranger/biz/XAuditMgr.java
+++ b/security-admin/src/main/java/org/apache/ranger/biz/XAuditMgr.java
@@ -52,35 +52,35 @@ public class XAuditMgr extends XAuditMgrBase {
 	RangerBizUtil rangerBizUtil;
 
 	public VXTrxLog getXTrxLog(Long id) {
-		checkAdminAccess();
+		checkAllAdminsAccess();
 		return super.getXTrxLog(id);
 	}
 
 	public VXTrxLog createXTrxLog(VXTrxLog vXTrxLog) {
 		checkAdminAccess();
-                rangerBizUtil.blockAuditorRoleUser();
+		rangerBizUtil.blockAuditorRoleUser();
 		return super.createXTrxLog(vXTrxLog);
 	}
 
 	public VXTrxLog updateXTrxLog(VXTrxLog vXTrxLog) {
 		checkAdminAccess();
-                rangerBizUtil.blockAuditorRoleUser();
+		rangerBizUtil.blockAuditorRoleUser();
 		return super.updateXTrxLog(vXTrxLog);
 	}
 
 	public void deleteXTrxLog(Long id, boolean force) {
 		checkAdminAccess();
-                rangerBizUtil.blockAuditorRoleUser();
+		rangerBizUtil.blockAuditorRoleUser();
 		super.deleteXTrxLog(id, force);
 	}
 
 	public VXTrxLogList searchXTrxLogs(SearchCriteria searchCriteria) {
-		checkAdminAccess();
+		checkAllAdminsAccess();
 		return super.searchXTrxLogs(searchCriteria);
 	}
 
 	public VXLong getXTrxLogSearchCount(SearchCriteria searchCriteria) {
-		checkAdminAccess();
+		checkAllAdminsAccess();
 		return super.getXTrxLogSearchCount(searchCriteria);
 	}
 
@@ -141,6 +141,14 @@ public class XAuditMgr extends XAuditMgrBase {
 			return cloudWatchAccessAuditsService.getXAccessAuditSearchCount(searchCriteria);
 		} else {
 			return super.getXAccessAuditSearchCount(searchCriteria);
+		}
+	}
+
+	private boolean checkAllAdminsAccess(){
+		if (rangerBizUtil.isAdmin() || rangerBizUtil.isKeyAdmin() || rangerBizUtil.isAuditAdmin() || rangerBizUtil.isAuditKeyAdmin()){
+			return true;
+		} else {
+			throw restErrorUtil.createRESTException(HttpServletResponse.SC_FORBIDDEN, "User doesn't have permissions to perform this action", true);
 		}
 	}
 

--- a/security-admin/src/main/java/org/apache/ranger/biz/XAuditMgrBase.java
+++ b/security-admin/src/main/java/org/apache/ranger/biz/XAuditMgrBase.java
@@ -19,12 +19,15 @@
 
  package org.apache.ranger.biz;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.apache.ranger.common.MessageEnums;
 import org.apache.ranger.common.RESTErrorUtil;
 import org.apache.ranger.common.SearchCriteria;
 import org.apache.ranger.plugin.store.PList;
-import org.apache.ranger.service.XAccessAuditService;
 import org.apache.ranger.service.RangerTrxLogV2Service;
+import org.apache.ranger.service.XAccessAuditService;
 import org.apache.ranger.view.VXAccessAudit;
 import org.apache.ranger.view.VXAccessAuditList;
 import org.apache.ranger.view.VXLong;
@@ -32,9 +35,6 @@ import org.apache.ranger.view.VXTrxLog;
 import org.apache.ranger.view.VXTrxLogList;
 import org.apache.ranger.view.VXTrxLogV2;
 import org.springframework.beans.factory.annotation.Autowired;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 public class XAuditMgrBase {
 

--- a/security-admin/src/main/java/org/apache/ranger/biz/XUserMgr.java
+++ b/security-admin/src/main/java/org/apache/ranger/biz/XUserMgr.java
@@ -58,7 +58,6 @@ import org.apache.ranger.db.RangerDaoManager;
 import org.apache.ranger.db.XXAuditMapDao;
 import org.apache.ranger.db.XXAuthSessionDao;
 import org.apache.ranger.db.XXGroupDao;
-import org.apache.ranger.db.XXGroupGroupDao;
 import org.apache.ranger.db.XXGroupPermissionDao;
 import org.apache.ranger.db.XXGroupUserDao;
 import org.apache.ranger.db.XXPermMapDao;
@@ -70,7 +69,6 @@ import org.apache.ranger.db.XXUserDao;
 import org.apache.ranger.db.XXUserPermissionDao;
 import org.apache.ranger.entity.XXAuditMap;
 import org.apache.ranger.entity.XXGroup;
-import org.apache.ranger.entity.XXGroupGroup;
 import org.apache.ranger.entity.XXGroupUser;
 import org.apache.ranger.entity.XXPermMap;
 import org.apache.ranger.entity.XXPolicy;
@@ -162,9 +160,15 @@ public class XUserMgr extends XUserMgrBase {
 	static final Logger logger = LoggerFactory.getLogger(XUserMgr.class);
 	static final Set<String> roleAssignmentUpdatedUsers = new HashSet<>();
 
+	static final String MSG_DATA_ACCESS_DENY = "Logged-In user is not allowed to access requested user data";
+
 	public VXUser getXUserByUserName(String userName) {
 		VXUser vXUser=null;
 		vXUser=xUserService.getXUserByUserName(userName);
+		if(vXUser != null && !hasAccessToGetUserInfo(vXUser)) {
+			logger.info(MSG_DATA_ACCESS_DENY);
+			throw restErrorUtil.createRESTException(HttpServletResponse.SC_FORBIDDEN, MSG_DATA_ACCESS_DENY, true);
+		}
 		if(vXUser!=null && !hasAccessToModule(RangerConstants.MODULE_USER_GROUPS)){
 			vXUser=getMaskedVXUser(vXUser);
 		}
@@ -381,7 +385,7 @@ public class XUserMgr extends XUserMgrBase {
 			throw restErrorUtil.createRESTException("Please provide a valid first name.", MessageEnums.INVALID_INPUT_DATA);
 		}
 
-		checkAccess(vXUser.getName());
+		checkAccess(vXUser);
 		xaBizUtil.blockAuditorRoleUser();
 		VXPortalUser oldUserProfile = userMgr.getUserProfileByLoginId(vXUser
 				.getName());
@@ -792,11 +796,9 @@ public class XUserMgr extends XUserMgrBase {
 	public VXUser getXUser(Long id) {
 		VXUser vXUser=null;
 		vXUser=xUserService.readResourceWithOutLogin(id);
-		if(vXUser != null){
-			if(!hasAccessToGetUserInfo(vXUser)){
-				logger.info("Logged-In user is not allowed to access requested user data.");
-				throw restErrorUtil.create403RESTException("Logged-In user is not allowed to access requested user data.");
-			}
+		if(vXUser != null && !hasAccessToGetUserInfo(vXUser)){
+			logger.info(MSG_DATA_ACCESS_DENY);
+			throw restErrorUtil.createRESTException(HttpServletResponse.SC_FORBIDDEN, MSG_DATA_ACCESS_DENY, true);
 		}
 
 		if(vXUser!=null && !hasAccessToModule(RangerConstants.MODULE_USER_GROUPS)){
@@ -808,17 +810,20 @@ public class XUserMgr extends XUserMgrBase {
 	private boolean hasAccessToGetUserInfo(VXUser requestedVXUser) {
 		UserSessionBase userSession = ContextUtil.getCurrentUserSession();
 		if (userSession != null && userSession.getLoginId() != null) {
-			VXUser loggedInVXUser = xUserService.getXUserByUserName(userSession
-					.getLoginId());
-			if (loggedInVXUser != null) {
-				if (loggedInVXUser.getUserRoleList().size() == 1
-						&& loggedInVXUser.getUserRoleList().contains(
-						RangerConstants.ROLE_USER)) {
-
+			VXUser loggedInVXUser = xUserService.getXUserByUserName(userSession.getLoginId());
+			if (requestedVXUser != null && CollectionUtils.isNotEmpty(requestedVXUser.getUserRoleList()) && loggedInVXUser != null && loggedInVXUser.getUserRoleList().size() == 1) {
+				if (loggedInVXUser.getUserRoleList().contains(RangerConstants.ROLE_USER)) {
 					return requestedVXUser.getId().equals(loggedInVXUser.getId()) ? true : false;
-
-				}else{
-					return true;
+				} else if (loggedInVXUser.getUserRoleList().contains(RangerConstants.ROLE_KEY_ADMIN) || loggedInVXUser.getUserRoleList().contains(RangerConstants.ROLE_KEY_ADMIN_AUDITOR)) {
+					if (requestedVXUser.getUserRoleList().contains(RangerConstants.ROLE_KEY_ADMIN) || requestedVXUser.getUserRoleList().contains(RangerConstants.ROLE_KEY_ADMIN_AUDITOR) || requestedVXUser.getUserRoleList().contains(RangerConstants.ROLE_USER)) {
+						return true;
+					}
+				} else if (loggedInVXUser.getUserRoleList().contains(RangerConstants.ROLE_SYS_ADMIN) || loggedInVXUser.getUserRoleList().contains(RangerConstants.ROLE_ADMIN_AUDITOR)) {
+					if (loggedInVXUser.getUserRoleList().contains(RangerConstants.ROLE_SYS_ADMIN) && "rangerusersync".equalsIgnoreCase(userSession.getLoginId())) {
+						return true;
+					} else if (requestedVXUser.getUserRoleList().contains(RangerConstants.ROLE_SYS_ADMIN) || requestedVXUser.getUserRoleList().contains(RangerConstants.ROLE_ADMIN_AUDITOR) || requestedVXUser.getUserRoleList().contains(RangerConstants.ROLE_USER)) {
+						return true;
+					}
 				}
 			}
 		}
@@ -846,7 +851,7 @@ public class XUserMgr extends XUserMgrBase {
 							.findGroupIdListByUserId(loggedInVXUser.getId());
 
 					if (!listGroupId.contains(id)) {
-						logger.info("Logged-In user is not allowed to access requested user data.");
+						logger.info(MSG_DATA_ACCESS_DENY);
 						throw restErrorUtil
 								.create403RESTException("Logged-In user is not allowed to access requested group data.");
 					}
@@ -1035,24 +1040,6 @@ public class XUserMgr extends XUserMgrBase {
 		checkAdminAccess();
 		xaBizUtil.blockAuditorRoleUser();
 		super.deleteXGroupUser(id, force);
-	}
-
-	public VXGroupGroup createXGroupGroup(VXGroupGroup vXGroupGroup){
-		checkAdminAccess();
-		xaBizUtil.blockAuditorRoleUser();
-		return super.createXGroupGroup(vXGroupGroup);
-	}
-
-	public VXGroupGroup updateXGroupGroup(VXGroupGroup vXGroupGroup) {
-		checkAdminAccess();
-		xaBizUtil.blockAuditorRoleUser();
-		return super.updateXGroupGroup(vXGroupGroup);
-	}
-
-	public void deleteXGroupGroup(Long id, boolean force) {
-		checkAdminAccess();
-		xaBizUtil.blockAuditorRoleUser();
-		super.deleteXGroupGroup(id, force);
 	}
 
 	public void deleteXPermMap(Long id, boolean force) {
@@ -1374,12 +1361,11 @@ public class XUserMgr extends XUserMgrBase {
 		}
 	}
 
-	public void checkAccess(String loginID) {
+	public void checkAccess(VXUser vxUser) {
 		UserSessionBase session = ContextUtil.getCurrentUserSession();
 		if (session != null) {
-			if (!session.isUserAdmin() && !session.isKeyAdmin() && !session.getLoginId().equalsIgnoreCase(loginID)) {
-				throw restErrorUtil.create403RESTException("Operation" + " denied. LoggedInUser=" + (session != null ? session.getXXPortalUser().getId() : "Not Logged In")
-						+ " ,isn't permitted to perform the action.");
+			if (!hasAccessToGetUserInfo(vxUser)) {
+				throw restErrorUtil.create403RESTException("Operation" + " denied. LoggedInUser=" + (session != null ? session.getXXPortalUser().getId() : "Not Logged In") + " ,isn't permitted to perform the action.");
 			}
 		} else {
 			VXResponse vXResponse = new VXResponse();
@@ -1482,37 +1468,14 @@ public class XUserMgr extends XUserMgrBase {
 		UserSessionBase session = ContextUtil.getCurrentUserSession();
 		if (session != null && stringRolesList != null) {
 			if (!session.isUserAdmin() && !session.isKeyAdmin()) {
-				throw restErrorUtil.create403RESTException("Permission"
-						+ " denied. LoggedInUser="
-						+ (session != null ? session.getXXPortalUser().getId()
-						: "Not Logged In")
-						+ " ,isn't permitted to perform the action.");
+				throw restErrorUtil.create403RESTException("Permission denied. LoggedInUser=" + (session != null ? session.getXXPortalUser().getId() : "Not Logged In") + " ,isn't permitted to perform the action.");
 			} else {
-				if (!"rangerusersync".equals(session.getXXPortalUser()
-						.getLoginId())) {// new logic for rangerusersync user
-					if (session.isUserAdmin()
-							&& stringRolesList
-							.contains(RangerConstants.ROLE_KEY_ADMIN)) {
-						throw restErrorUtil.create403RESTException("Permission"
-								+ " denied. LoggedInUser="
-								+ (session != null ? session.getXXPortalUser()
-								.getId() : "")
-								+ " isn't permitted to perform the action.");
+				if (!"rangerusersync".equals(session.getXXPortalUser().getLoginId())) {// new logic for rangerusersync user
+					if (session.isUserAdmin() && (stringRolesList.contains(RangerConstants.ROLE_KEY_ADMIN) || stringRolesList.contains(RangerConstants.ROLE_KEY_ADMIN_AUDITOR))) {
+						throw restErrorUtil.create403RESTException("Permission denied. LoggedInUser=" + (session != null ? session.getXXPortalUser().getId() : "") + " isn't permitted to perform the action.");
+					} else if (session.isKeyAdmin() && (stringRolesList.contains(RangerConstants.ROLE_SYS_ADMIN) || stringRolesList.contains(RangerConstants.ROLE_ADMIN_AUDITOR))) {
+						throw restErrorUtil.create403RESTException("Permission denied. LoggedInUser=" + (session != null ? session.getXXPortalUser().getId() : "") + " isn't permitted to perform the action.");
 					}
-					if (session.isKeyAdmin()
-							&& stringRolesList
-							.contains(RangerConstants.ROLE_SYS_ADMIN)) {
-						throw restErrorUtil.create403RESTException("Permission"
-								+ " denied. LoggedInUser="
-								+ (session != null ? session.getXXPortalUser()
-								.getId() : "")
-								+ " isn't permitted to perform the action.");
-					}
-				} else {
-					logger.info("LoggedInUser="
-							+ (session != null ? session.getXXPortalUser()
-							.getId() : "")
-							+ " is permitted to perform the action.");
 				}
 			}
 		} else {
@@ -1531,8 +1494,8 @@ public class XUserMgr extends XUserMgrBase {
 				roleListNewProfile.add(vXString.getValue());
 			}
 		}
-		checkAccessRoles(roleListNewProfile);
 		VXUser vXUser=getXUser(userId);
+		checkAccessRoles(roleListNewProfile);
 		List<XXPortalUserRole> portalUserRoleList =null;
 		if(vXUser!=null && roleListNewProfile.size()>0){
 			VXPortalUser oldUserProfile = userMgr.getUserProfileByLoginId(vXUser.getName());
@@ -1557,9 +1520,10 @@ public class XUserMgr extends XUserMgrBase {
 				roleListNewProfile.add(vXString.getValue());
 			}
 		}
+		VXUser vXUser=getXUserByUserName(userName);
 		checkAccessRoles(roleListNewProfile);
-		if(userName!=null && roleListNewProfile.size()>0){
-			VXPortalUser oldUserProfile = userMgr.getUserProfileByLoginId(userName);
+		if(vXUser!=null && roleListNewProfile.size()>0){
+			VXPortalUser oldUserProfile = userMgr.getUserProfileByLoginId(vXUser.getName());
 			if(oldUserProfile!=null){
 				denySelfRoleChange(oldUserProfile.getLoginId());
 				updateUserRolesPermissions(oldUserProfile,roleListNewProfile);
@@ -1579,7 +1543,7 @@ public class XUserMgr extends XUserMgrBase {
 		if(vXUser==null){
 			throw restErrorUtil.createRESTException("Please provide a valid ID", MessageEnums.INVALID_INPUT_DATA);
 		}
-		checkAccess(vXUser.getName());
+		checkAccess(vXUser);
 		List<XXPortalUserRole> portalUserRoleList =null;
 		VXPortalUser oldUserProfile = userMgr.getUserProfileByLoginId(vXUser.getName());
 		if(oldUserProfile!=null){
@@ -1593,7 +1557,8 @@ public class XUserMgr extends XUserMgrBase {
 	public VXStringList getUserRolesByName(String userName) {
 		VXPortalUser vXPortalUser=null;
 		if(userName!=null && !userName.trim().isEmpty()){
-			checkAccess(userName);
+			VXUser vXUser=xUserService.getXUserByUserName(userName);
+			checkAccess(vXUser);
 			vXPortalUser = userMgr.getUserProfileByLoginId(userName);
 			if(vXPortalUser!=null && vXPortalUser.getUserRoleList()!=null){
 				List<XXPortalUserRole> portalUserRoleList = daoManager.getXXPortalUserRole().findByUserId(vXPortalUser.getId());
@@ -2090,9 +2055,6 @@ public class XUserMgr extends XUserMgrBase {
 		XXGroupPermissionDao xXGroupPermissionDao=daoManager.getXXGroupPermission();
 		List<XXGroupPermission> xXGroupPermissions=xXGroupPermissionDao.findByGroupId(id);
 
-		XXGroupGroupDao xXGroupGroupDao = daoManager.getXXGroupGroup();
-		List<XXGroupGroup> xXGroupGroups = xXGroupGroupDao.findByGroupId(id);
-
 		XXPolicyDao xXPolicyDao = daoManager.getXXPolicy();
 		List<XXPolicy> xXPolicyList = xXPolicyDao.findByGroupId(id);
 		logger.warn("Deleting GROUP : "+vXGroup.getName());
@@ -2129,17 +2091,6 @@ public class XUserMgr extends XUserMgrBase {
 				if(vXAuditMap!=null){
 					xXResource=xXResourceDao.getById(vXAuditMap.getResourceId());
 					xXAuditMapDao.remove(vXAuditMap.getId());
-				}
-			}
-			//delete XXGroupGroupDao records of group-group mapping
-			for (XXGroupGroup xXGroupGroup : xXGroupGroups) {
-				if(xXGroupGroup!=null){
-					XXGroup xXGroupParent=xXGroupDao.getById(xXGroupGroup.getParentGroupId());
-					XXGroup xXGroupChild=xXGroupDao.getById(xXGroupGroup.getGroupId());
-					if(xXGroupParent!=null && xXGroupChild!=null){
-						logger.warn("Removing group '" + xXGroupChild.getName() + "' from group '" + xXGroupParent.getName() + "'");
-					}
-					xXGroupGroupDao.remove(xXGroupGroup.getId());
 				}
 			}
 			//delete XXPolicyItemGroupPerm records of group
@@ -2233,9 +2184,6 @@ public class XUserMgr extends XUserMgrBase {
 				hasReferences=true;
 			}
 			if(hasReferences==false && vXAuditMapList.getListSize()>0){
-				hasReferences=true;
-			}
-			if(hasReferences==false && CollectionUtils.isNotEmpty(xXGroupGroups)){
 				hasReferences=true;
 			}
 			if(hasReferences==false && CollectionUtils.isNotEmpty(xXGroupPermissions)){
@@ -2780,7 +2728,7 @@ public class XUserMgr extends XUserMgrBase {
 				continue;
 			}
 
-			checkAccess(userName);
+			checkAccess(vXUser);
 			TransactionTemplate txTemplate = new TransactionTemplate(txManager);
 			txTemplate.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
 			try {

--- a/security-admin/src/main/java/org/apache/ranger/biz/XUserMgrBase.java
+++ b/security-admin/src/main/java/org/apache/ranger/biz/XUserMgrBase.java
@@ -23,7 +23,6 @@ import org.apache.ranger.common.MessageEnums;
 import org.apache.ranger.common.RESTErrorUtil;
 import org.apache.ranger.common.SearchCriteria;
 import org.apache.ranger.service.XAuditMapService;
-import org.apache.ranger.service.XGroupGroupService;
 import org.apache.ranger.service.XGroupPermissionService;
 import org.apache.ranger.service.XGroupService;
 import org.apache.ranger.service.XGroupUserService;
@@ -34,8 +33,6 @@ import org.apache.ranger.service.XUserService;
 import org.apache.ranger.view.VXAuditMap;
 import org.apache.ranger.view.VXAuditMapList;
 import org.apache.ranger.view.VXGroup;
-import org.apache.ranger.view.VXGroupGroup;
-import org.apache.ranger.view.VXGroupGroupList;
 import org.apache.ranger.view.VXGroupList;
 import org.apache.ranger.view.VXGroupPermissionList;
 import org.apache.ranger.view.VXGroupUser;
@@ -62,9 +59,6 @@ public class XUserMgrBase {
 
 	@Autowired
 	XGroupUserService xGroupUserService;
-
-	@Autowired
-	XGroupGroupService xGroupGroupService;
 
 	@Autowired
 	XPermMapService xPermMapService;
@@ -177,39 +171,6 @@ public class XUserMgrBase {
 	public VXLong getXGroupUserSearchCount(SearchCriteria searchCriteria) {
 		return xGroupUserService.getSearchCount(searchCriteria,
 				xGroupUserService.searchFields);
-	}
-
-	public VXGroupGroup getXGroupGroup(Long id){
-		return (VXGroupGroup)xGroupGroupService.readResource(id);
-	}
-
-	public VXGroupGroup createXGroupGroup(VXGroupGroup vXGroupGroup){
-		vXGroupGroup =  (VXGroupGroup)xGroupGroupService.createResource(vXGroupGroup);
-		return vXGroupGroup;
-	}
-
-	public VXGroupGroup updateXGroupGroup(VXGroupGroup vXGroupGroup) {
-		vXGroupGroup =  (VXGroupGroup)xGroupGroupService.updateResource(vXGroupGroup);
-		return vXGroupGroup;
-	}
-
-	public void deleteXGroupGroup(Long id, boolean force) {
-		 if (force) {
-			 xGroupGroupService.deleteResource(id);
-		 } else {
-			 throw restErrorUtil.createRESTException(
-				"serverMsg.modelMgrBaseDeleteModel",
-				MessageEnums.OPER_NOT_ALLOWED_FOR_ENTITY);
-		 }
-	}
-
-	public VXGroupGroupList searchXGroupGroups(SearchCriteria searchCriteria) {
-		return xGroupGroupService.searchXGroupGroups(searchCriteria);
-	}
-
-	public VXLong getXGroupGroupSearchCount(SearchCriteria searchCriteria) {
-		return xGroupGroupService.getSearchCount(searchCriteria,
-				xGroupGroupService.searchFields);
 	}
 
 	public VXPermMap getXPermMap(Long id){

--- a/security-admin/src/main/java/org/apache/ranger/rest/RoleREST.java
+++ b/security-admin/src/main/java/org/apache/ranger/rest/RoleREST.java
@@ -374,6 +374,7 @@ public class RoleREST {
         }
         SearchFilter filter = searchUtil.getSearchFilter(request, roleService.sortFields);
         try {
+            ensureAdminAccess(null, null);
             roleStore.getRoles(filter,ret);
         } catch(WebApplicationException excp) {
             throw excp;

--- a/security-admin/src/main/java/org/apache/ranger/rest/TagREST.java
+++ b/security-admin/src/main/java/org/apache/ranger/rest/TagREST.java
@@ -409,10 +409,14 @@ public class TagREST {
     @GET
     @Path(TagRESTConstants.TAGTYPES_RESOURCE)
     @Produces({ "application/json" })
-    @PreAuthorize("hasRole('ROLE_SYS_ADMIN')")
     public List<String> getTagTypes() {
         if(LOG.isDebugEnabled()) {
             LOG.debug("==> TagREST.getTagTypes()");
+        }
+
+        // check for ADMIN access
+        if (!bizUtil.isAdmin()) {
+            throw restErrorUtil.createRESTException(HttpServletResponse.SC_FORBIDDEN, "User don't have permission to perform this action", true);
         }
 
         List<String> ret = null;
@@ -638,10 +642,14 @@ public class TagREST {
     @GET
     @Path(TagRESTConstants.TAGS_RESOURCE)
     @Produces({ "application/json" })
-    @PreAuthorize("hasRole('ROLE_SYS_ADMIN')")
     public List<RangerTag> getAllTags() {
         if(LOG.isDebugEnabled()) {
             LOG.debug("==> TagREST.getAllTags()");
+        }
+
+        // check for ADMIN access
+        if (!bizUtil.isAdmin()) {
+            throw restErrorUtil.createRESTException(HttpServletResponse.SC_FORBIDDEN, "User don't have permission to perform this action", true);
         }
 
         List<RangerTag> ret;
@@ -1042,10 +1050,14 @@ public class TagREST {
     @GET
     @Path(TagRESTConstants.RESOURCES_RESOURCE)
     @Produces({ "application/json" })
-    @PreAuthorize("hasRole('ROLE_SYS_ADMIN')")
     public List<RangerServiceResource> getAllServiceResources() {
         if(LOG.isDebugEnabled()) {
             LOG.debug("==> TagREST.getAllServiceResources()");
+        }
+
+        // check for ADMIN access
+        if (!bizUtil.isAdmin()) {
+            throw restErrorUtil.createRESTException(HttpServletResponse.SC_FORBIDDEN, "User don't have permission to perform this action", true);
         }
 
         List<RangerServiceResource> ret;

--- a/security-admin/src/main/java/org/apache/ranger/rest/UserREST.java
+++ b/security-admin/src/main/java/org/apache/ranger/rest/UserREST.java
@@ -323,7 +323,6 @@ public class UserREST {
 			throw restErrorUtil.createRESTException("serverMsg.userRestUser",MessageEnums.DATA_NOT_FOUND, null, null, changePassword.getLoginId());
 		}
 
-		userManager.checkAccessForUpdate(gjUser);
 		changePassword.setId(gjUser.getId());
  		VXResponse ret = userManager.changePassword(changePassword);
 		return ret;
@@ -358,7 +357,6 @@ public class UserREST {
 			throw restErrorUtil.createRESTException("serverMsg.userRestUser",MessageEnums.DATA_NOT_FOUND, null, null, changeEmail.getLoginId());
 		}
 
-		userManager.checkAccessForUpdate(gjUser);
 		changeEmail.setId(gjUser.getId());
 		VXPortalUser ret = userManager.changeEmailAddress(gjUser, changeEmail);
 		return ret;

--- a/security-admin/src/main/java/org/apache/ranger/security/context/RangerAPIList.java
+++ b/security-admin/src/main/java/org/apache/ranger/security/context/RangerAPIList.java
@@ -160,12 +160,6 @@ public class RangerAPIList {
 	public static final String SEARCH_X_GROUP_USERS = "XUserREST.searchXGroupUsers";
 	public static final String GET_X_GROUP_USERS_BY_GROUP_NAME = "XUserREST.getXGroupUsersByGroupName";
 	public static final String COUNT_X_GROUP_USERS = "XUserREST.countXGroupUsers";
-	public static final String GET_X_GROUP_GROUP = "XUserREST.getXGroupGroup";
-	public static final String CREATE_X_GROUP_GROUP = "XUserREST.createXGroupGroup";
-	public static final String UPDATE_X_GROUP_GROUP = "XUserREST.updateXGroupGroup";
-	public static final String DELETE_X_GROUP_GROUP = "XUserREST.deleteXGroupGroup";
-	public static final String SEARCH_X_GROUP_GROUPS = "XUserREST.searchXGroupGroups";
-	public static final String COUNT_X_GROUP_GROUPS = "XUserREST.countXGroupGroups";
 	public static final String GET_X_PERM_MAP = "XUserREST.getXPermMap";
 	public static final String CREATE_X_PERM_MAP = "XUserREST.createXPermMap";
 	public static final String UPDATE_X_PERM_MAP = "XUserREST.updateXPermMap";

--- a/security-admin/src/main/java/org/apache/ranger/security/context/RangerAPIMapping.java
+++ b/security-admin/src/main/java/org/apache/ranger/security/context/RangerAPIMapping.java
@@ -103,7 +103,6 @@ public class RangerAPIMapping {
 		apiAssociatedWithReports.add(RangerAPIList.SEARCH_USERS);
 
 		apiAssociatedWithReports.add(RangerAPIList.COUNT_X_AUDIT_MAPS);
-		apiAssociatedWithReports.add(RangerAPIList.COUNT_X_GROUP_GROUPS);
 		apiAssociatedWithReports.add(RangerAPIList.COUNT_X_GROUPS);
 		apiAssociatedWithReports.add(RangerAPIList.COUNT_X_GROUP_USERS);
 		apiAssociatedWithReports.add(RangerAPIList.COUNT_X_PERM_MAPS);
@@ -111,7 +110,6 @@ public class RangerAPIMapping {
 		apiAssociatedWithReports.add(RangerAPIList.GET_X_AUDIT_MAP);
 		apiAssociatedWithReports.add(RangerAPIList.GET_X_GROUP);
 		apiAssociatedWithReports.add(RangerAPIList.GET_X_GROUP_BY_GROUP_NAME);
-		apiAssociatedWithReports.add(RangerAPIList.GET_X_GROUP_GROUP);
 		apiAssociatedWithReports.add(RangerAPIList.GET_X_GROUP_USER);
 		apiAssociatedWithReports.add(RangerAPIList.GET_X_GROUP_USERS);
 		apiAssociatedWithReports.add(RangerAPIList.GET_X_PERM_MAP);
@@ -119,7 +117,6 @@ public class RangerAPIMapping {
 		apiAssociatedWithReports.add(RangerAPIList.GET_X_USER_BY_USER_NAME);
 		apiAssociatedWithReports.add(RangerAPIList.GET_X_USER_GROUPS);
 		apiAssociatedWithReports.add(RangerAPIList.SEARCH_X_AUDIT_MAPS);
-		apiAssociatedWithReports.add(RangerAPIList.SEARCH_X_GROUP_GROUPS);
 		apiAssociatedWithReports.add(RangerAPIList.SEARCH_X_GROUPS);
 		apiAssociatedWithReports.add(RangerAPIList.SEARCH_X_GROUP_USERS);
 		apiAssociatedWithReports.add(RangerAPIList.SEARCH_X_PERM_MAPS);
@@ -171,7 +168,6 @@ public class RangerAPIMapping {
 		apiAssociatedWithTagBasedPolicy.add(RangerAPIList.SEARCH_USERS);
 
 		apiAssociatedWithTagBasedPolicy.add(RangerAPIList.COUNT_X_AUDIT_MAPS);
-		apiAssociatedWithTagBasedPolicy.add(RangerAPIList.COUNT_X_GROUP_GROUPS);
 		apiAssociatedWithTagBasedPolicy.add(RangerAPIList.COUNT_X_GROUPS);
 		apiAssociatedWithTagBasedPolicy.add(RangerAPIList.COUNT_X_GROUP_USERS);
 		apiAssociatedWithTagBasedPolicy.add(RangerAPIList.COUNT_X_PERM_MAPS);
@@ -183,7 +179,6 @@ public class RangerAPIMapping {
 		apiAssociatedWithTagBasedPolicy.add(RangerAPIList.GET_X_AUDIT_MAP);
 		apiAssociatedWithTagBasedPolicy.add(RangerAPIList.GET_X_GROUP);
 		apiAssociatedWithTagBasedPolicy.add(RangerAPIList.GET_X_GROUP_BY_GROUP_NAME);
-		apiAssociatedWithTagBasedPolicy.add(RangerAPIList.GET_X_GROUP_GROUP);
 		apiAssociatedWithTagBasedPolicy.add(RangerAPIList.GET_X_GROUP_USER);
 		apiAssociatedWithTagBasedPolicy.add(RangerAPIList.GET_X_GROUP_USERS);
 		apiAssociatedWithTagBasedPolicy.add(RangerAPIList.GET_X_PERM_MAP);
@@ -194,7 +189,6 @@ public class RangerAPIMapping {
 		apiAssociatedWithTagBasedPolicy.add(RangerAPIList.MODIFY_USER_ACTIVE_STATUS);
 		apiAssociatedWithTagBasedPolicy.add(RangerAPIList.MODIFY_USER_VISIBILITY);
 		apiAssociatedWithTagBasedPolicy.add(RangerAPIList.SEARCH_X_AUDIT_MAPS);
-		apiAssociatedWithTagBasedPolicy.add(RangerAPIList.SEARCH_X_GROUP_GROUPS);
 		apiAssociatedWithTagBasedPolicy.add(RangerAPIList.SEARCH_X_GROUPS);
 		apiAssociatedWithTagBasedPolicy.add(RangerAPIList.SEARCH_X_GROUP_USERS);
 		apiAssociatedWithTagBasedPolicy.add(RangerAPIList.SEARCH_X_PERM_MAPS);
@@ -307,7 +301,6 @@ public class RangerAPIMapping {
 		apiAssociatedWithUserAndGroups.add(RangerAPIList.SEARCH_USERS);
 
 		apiAssociatedWithUserAndGroups.add(RangerAPIList.COUNT_X_AUDIT_MAPS);
-		apiAssociatedWithUserAndGroups.add(RangerAPIList.COUNT_X_GROUP_GROUPS);
 		apiAssociatedWithUserAndGroups.add(RangerAPIList.COUNT_X_GROUPS);
 		apiAssociatedWithUserAndGroups.add(RangerAPIList.COUNT_X_GROUP_USERS);
 		apiAssociatedWithUserAndGroups.add(RangerAPIList.COUNT_X_PERM_MAPS);
@@ -319,7 +312,6 @@ public class RangerAPIMapping {
 		apiAssociatedWithUserAndGroups.add(RangerAPIList.GET_X_AUDIT_MAP);
 		apiAssociatedWithUserAndGroups.add(RangerAPIList.GET_X_GROUP);
 		apiAssociatedWithUserAndGroups.add(RangerAPIList.GET_X_GROUP_BY_GROUP_NAME);
-		apiAssociatedWithUserAndGroups.add(RangerAPIList.GET_X_GROUP_GROUP);
 		apiAssociatedWithUserAndGroups.add(RangerAPIList.GET_X_GROUP_USER);
 		apiAssociatedWithUserAndGroups.add(RangerAPIList.GET_X_GROUP_USERS);
 		apiAssociatedWithUserAndGroups.add(RangerAPIList.GET_X_PERM_MAP);
@@ -330,7 +322,6 @@ public class RangerAPIMapping {
 		apiAssociatedWithUserAndGroups.add(RangerAPIList.MODIFY_USER_ACTIVE_STATUS);
 		apiAssociatedWithUserAndGroups.add(RangerAPIList.MODIFY_USER_VISIBILITY);
 		apiAssociatedWithUserAndGroups.add(RangerAPIList.SEARCH_X_AUDIT_MAPS);
-		apiAssociatedWithUserAndGroups.add(RangerAPIList.SEARCH_X_GROUP_GROUPS);
 		apiAssociatedWithUserAndGroups.add(RangerAPIList.SEARCH_X_GROUPS);
 		apiAssociatedWithUserAndGroups.add(RangerAPIList.SEARCH_X_GROUP_USERS);
 		apiAssociatedWithUserAndGroups.add(RangerAPIList.SEARCH_X_PERM_MAPS);
@@ -385,7 +376,6 @@ public class RangerAPIMapping {
 		apiAssociatedWithAudit.add(RangerAPIList.SEARCH_USERS);
 
 		apiAssociatedWithAudit.add(RangerAPIList.COUNT_X_AUDIT_MAPS);
-		apiAssociatedWithAudit.add(RangerAPIList.COUNT_X_GROUP_GROUPS);
 		apiAssociatedWithAudit.add(RangerAPIList.COUNT_X_GROUPS);
 		apiAssociatedWithAudit.add(RangerAPIList.COUNT_X_GROUP_USERS);
 		apiAssociatedWithAudit.add(RangerAPIList.COUNT_X_PERM_MAPS);
@@ -393,7 +383,6 @@ public class RangerAPIMapping {
 		apiAssociatedWithAudit.add(RangerAPIList.GET_X_AUDIT_MAP);
 		apiAssociatedWithAudit.add(RangerAPIList.GET_X_GROUP);
 		apiAssociatedWithAudit.add(RangerAPIList.GET_X_GROUP_BY_GROUP_NAME);
-		apiAssociatedWithAudit.add(RangerAPIList.GET_X_GROUP_GROUP);
 		apiAssociatedWithAudit.add(RangerAPIList.GET_X_GROUP_USER);
 		apiAssociatedWithAudit.add(RangerAPIList.GET_X_GROUP_USERS);
 		apiAssociatedWithAudit.add(RangerAPIList.GET_X_PERM_MAP);
@@ -401,7 +390,6 @@ public class RangerAPIMapping {
 		apiAssociatedWithAudit.add(RangerAPIList.GET_X_USER_BY_USER_NAME);
 		apiAssociatedWithAudit.add(RangerAPIList.GET_X_USER_GROUPS);
 		apiAssociatedWithAudit.add(RangerAPIList.SEARCH_X_AUDIT_MAPS);
-		apiAssociatedWithAudit.add(RangerAPIList.SEARCH_X_GROUP_GROUPS);
 		apiAssociatedWithAudit.add(RangerAPIList.SEARCH_X_GROUPS);
 		apiAssociatedWithAudit.add(RangerAPIList.SEARCH_X_GROUP_USERS);
 		apiAssociatedWithAudit.add(RangerAPIList.SEARCH_X_PERM_MAPS);
@@ -468,7 +456,6 @@ public class RangerAPIMapping {
 		apiAssociatedWithRBPolicies.add(RangerAPIList.SEARCH_USERS);
 
 		apiAssociatedWithRBPolicies.add(RangerAPIList.COUNT_X_AUDIT_MAPS);
-		apiAssociatedWithRBPolicies.add(RangerAPIList.COUNT_X_GROUP_GROUPS);
 		apiAssociatedWithRBPolicies.add(RangerAPIList.COUNT_X_GROUPS);
 		apiAssociatedWithRBPolicies.add(RangerAPIList.COUNT_X_GROUP_USERS);
 		apiAssociatedWithRBPolicies.add(RangerAPIList.COUNT_X_PERM_MAPS);
@@ -480,7 +467,6 @@ public class RangerAPIMapping {
 		apiAssociatedWithRBPolicies.add(RangerAPIList.GET_X_AUDIT_MAP);
 		apiAssociatedWithRBPolicies.add(RangerAPIList.GET_X_GROUP);
 		apiAssociatedWithRBPolicies.add(RangerAPIList.GET_X_GROUP_BY_GROUP_NAME);
-		apiAssociatedWithRBPolicies.add(RangerAPIList.GET_X_GROUP_GROUP);
 		apiAssociatedWithRBPolicies.add(RangerAPIList.GET_X_GROUP_USER);
 		apiAssociatedWithRBPolicies.add(RangerAPIList.GET_X_GROUP_USERS);
 		apiAssociatedWithRBPolicies.add(RangerAPIList.GET_X_PERM_MAP);
@@ -491,7 +477,6 @@ public class RangerAPIMapping {
 		apiAssociatedWithRBPolicies.add(RangerAPIList.MODIFY_USER_ACTIVE_STATUS);
 		apiAssociatedWithRBPolicies.add(RangerAPIList.MODIFY_USER_VISIBILITY);
 		apiAssociatedWithRBPolicies.add(RangerAPIList.SEARCH_X_AUDIT_MAPS);
-		apiAssociatedWithRBPolicies.add(RangerAPIList.SEARCH_X_GROUP_GROUPS);
 		apiAssociatedWithRBPolicies.add(RangerAPIList.SEARCH_X_GROUPS);
 		apiAssociatedWithRBPolicies.add(RangerAPIList.SEARCH_X_GROUP_USERS);
 		apiAssociatedWithRBPolicies.add(RangerAPIList.SEARCH_X_PERM_MAPS);

--- a/security-admin/src/main/java/org/apache/ranger/service/XGroupService.java
+++ b/security-admin/src/main/java/org/apache/ranger/service/XGroupService.java
@@ -168,4 +168,8 @@ public class XGroupService extends XGroupServiceBase<XXGroup, VXGroup> {
 	public Long getAllGroupCount() {
 		return daoManager.getXXGroup().getAllCount();
 	}
+
+	public List<XXGroup> getGroupsByUserId(Long userId) {
+		return daoManager.getXXGroup().findByUserId(userId);
+	}
 }

--- a/security-admin/src/main/java/org/apache/ranger/service/XUgsyncAuditInfoService.java
+++ b/security-admin/src/main/java/org/apache/ranger/service/XUgsyncAuditInfoService.java
@@ -134,6 +134,8 @@ public class XUgsyncAuditInfoService extends XUgsyncAuditInfoServiceBase<XXUgsyn
 		}
 
 		returnList.setVxUgsyncAuditInfoList(xUgsyncAuditInfoList);
+		returnList.setTotalCount(xUgsyncAuditInfoList.size());
+		returnList.setResultSize(xUgsyncAuditInfoList.size());
 		return returnList;
 	}
 

--- a/security-admin/src/test/java/org/apache/ranger/biz/TestServiceDBStore.java
+++ b/security-admin/src/test/java/org/apache/ranger/biz/TestServiceDBStore.java
@@ -25,12 +25,14 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.commons.collections.ListUtils;
 import org.apache.ranger.common.ContextUtil;
 import org.apache.ranger.common.GUIDUtil;
 import org.apache.ranger.common.JSONUtil;
 import org.apache.ranger.common.RESTErrorUtil;
+import org.apache.ranger.common.RangerConstants;
 import org.apache.ranger.common.RangerFactory;
 import org.apache.ranger.common.SearchCriteria;
 import org.apache.ranger.common.StringUtil;
@@ -69,6 +71,7 @@ import org.apache.ranger.service.XUserService;
 import org.apache.ranger.view.RangerPolicyList;
 import org.apache.ranger.view.RangerServiceDefList;
 import org.apache.ranger.view.RangerServiceList;
+import org.apache.ranger.view.VXGroup;
 import org.apache.ranger.view.VXGroupList;
 import org.apache.ranger.view.VXString;
 import org.apache.ranger.view.VXUser;
@@ -166,6 +169,15 @@ public class TestServiceDBStore {
 
 	@Rule
 	public ExpectedException thrown = ExpectedException.none();
+
+	private VXGroup vxGroup() {
+		VXGroup vXGroup = new VXGroup();
+		vXGroup.setId(Id);
+		vXGroup.setDescription("group test working");
+		vXGroup.setName(RangerConstants.GROUP_PUBLIC);
+		vXGroup.setIsVisible(1);
+		return vXGroup;
+	}
 
 	public void setup() {
 		RangerSecurityContext context = new RangerSecurityContext();
@@ -1999,6 +2011,25 @@ public class TestServiceDBStore {
 		policyListObj.setSortType("1");
 		policyListObj.setStartIndex(0);
 		policyListObj.setTotalCount(10);
+		
+		Set<String> groupNames = new HashSet<String>(){{add(RangerConstants.GROUP_PUBLIC);}};
+		XXGroupGroupDao xXGroupGroupDao = Mockito.mock(XXGroupGroupDao.class);
+		Mockito.when(daoManager.getXXGroupGroup()).thenReturn(xXGroupGroupDao);
+		XXGroupDao xxGroupDao = Mockito.mock(XXGroupDao.class);
+		XXRoleDao xxRoleDao = Mockito.mock(XXRoleDao.class);
+		VXGroup vxGroup = vxGroup();
+		XXGroup xxGroup = new XXGroup();
+		xxGroup.setId(vxGroup.getId());
+		xxGroup.setName(vxGroup.getName());
+		xxGroup.setDescription(vxGroup.getDescription());
+		xxGroup.setIsVisible(vxGroup.getIsVisible());
+		Mockito.when(daoManager.getXXGroup()).thenReturn(xxGroupDao);
+		Mockito.when(xxGroupDao.findByGroupName(vxGroup.getName())).thenReturn(xxGroup);
+		Mockito.when(xXGroupGroupDao.findGroupNamesByGroupName(Mockito.anyString())).thenReturn(groupNames);
+		List<XXRole> xxRoles = new ArrayList<XXRole>();
+		Mockito.when(daoManager.getXXGroup()).thenReturn(xxGroupDao);
+		Mockito.when(daoManager.getXXRole()).thenReturn(xxRoleDao);
+		Mockito.when(xxRoleDao.findByGroupId(xxGroup.getId())).thenReturn(xxRoles);
 
 		List<RangerPolicy> dbRangerPolicy = serviceDBStore.getPolicies(filter);
 		Assert.assertNotNull(dbRangerPolicy);
@@ -2017,6 +2048,25 @@ public class TestServiceDBStore {
 		policyListObj.setSortType("1");
 		policyListObj.setStartIndex(0);
 		policyListObj.setTotalCount(10);
+		
+		Set<String> groupNames = new HashSet<String>(){{add(RangerConstants.GROUP_PUBLIC);}};
+		XXGroupGroupDao xXGroupGroupDao = Mockito.mock(XXGroupGroupDao.class);
+		Mockito.when(daoManager.getXXGroupGroup()).thenReturn(xXGroupGroupDao);
+		XXGroupDao xxGroupDao = Mockito.mock(XXGroupDao.class);
+		XXRoleDao xxRoleDao = Mockito.mock(XXRoleDao.class);
+		VXGroup vxGroup = vxGroup();
+		XXGroup xxGroup = new XXGroup();
+		xxGroup.setId(vxGroup.getId());
+		xxGroup.setName(vxGroup.getName());
+		xxGroup.setDescription(vxGroup.getDescription());
+		xxGroup.setIsVisible(vxGroup.getIsVisible());
+		Mockito.when(daoManager.getXXGroup()).thenReturn(xxGroupDao);
+		Mockito.when(xxGroupDao.findByGroupName(vxGroup.getName())).thenReturn(xxGroup);
+		Mockito.when(xXGroupGroupDao.findGroupNamesByGroupName(Mockito.anyString())).thenReturn(groupNames);
+		List<XXRole> xxRoles = new ArrayList<XXRole>();
+		Mockito.when(daoManager.getXXGroup()).thenReturn(xxGroupDao);
+		Mockito.when(daoManager.getXXRole()).thenReturn(xxRoleDao);
+		Mockito.when(xxRoleDao.findByGroupId(xxGroup.getId())).thenReturn(xxRoles);
 
 		PList<RangerPolicy> dbRangerPolicyList = serviceDBStore
 				.getPaginatedPolicies(filter);
@@ -2113,6 +2163,25 @@ public class TestServiceDBStore {
 		SearchFilter filter = new SearchFilter();
 		filter.setParam(SearchFilter.POLICY_NAME, "policyName");
 		filter.setParam(SearchFilter.SERVICE_NAME, "serviceName");
+		
+		Set<String> groupNames = new HashSet<String>(){{add(RangerConstants.GROUP_PUBLIC);}};
+		XXGroupGroupDao xXGroupGroupDao = Mockito.mock(XXGroupGroupDao.class);
+		Mockito.when(daoManager.getXXGroupGroup()).thenReturn(xXGroupGroupDao);
+		XXGroupDao xxGroupDao = Mockito.mock(XXGroupDao.class);
+		XXRoleDao xxRoleDao = Mockito.mock(XXRoleDao.class);
+		VXGroup vxGroup = vxGroup();
+		XXGroup xxGroup = new XXGroup();
+		xxGroup.setId(vxGroup.getId());
+		xxGroup.setName(vxGroup.getName());
+		xxGroup.setDescription(vxGroup.getDescription());
+		xxGroup.setIsVisible(vxGroup.getIsVisible());
+		Mockito.when(daoManager.getXXGroup()).thenReturn(xxGroupDao);
+		Mockito.when(xxGroupDao.findByGroupName(vxGroup.getName())).thenReturn(xxGroup);
+		Mockito.when(xXGroupGroupDao.findGroupNamesByGroupName(Mockito.anyString())).thenReturn(groupNames);
+		List<XXRole> xxRoles = new ArrayList<XXRole>();
+		Mockito.when(daoManager.getXXGroup()).thenReturn(xxGroupDao);
+		Mockito.when(daoManager.getXXRole()).thenReturn(xxRoleDao);
+		Mockito.when(xxRoleDao.findByGroupId(xxGroup.getId())).thenReturn(xxRoles);
 
 		PList<RangerPolicy> dbRangerPolicyList = serviceDBStore
 				.getPaginatedServicePolicies(serviceName, filter);
@@ -2131,6 +2200,25 @@ public class TestServiceDBStore {
 		XXServiceDao xServiceDao = Mockito.mock(XXServiceDao.class);
 		Mockito.when(daoManager.getXXService()).thenReturn(xServiceDao);
 		Mockito.when(xServiceDao.getById(Id)).thenReturn(xService);
+
+		Set<String> groupNames = new HashSet<String>(){{add(RangerConstants.GROUP_PUBLIC);}};
+		XXGroupGroupDao xXGroupGroupDao = Mockito.mock(XXGroupGroupDao.class);
+		Mockito.when(daoManager.getXXGroupGroup()).thenReturn(xXGroupGroupDao);
+		XXGroupDao xxGroupDao = Mockito.mock(XXGroupDao.class);
+		XXRoleDao xxRoleDao = Mockito.mock(XXRoleDao.class);
+		VXGroup vxGroup = vxGroup();
+		XXGroup xxGroup = new XXGroup();
+		xxGroup.setId(vxGroup.getId());
+		xxGroup.setName(vxGroup.getName());
+		xxGroup.setDescription(vxGroup.getDescription());
+		xxGroup.setIsVisible(vxGroup.getIsVisible());
+		Mockito.when(daoManager.getXXGroup()).thenReturn(xxGroupDao);
+		Mockito.when(xxGroupDao.findByGroupName(vxGroup.getName())).thenReturn(xxGroup);
+		Mockito.when(xXGroupGroupDao.findGroupNamesByGroupName(Mockito.anyString())).thenReturn(groupNames);
+		List<XXRole> xxRoles = new ArrayList<XXRole>();
+		Mockito.when(daoManager.getXXGroup()).thenReturn(xxGroupDao);
+		Mockito.when(daoManager.getXXRole()).thenReturn(xxRoleDao);
+		Mockito.when(xxRoleDao.findByGroupId(xxGroup.getId())).thenReturn(xxRoles);
 
 		//PList<RangerPolicy> dbRangerPolicyList =
         serviceDBStore.getPaginatedServicePolicies(rangerService.getId(), filter);
@@ -2325,7 +2413,6 @@ public void test44getMetricByTypePolicies() throws Exception {
     String                type    = "policies";
     RangerServiceList     svcList = new RangerServiceList();
     svcList.setTotalCount(10l);
-    Mockito.when(svcService.searchRangerServices(Mockito.any(SearchFilter.class))).thenReturn(svcList);
     serviceDBStore.getMetricByType(ServiceDBStore.METRIC_TYPE.getMetricTypeByName(type));
 }
 

--- a/security-admin/src/test/java/org/apache/ranger/biz/TestUserMgr.java
+++ b/security-admin/src/test/java/org/apache/ranger/biz/TestUserMgr.java
@@ -313,10 +313,24 @@ public class TestUserMgr {
 
 		Mockito.when(daoManager.getXXPortalUser()).thenReturn(userDao);
 		Mockito.when(userDao.findByLoginId(Mockito.nullable(String.class))).thenReturn(user);
-		Mockito.when(stringUtil.equals(Mockito.anyString(), Mockito.nullable(String.class))).thenReturn(true);
 
-		Mockito.when(daoManager.getXXPortalUser()).thenReturn(userDao);
-		Mockito.when(stringUtil.validatePassword(Mockito.anyString(), Mockito.any(String[].class))).thenReturn(true);
+		XXPortalUserRoleDao xPortalUserRoleDao = Mockito.mock(XXPortalUserRoleDao.class);
+		Mockito.when(daoManager.getXXPortalUserRole()).thenReturn(xPortalUserRoleDao);
+		List<XXPortalUserRole> xPortalUserRoleList = new ArrayList<XXPortalUserRole>();
+		XXPortalUserRole XXPortalUserRole = new XXPortalUserRole();
+		XXPortalUserRole.setId(userId);
+		XXPortalUserRole.setUserId(userId);
+		XXPortalUserRole.setUserRole("ROLE_USER");
+		xPortalUserRoleList.add(XXPortalUserRole);
+		XXUserPermissionDao xUserPermissionDao = Mockito.mock(XXUserPermissionDao.class);
+		XXGroupPermissionDao xGroupPermissionDao = Mockito.mock(XXGroupPermissionDao.class);
+		Mockito.when(daoManager.getXXUserPermission()).thenReturn(xUserPermissionDao);
+		Mockito.when(daoManager.getXXGroupPermission()).thenReturn(xGroupPermissionDao);
+		XXPortalUserRoleDao roleDao = Mockito.mock(XXPortalUserRoleDao.class);
+		Mockito.when(daoManager.getXXPortalUserRole()).thenReturn(roleDao);
+		Mockito.when(restErrorUtil.createRESTException(HttpServletResponse.SC_FORBIDDEN, "Logged-In user is not allowed to access requested user data", true)).thenThrow(new WebApplicationException());
+		thrown.expect(WebApplicationException.class);
+
 		VXResponse dbVXResponse = userMgr.changePassword(pwdChange);
 		Assert.assertNotNull(dbVXResponse);
 		Assert.assertEquals(userProfile.getStatus(),dbVXResponse.getStatusCode());
@@ -369,6 +383,25 @@ public class TestUserMgr {
 		Mockito.when(daoManager.getXXPortalUser()).thenReturn(userDao);
 		Mockito.when(stringUtil.validatePassword(Mockito.anyString(), Mockito.any(String[].class))).thenReturn(true);
 
+		XXPortalUserRoleDao xPortalUserRoleDao = Mockito.mock(XXPortalUserRoleDao.class);
+		Mockito.when(daoManager.getXXPortalUserRole()).thenReturn(xPortalUserRoleDao);
+		List<XXPortalUserRole> xPortalUserRoleList = new ArrayList<XXPortalUserRole>();
+		XXPortalUserRole XXPortalUserRole = new XXPortalUserRole();
+		XXPortalUserRole.setId(userId);
+		XXPortalUserRole.setUserId(userId);
+		XXPortalUserRole.setUserRole("ROLE_USER");
+		xPortalUserRoleList.add(XXPortalUserRole);
+		XXPortalUserRoleDao roleDao = Mockito.mock(XXPortalUserRoleDao.class);
+		Mockito.when(daoManager.getXXPortalUserRole()).thenReturn(roleDao);
+		Mockito.when(roleDao.findByParentId(Mockito.anyLong())).thenReturn(xPortalUserRoleList);
+		XXUserPermissionDao xUserPermissionDao = Mockito.mock(XXUserPermissionDao.class);
+		XXGroupPermissionDao xGroupPermissionDao = Mockito.mock(XXGroupPermissionDao.class);
+		Mockito.when(daoManager.getXXUserPermission()).thenReturn(xUserPermissionDao);
+		List<XXUserPermission> xUserPermissionsList = new ArrayList<XXUserPermission>();
+		List<XXGroupPermission> xGroupPermissionList = new ArrayList<XXGroupPermission>();
+		Mockito.when(xUserPermissionDao.findByUserPermissionIdAndIsAllowed(userProfile.getId())).thenReturn(xUserPermissionsList);
+		Mockito.when(daoManager.getXXGroupPermission()).thenReturn(xGroupPermissionDao);
+		Mockito.when(xGroupPermissionDao.findbyVXPortalUserId(userProfile.getId())).thenReturn(xGroupPermissionList);
 		VXResponse dbVXResponse = userMgr.changePassword(pwdChange);
 		Assert.assertNotNull(dbVXResponse);
 		Assert.assertEquals(userProfile.getStatus(),dbVXResponse.getStatusCode());
@@ -398,6 +431,26 @@ public class TestUserMgr {
 		Mockito.when(stringUtil.equals(Mockito.anyString(), Mockito.nullable(String.class))).thenReturn(true);
 		Mockito.when(daoManager.getXXPortalUser()).thenReturn(userDao);
 		Mockito.when(stringUtil.validatePassword(Mockito.anyString(), Mockito.any(String[].class))).thenReturn(true);
+		Mockito.when(userDao.findByLoginId(Mockito.anyString())).thenReturn(user);
+		XXPortalUserRoleDao xPortalUserRoleDao = Mockito.mock(XXPortalUserRoleDao.class);
+		Mockito.when(daoManager.getXXPortalUserRole()).thenReturn(xPortalUserRoleDao);
+		List<XXPortalUserRole> xPortalUserRoleList = new ArrayList<XXPortalUserRole>();
+		XXPortalUserRole XXPortalUserRole = new XXPortalUserRole();
+		XXPortalUserRole.setId(userId);
+		XXPortalUserRole.setUserId(userId);
+		XXPortalUserRole.setUserRole("ROLE_USER");
+		xPortalUserRoleList.add(XXPortalUserRole);
+		XXUserPermissionDao xUserPermissionDao = Mockito.mock(XXUserPermissionDao.class);
+		XXGroupPermissionDao xGroupPermissionDao = Mockito.mock(XXGroupPermissionDao.class);
+		Mockito.when(daoManager.getXXUserPermission()).thenReturn(xUserPermissionDao);
+		List<XXUserPermission> xUserPermissionsList = new ArrayList<XXUserPermission>();
+		List<XXGroupPermission> xGroupPermissionList = new ArrayList<XXGroupPermission>();
+		Mockito.when(xUserPermissionDao.findByUserPermissionIdAndIsAllowed(userProfile.getId())).thenReturn(xUserPermissionsList);
+		Mockito.when(daoManager.getXXGroupPermission()).thenReturn(xGroupPermissionDao);
+		Mockito.when(xGroupPermissionDao.findbyVXPortalUserId(userProfile.getId())).thenReturn(xGroupPermissionList);
+		XXPortalUserRoleDao roleDao = Mockito.mock(XXPortalUserRoleDao.class);
+		Mockito.when(daoManager.getXXPortalUserRole()).thenReturn(roleDao);
+		Mockito.when(roleDao.findByParentId(Mockito.anyLong())).thenReturn(xPortalUserRoleList);
 
 		VXResponse dbVXResponse = userMgr.changePassword(pwdChange);
 		Assert.assertNotNull(dbVXResponse);
@@ -415,7 +468,16 @@ public class TestUserMgr {
 		XXUserPermissionDao xUserPermissionDao = Mockito.mock(XXUserPermissionDao.class);
 		XXGroupPermissionDao xGroupPermissionDao = Mockito.mock(XXGroupPermissionDao.class);
 		XXModuleDefDao xModuleDefDao = Mockito.mock(XXModuleDefDao.class);
-		XXModuleDef xModuleDef = Mockito.mock(XXModuleDef.class);
+
+		XXModuleDef xModuleDef = new XXModuleDef();
+		xModuleDef.setUpdatedByUserId(userId);
+		xModuleDef.setAddedByUserId(userId);
+		xModuleDef.setCreateTime(new Date());
+		xModuleDef.setId(userId);
+		xModuleDef.setModule("Policy manager");
+		xModuleDef.setUpdateTime(new Date());
+		xModuleDef.setUrl("/policy manager");
+
 		VXPortalUser userProfile = userProfile();
 
 		XXPortalUser user = new XXPortalUser();
@@ -482,11 +544,8 @@ public class TestUserMgr {
 		groupPermission.setOwner("admin");
 
 		Mockito.when(stringUtil.validateEmail(Mockito.anyString())).thenReturn(true);
-		Mockito.when(stringUtil.equals(Mockito.anyString(), Mockito.anyString())).thenReturn(true);
-		Mockito.when(stringUtil.normalizeEmail(Mockito.anyString())).thenReturn(changeEmail.getEmailAddress());
 		Mockito.when(daoManager.getXXPortalUser()).thenReturn(userDao);
 		Mockito.when(daoManager.getXXPortalUserRole()).thenReturn(roleDao);
-		Mockito.when(userDao.update(user)).thenReturn(user);
 		Mockito.when(roleDao.findByParentId(Mockito.anyLong())).thenReturn(list);
 		Mockito.when(daoManager.getXXUserPermission()).thenReturn(xUserPermissionDao);
 		Mockito.when(daoManager.getXXGroupPermission()).thenReturn(xGroupPermissionDao);
@@ -496,7 +555,28 @@ public class TestUserMgr {
 		Mockito.when(xUserPermissionService.populateViewBean(xUserPermissionObj)).thenReturn(userPermission);
 		Mockito.when(daoManager.getXXModuleDef()).thenReturn(xModuleDefDao);
 		Mockito.when(xModuleDefDao.findByModuleId(Mockito.anyLong())).thenReturn(xModuleDef);
-		Mockito.doNothing().when(rangerBizUtil).blockAuditorRoleUser();
+
+		Mockito.when(daoManager.getXXPortalUser()).thenReturn(userDao);
+		Mockito.when(userDao.findByLoginId(Mockito.anyString())).thenReturn(user);
+		Mockito.when(daoManager.getXXPortalUser()).thenReturn(userDao);
+		Mockito.when(userDao.findByLoginId(Mockito.anyString())).thenReturn(user);
+		XXPortalUserRoleDao xPortalUserRoleDao = Mockito.mock(XXPortalUserRoleDao.class);
+		Mockito.when(daoManager.getXXPortalUserRole()).thenReturn(xPortalUserRoleDao);
+		List<XXPortalUserRole> xPortalUserRoleList = new ArrayList<XXPortalUserRole>();
+		XXPortalUserRole.setId(userId);
+		XXPortalUserRole.setUserId(userId);
+		XXPortalUserRole.setUserRole("ROLE_USER");
+		xPortalUserRoleList.add(XXPortalUserRole);
+		Mockito.when(daoManager.getXXUserPermission()).thenReturn(xUserPermissionDao);
+		Mockito.when(xUserPermissionDao.findByUserPermissionIdAndIsAllowed(userProfile.getId())).thenReturn(xUserPermissionsList);
+		Mockito.when(daoManager.getXXGroupPermission()).thenReturn(xGroupPermissionDao);
+		Mockito.when(xGroupPermissionDao.findbyVXPortalUserId(userProfile.getId())).thenReturn(xGroupPermissionList);
+		Mockito.when(daoManager.getXXPortalUserRole()).thenReturn(roleDao);
+		Mockito.when(roleDao.findByParentId(Mockito.anyLong())).thenReturn(xPortalUserRoleList);
+		Mockito.when(daoManager.getXXModuleDef()).thenReturn(xModuleDefDao);
+		Mockito.when(xModuleDefDao.findByModuleId(Mockito.anyLong())).thenReturn(xModuleDef);
+		Mockito.when(restErrorUtil.createRESTException(HttpServletResponse.SC_FORBIDDEN, "Logged-In user is not allowed to access requested user data", true)).thenThrow(new WebApplicationException());
+		thrown.expect(WebApplicationException.class);
 		VXPortalUser dbVXPortalUser = userMgr.changeEmailAddress(user,changeEmail);
 		Assert.assertNotNull(dbVXPortalUser);
 		Assert.assertEquals(userId, dbVXPortalUser.getId());
@@ -521,10 +601,6 @@ public class TestUserMgr {
 		setupKeyAdmin();
 		XXPortalUserDao userDao = Mockito.mock(XXPortalUserDao.class);
 		XXPortalUserRoleDao roleDao = Mockito.mock(XXPortalUserRoleDao.class);
-		XXUserPermissionDao xUserPermissionDao = Mockito.mock(XXUserPermissionDao.class);
-		XXGroupPermissionDao xGroupPermissionDao = Mockito.mock(XXGroupPermissionDao.class);
-		XXModuleDefDao xModuleDefDao = Mockito.mock(XXModuleDefDao.class);
-		XXModuleDef xModuleDef = Mockito.mock(XXModuleDef.class);
 		VXPortalUser userProfile = userProfile();
 
 		XXPortalUser userKeyAdmin = new XXPortalUser();
@@ -596,15 +672,30 @@ public class TestUserMgr {
 		Mockito.when(daoManager.getXXPortalUser()).thenReturn(userDao);
 		Mockito.when(daoManager.getXXPortalUserRole()).thenReturn(roleDao);
 		Mockito.when(roleDao.findByParentId(Mockito.anyLong())).thenReturn(list);
+		Mockito.when(daoManager.getXXPortalUser()).thenReturn(userDao);
+		Mockito.when(userDao.findByLoginId(Mockito.anyString())).thenReturn(userKeyAdmin);
+		XXPortalUserRoleDao xPortalUserRoleDao = Mockito.mock(XXPortalUserRoleDao.class);
+		Mockito.when(daoManager.getXXPortalUserRole()).thenReturn(xPortalUserRoleDao);
+		List<XXPortalUserRole> xPortalUserRoleList = new ArrayList<XXPortalUserRole>();
+		XXPortalUserRole.setId(userId);
+		XXPortalUserRole.setUserId(userId);
+		XXPortalUserRole.setUserRole("ROLE_USER");
+		xPortalUserRoleList.add(XXPortalUserRole);
+		Mockito.when(daoManager.getXXPortalUserRole()).thenReturn(roleDao);
+		Mockito.when(roleDao.findByParentId(Mockito.anyLong())).thenReturn(xPortalUserRoleList);
+		XXUserPermissionDao xUserPermissionDao = Mockito.mock(XXUserPermissionDao.class);
+		XXGroupPermissionDao xGroupPermissionDao = Mockito.mock(XXGroupPermissionDao.class);
 		Mockito.when(daoManager.getXXUserPermission()).thenReturn(xUserPermissionDao);
-		Mockito.when(daoManager.getXXGroupPermission()).thenReturn(xGroupPermissionDao);
 		Mockito.when(xUserPermissionDao.findByUserPermissionIdAndIsAllowed(userProfile.getId())).thenReturn(xUserPermissionsList);
+		Mockito.when(daoManager.getXXGroupPermission()).thenReturn(xGroupPermissionDao);
 		Mockito.when(xGroupPermissionDao.findbyVXPortalUserId(userProfile.getId())).thenReturn(xGroupPermissionList);
 		Mockito.when(xGroupPermissionService.populateViewBean(xGroupPermissionObj)).thenReturn(groupPermission);
 		Mockito.when(xUserPermissionService.populateViewBean(xUserPermissionObj)).thenReturn(userPermission);
+		XXModuleDefDao xModuleDefDao = Mockito.mock(XXModuleDefDao.class);
+		XXModuleDef xModuleDef = new XXModuleDef();
+		xModuleDef.setModule("Users/Groups");
 		Mockito.when(daoManager.getXXModuleDef()).thenReturn(xModuleDefDao);
-		Mockito.when(xModuleDefDao.findByModuleId(Mockito.anyLong())).thenReturn(xModuleDef);
-		Mockito.doNothing().when(rangerBizUtil).blockAuditorRoleUser();
+		Mockito.when(xModuleDefDao.findByModuleId(groupPermission.getModuleId())).thenReturn(xModuleDef);
 		VXPortalUser dbVXPortalUser = userMgr.changeEmailAddress(userKeyAdmin,changeEmail);
 		Assert.assertNotNull(dbVXPortalUser);
 		Assert.assertEquals(userId, dbVXPortalUser.getId());
@@ -612,7 +703,6 @@ public class TestUserMgr {
 		Assert.assertEquals(changeEmail.getLoginId(),dbVXPortalUser.getLoginId());
 		Assert.assertEquals(changeEmail.getEmailAddress(),dbVXPortalUser.getEmailAddress());
 	}
-
 
 	@Test
 	public void test08ChangeEmailAddressAsUser() {
@@ -702,7 +792,23 @@ public class TestUserMgr {
 		Mockito.when(xUserPermissionService.populateViewBean(xUserPermissionObj)).thenReturn(userPermission);
 		Mockito.when(daoManager.getXXModuleDef()).thenReturn(xModuleDefDao);
 		Mockito.when(xModuleDefDao.findByModuleId(Mockito.anyLong())).thenReturn(xModuleDef);
-		Mockito.doNothing().when(rangerBizUtil).blockAuditorRoleUser();
+		Mockito.when(daoManager.getXXPortalUser()).thenReturn(userDao);
+		Mockito.when(userDao.findByLoginId(Mockito.anyString())).thenReturn(user);
+		XXPortalUserRoleDao xPortalUserRoleDao = Mockito.mock(XXPortalUserRoleDao.class);
+		Mockito.when(daoManager.getXXPortalUserRole()).thenReturn(xPortalUserRoleDao);
+		List<XXPortalUserRole> xPortalUserRoleList = new ArrayList<XXPortalUserRole>();
+		XXPortalUserRole.setId(userId);
+		XXPortalUserRole.setUserId(userId);
+		XXPortalUserRole.setUserRole("ROLE_USER");
+		xPortalUserRoleList.add(XXPortalUserRole);
+		Mockito.when(daoManager.getXXUserPermission()).thenReturn(xUserPermissionDao);
+		Mockito.when(xUserPermissionDao.findByUserPermissionIdAndIsAllowed(userProfile.getId())).thenReturn(xUserPermissionsList);
+		Mockito.when(daoManager.getXXGroupPermission()).thenReturn(xGroupPermissionDao);
+		Mockito.when(xGroupPermissionDao.findbyVXPortalUserId(userProfile.getId())).thenReturn(xGroupPermissionList);
+		Mockito.when(daoManager.getXXPortalUserRole()).thenReturn(roleDao);
+		Mockito.when(roleDao.findByParentId(Mockito.anyLong())).thenReturn(xPortalUserRoleList);
+		Mockito.when(daoManager.getXXModuleDef()).thenReturn(xModuleDefDao);
+		Mockito.when(xModuleDefDao.findByModuleId(Mockito.anyLong())).thenReturn(xModuleDef);
 		VXPortalUser dbVXPortalUser = userMgr.changeEmailAddress(user,changeEmail);
 		Assert.assertNotNull(dbVXPortalUser);
 		Assert.assertEquals(userId, dbVXPortalUser.getId());
@@ -934,10 +1040,8 @@ public class TestUserMgr {
 		user.setPassword(encryptedPwd);
 		Mockito.when(daoManager.getXXPortalUser()).thenReturn(userDao);
 		Mockito.when(userDao.getById(userProfile.getId())).thenReturn(user);
-		Mockito.when(stringUtil.validateEmail(Mockito.anyString())).thenReturn(true);
-		Mockito.doNothing().when(rangerBizUtil).blockAuditorRoleUser();
-		Mockito.when(stringUtil.validatePassword(Mockito.anyString(), Mockito.any(String[].class))).thenReturn(true);
-		Mockito.when(userDao.update(user)).thenReturn(user);
+		Mockito.when(restErrorUtil.createRESTException(HttpServletResponse.SC_FORBIDDEN, "Logged-In user is not allowed to access requested user data", true)).thenThrow(new WebApplicationException());
+		thrown.expect(WebApplicationException.class);
 		XXPortalUser dbXXPortalUser = userMgr.updateUserWithPass(userProfile);
 		Assert.assertNotNull(dbXXPortalUser);
 		Assert.assertEquals(userId, dbXXPortalUser.getId());
@@ -1174,6 +1278,8 @@ public class TestUserMgr {
 		XXPortalUser xPortalUser = Mockito.mock(XXPortalUser.class);
 		Mockito.when(daoManager.getXXPortalUser()).thenReturn(xPortalUserDao);
 		Mockito.when(xPortalUserDao.getById(userId)).thenReturn(xPortalUser);
+		Mockito.when(restErrorUtil.createRESTException(HttpServletResponse.SC_FORBIDDEN, "Logged-In user is not allowed to access requested user data", true)).thenThrow(new WebApplicationException());
+		thrown.expect(WebApplicationException.class);
 		userMgr.checkAccess(userId);
 
 		Mockito.when(xPortalUserDao.getById(userId)).thenReturn(null);
@@ -1187,10 +1293,6 @@ public class TestUserMgr {
 		setup();
 		XXPortalUserDao xPortalUserDao = Mockito.mock(XXPortalUserDao.class);
 		XXPortalUser xPortalUser = Mockito.mock(XXPortalUser.class);
-		XXUserPermissionDao xUserPermissionDao = Mockito.mock(XXUserPermissionDao.class);
-		XXGroupPermissionDao xGroupPermissionDao = Mockito.mock(XXGroupPermissionDao.class);
-
-		XXPortalUserRoleDao xPortalUserRoleDao = Mockito.mock(XXPortalUserRoleDao.class);
 
 		List<XXPortalUserRole> xPortalUserRoleList = new ArrayList<XXPortalUserRole>();
 		XXPortalUserRole XXPortalUserRole = new XXPortalUserRole();
@@ -1224,10 +1326,8 @@ public class TestUserMgr {
 
 		Mockito.when(daoManager.getXXPortalUser()).thenReturn(xPortalUserDao);
 		Mockito.when(xPortalUserDao.getById(userId)).thenReturn(null);
-		Mockito.when(daoManager.getXXPortalUserRole()).thenReturn(xPortalUserRoleDao);
-		Mockito.when(daoManager.getXXUserPermission()).thenReturn(xUserPermissionDao);
-
-		Mockito.when(daoManager.getXXGroupPermission()).thenReturn(xGroupPermissionDao);
+		Mockito.when(restErrorUtil.createRESTException(HttpServletResponse.SC_FORBIDDEN, "Logged-In user is not allowed to access requested user data", true)).thenThrow(new WebApplicationException());
+		thrown.expect(WebApplicationException.class);
 		VXPortalUser dbVXPortalUser = userMgr.getUserProfile(userId);
 		Mockito.when(xPortalUserDao.getById(userId)).thenReturn(xPortalUser);
 		dbVXPortalUser = userMgr.getUserProfile(userId);
@@ -1275,12 +1375,7 @@ public class TestUserMgr {
 	@Test
 	public void test23setUserRoles() {
 		setup();
-		XXPortalUserRoleDao xPortalUserRoleDao = Mockito.mock(XXPortalUserRoleDao.class);
 		XXPortalUserDao userDao = Mockito.mock(XXPortalUserDao.class);
-		XXUserPermissionDao xUserPermissionDao = Mockito.mock(XXUserPermissionDao.class);
-		XXGroupPermissionDao xGroupPermissionDao = Mockito.mock(XXGroupPermissionDao.class);
-		XXModuleDefDao xModuleDefDao = Mockito.mock(XXModuleDefDao.class);
-
 		VXPortalUser userProfile = userProfile();
 		XXPortalUser user = new XXPortalUser();
 		user.setEmailAddress(userProfile.getEmailAddress());
@@ -1354,21 +1449,10 @@ public class TestUserMgr {
 		userPermission.setUserId(userId);
 		userPermission.setUserName("xyz");
 		userPermission.setOwner("admin");
-
-		Mockito.when(daoManager.getXXPortalUserRole()).thenReturn(xPortalUserRoleDao);
 		Mockito.when(daoManager.getXXPortalUser()).thenReturn(userDao);
 		Mockito.when(userDao.getById(userId)).thenReturn(user);
-		Mockito.when(daoManager.getXXUserPermission()).thenReturn(xUserPermissionDao);
-		Mockito.when(xUserPermissionDao.findByUserPermissionIdAndIsAllowed(userProfile.getId())).thenReturn(xUserPermissionsList);
-		Mockito.when(daoManager.getXXGroupPermission()).thenReturn(xGroupPermissionDao);
-		Mockito.when(xGroupPermissionDao.findbyVXPortalUserId(userProfile.getId())).thenReturn(xGroupPermissionList);
-		Mockito.when(xGroupPermissionService.populateViewBean(xGroupPermissionObj)).thenReturn(groupPermission);
-		Mockito.when(daoManager.getXXModuleDef()).thenReturn(xModuleDefDao);
-		Mockito.when(xModuleDefDao.findByModuleId(Mockito.anyLong())).thenReturn(xModuleDef);
-		Mockito.when(xUserPermissionService.populateViewBean(xUserPermissionObj)).thenReturn(userPermission);
-		Mockito.when(daoManager.getXXModuleDef()).thenReturn(xModuleDefDao);
-		Mockito.when(xModuleDefDao.findByModuleId(Mockito.anyLong())).thenReturn(xModuleDef);
-		Mockito.doNothing().when(rangerBizUtil).blockAuditorRoleUser();
+		Mockito.when(restErrorUtil.createRESTException(HttpServletResponse.SC_FORBIDDEN, "Logged-In user is not allowed to access requested user data", true)).thenThrow(new WebApplicationException());
+		thrown.expect(WebApplicationException.class);
 		userMgr.checkAccess(userId);
 		userMgr.setUserRoles(userId, vStringRolesList);
 
@@ -1496,9 +1580,8 @@ public class TestUserMgr {
 		user.setPassword(encryptedPwd);
 		Mockito.when(daoManager.getXXPortalUser()).thenReturn(userDao);
 		Mockito.when(userDao.getById(userProfile.getId())).thenReturn(user);
-		Mockito.when(stringUtil.validateEmail(Mockito.anyString())).thenReturn(true);
-
-		Mockito.doNothing().when(rangerBizUtil).blockAuditorRoleUser();
+		Mockito.when(restErrorUtil.createRESTException(HttpServletResponse.SC_FORBIDDEN, "Logged-In user is not allowed to access requested user data", true)).thenThrow(new WebApplicationException());
+		thrown.expect(WebApplicationException.class);
 		XXPortalUser dbXXPortalUser = userMgr.updateUser(userProfile);
 		Assert.assertNotNull(dbXXPortalUser);
 		Assert.assertEquals(userId, dbXXPortalUser.getId());
@@ -1536,9 +1619,8 @@ public class TestUserMgr {
 		user.setFirstName("null");
 		user.setLastName("null");
 		Mockito.when(userDao.getById(userProfile.getId())).thenReturn(user);
-		Mockito.when(stringUtil.validateEmail(Mockito.anyString())).thenReturn(true);
-		Mockito.doNothing().when(rangerBizUtil).blockAuditorRoleUser();
-		Mockito.when(userDao.findByEmailAddress(Mockito.anyString())).thenReturn(user);
+		Mockito.when(restErrorUtil.createRESTException(HttpServletResponse.SC_FORBIDDEN, "Logged-In user is not allowed to access requested user data", true)).thenThrow(new WebApplicationException());
+		thrown.expect(WebApplicationException.class);
 		dbXXPortalUser = userMgr.updateUser(userProfile);
 		Assert.assertNotNull(dbXXPortalUser);
 		Assert.assertEquals(userId, dbXXPortalUser.getId());
@@ -1661,7 +1743,11 @@ public class TestUserMgr {
 	@Test
 	public void test31checkAccess() {
 		setup();
+		XXPortalUserDao userDao = Mockito.mock(XXPortalUserDao.class);
+		Mockito.when(daoManager.getXXPortalUser()).thenReturn(userDao);
 		XXPortalUser xPortalUser = Mockito.mock(XXPortalUser.class);
+		Mockito.when(restErrorUtil.createRESTException(HttpServletResponse.SC_FORBIDDEN, "Logged-In user is not allowed to access requested user data", true)).thenThrow(new WebApplicationException());
+		thrown.expect(WebApplicationException.class);
 		userMgr.checkAccess(xPortalUser);
 		destroySession();
 		VXPortalUser userProfile = userProfile();
@@ -1692,30 +1778,9 @@ public class TestUserMgr {
 	}
 
 	@Test
-	public void test33checkAccessForUpdate() {
-		setup();
-		XXPortalUser xPortalUser = Mockito.mock(XXPortalUser.class);
-		userMgr.checkAccessForUpdate(xPortalUser);
-
-		destroySession();
-		xPortalUser.setId(userId);
-		VXResponse vXResponse = new VXResponse();
-		vXResponse.setStatusCode(HttpServletResponse.SC_FORBIDDEN);
-		vXResponse.setMsgDesc("User  access denied. loggedInUser=Not Logged In , accessing user="+ xPortalUser.getId());
-		Mockito.when(restErrorUtil.generateRESTException((VXResponse) Mockito.any())).thenThrow(new WebApplicationException());
-		thrown.expect(WebApplicationException.class);
-		userMgr.checkAccessForUpdate(xPortalUser);
-		xPortalUser = null;
-		Mockito.when(restErrorUtil.create403RESTException("serverMsg.userMgrWrongUser")).thenThrow(new WebApplicationException());
-		thrown.expect(WebApplicationException.class);
-		userMgr.checkAccessForUpdate(xPortalUser);
-	}
-
-	@Test
 	public void test34updateRoleForExternalUsers() {
 		setupRangerUserSyncUser();
 		XXPortalUserDao userDao = Mockito.mock(XXPortalUserDao.class);
-		XXPortalUserRoleDao roleDao = Mockito.mock(XXPortalUserRoleDao.class);
 		XXUserPermissionDao xUserPermissionDao = Mockito.mock(XXUserPermissionDao.class);
 		Collection<String> existingRoleList = new ArrayList<String>();
 		existingRoleList.add(RangerConstants.ROLE_USER);
@@ -1749,13 +1814,11 @@ public class TestUserMgr {
 		xUserPermissionObj.setUserId(userId);
 		xUserPermissionsList.add(xUserPermissionObj);
 		Mockito.when(daoManager.getXXPortalUser()).thenReturn(userDao);
-		Mockito.when(daoManager.getXXPortalUserRole()).thenReturn(roleDao);
-		Mockito.when(roleDao.findByUserId(userId)).thenReturn(list);
 		Mockito.when(userDao.getById(userProfile.getId())).thenReturn(user);
-		Mockito.when(stringUtil.validateEmail(Mockito.anyString())).thenReturn(true);
-		Mockito.doNothing().when(rangerBizUtil).blockAuditorRoleUser();
 		Mockito.when(daoManager.getXXUserPermission()).thenReturn(xUserPermissionDao);
 		Mockito.when(xUserPermissionDao.findByUserPermissionId(userProfile.getId())).thenReturn(xUserPermissionsList);
+		Mockito.when(restErrorUtil.createRESTException(HttpServletResponse.SC_FORBIDDEN, "Logged-In user is not allowed to access requested user data", true)).thenThrow(new WebApplicationException());
+		thrown.expect(WebApplicationException.class);
 		VXPortalUser dbVXPortalUser = userMgr.updateRoleForExternalUsers(reqRoleList,existingRoleList,userProfile);
 		Assert.assertNotNull(dbVXPortalUser);
 		Assert.assertEquals(userId, dbVXPortalUser.getId());
@@ -1822,13 +1885,12 @@ public class TestUserMgr {
 		user.setLoginId(userProfile.getLoginId());
 		userProfile.setFirstName("User");
 		userProfile.setLastName("User");
-		Mockito.when(stringUtil.validateEmail(Mockito.anyString())).thenReturn(true);
 		String encryptedPwd = userMgr.encrypt(userProfile.getLoginId(),userProfile.getPassword());
 		user.setPassword(encryptedPwd);
 		Mockito.when(daoManager.getXXPortalUser()).thenReturn(userDao);
 		Mockito.when(userDao.getById(userProfile.getId())).thenReturn(user);
-		Mockito.doNothing().when(rangerBizUtil).blockAuditorRoleUser();
-		Mockito.when(stringUtil.toCamelCaseAllWords(Mockito.anyString())).thenReturn(userProfile.getFirstName());
+		Mockito.when(restErrorUtil.createRESTException(HttpServletResponse.SC_FORBIDDEN, "Logged-In user is not allowed to access requested user data", true)).thenThrow(new WebApplicationException());
+		thrown.expect(WebApplicationException.class);
 		XXPortalUser dbXXPortalUser = userMgr.updateUser(userProfile);
 		Assert.assertNotNull(dbXXPortalUser);
 		Mockito.when(stringUtil.isEmpty(Mockito.anyString())).thenReturn(true);
@@ -1970,7 +2032,7 @@ public class TestUserMgr {
 		invalidpwdChange.setOldPassword("invalidOldPassword");
 		invalidpwdChange.setEmailAddress(userProfile.getEmailAddress());
 		invalidpwdChange.setUpdPassword(userProfile.getPassword());
-		Mockito.when(restErrorUtil.createRESTException("serverMsg.userMgrOldPassword",MessageEnums.INVALID_INPUT_DATA, null, null, invalidpwdChange.getLoginId())).thenThrow(new WebApplicationException());
+		Mockito.when(restErrorUtil.createRESTException(HttpServletResponse.SC_FORBIDDEN, "Logged-In user is not allowed to access requested user data", true)).thenThrow(new WebApplicationException());
 		thrown.expect(WebApplicationException.class);
 		userMgr.changePassword(invalidpwdChange);
 	}
@@ -1980,8 +2042,8 @@ public class TestUserMgr {
 		destroySession();
 		setupUser();
 		VXPortalUser userProfile = userProfile();
-		XXPortalUser user2 = new XXPortalUser();
-		user2.setId(userId);
+		XXPortalUser gjUser = new XXPortalUser();
+		gjUser.setId(userId);
 		VXPasswordChange invalidpwdChange = new VXPasswordChange();
 		invalidpwdChange.setId(userProfile.getId());
 		invalidpwdChange.setLoginId(userProfile.getLoginId()+1);
@@ -1991,10 +2053,9 @@ public class TestUserMgr {
 
 		XXPortalUserDao userDao = Mockito.mock(XXPortalUserDao.class);
 		Mockito.when(daoManager.getXXPortalUser()).thenReturn(userDao);
-		Mockito.when(userDao.findByLoginId(userProfile.getLoginId())).thenReturn(user2);
-		Mockito.when(userDao.findByLoginId(invalidpwdChange.getLoginId())).thenReturn(null);
+		Mockito.when(userDao.findByLoginId(invalidpwdChange.getLoginId())).thenReturn(gjUser);
 
-		Mockito.when(restErrorUtil.createRESTException("serverMsg.userMgrInvalidUser",MessageEnums.DATA_NOT_FOUND, null, null, invalidpwdChange.getLoginId())).thenThrow(new WebApplicationException());
+		Mockito.when(restErrorUtil.createRESTException(HttpServletResponse.SC_FORBIDDEN, "Logged-In user is not allowed to access requested user data", true)).thenThrow(new WebApplicationException());
 		thrown.expect(WebApplicationException.class);
 		userMgr.changePassword(invalidpwdChange);
 	}
@@ -2024,6 +2085,26 @@ public class TestUserMgr {
 		Mockito.when(stringUtil.equals(Mockito.anyString(), Mockito.nullable(String.class))).thenReturn(true);
 		Mockito.when(daoManager.getXXPortalUser()).thenReturn(userDao);
 		Mockito.when(stringUtil.validatePassword(Mockito.anyString(), Mockito.any(String[].class))).thenReturn(true);
+		Mockito.when(userDao.findByLoginId(Mockito.anyString())).thenReturn(user);
+		XXPortalUserRoleDao xPortalUserRoleDao = Mockito.mock(XXPortalUserRoleDao.class);
+		Mockito.when(daoManager.getXXPortalUserRole()).thenReturn(xPortalUserRoleDao);
+		List<XXPortalUserRole> xPortalUserRoleList = new ArrayList<XXPortalUserRole>();
+		XXPortalUserRole XXPortalUserRole = new XXPortalUserRole();
+		XXPortalUserRole.setId(userId);
+		XXPortalUserRole.setUserId(userId);
+		XXPortalUserRole.setUserRole("ROLE_USER");
+		xPortalUserRoleList.add(XXPortalUserRole);
+		XXUserPermissionDao xUserPermissionDao = Mockito.mock(XXUserPermissionDao.class);
+		XXGroupPermissionDao xGroupPermissionDao = Mockito.mock(XXGroupPermissionDao.class);
+		Mockito.when(daoManager.getXXUserPermission()).thenReturn(xUserPermissionDao);
+		List<XXUserPermission> xUserPermissionsList = new ArrayList<XXUserPermission>();
+		List<XXGroupPermission> xGroupPermissionList = new ArrayList<XXGroupPermission>();
+		Mockito.when(xUserPermissionDao.findByUserPermissionIdAndIsAllowed(userProfile.getId())).thenReturn(xUserPermissionsList);
+		Mockito.when(daoManager.getXXGroupPermission()).thenReturn(xGroupPermissionDao);
+		Mockito.when(xGroupPermissionDao.findbyVXPortalUserId(userProfile.getId())).thenReturn(xGroupPermissionList);
+		XXPortalUserRoleDao roleDao = Mockito.mock(XXPortalUserRoleDao.class);
+		Mockito.when(daoManager.getXXPortalUserRole()).thenReturn(roleDao);
+		Mockito.when(roleDao.findByParentId(Mockito.anyLong())).thenReturn(xPortalUserRoleList);
 		Mockito.when(restErrorUtil.createRESTException("serverMsg.userMgrOldPassword",MessageEnums.INVALID_INPUT_DATA, user.getId(), "password", user.toString())).thenThrow(new WebApplicationException());
 		thrown.expect(WebApplicationException.class);
 		userMgr.changePassword(pwdChange);
@@ -2053,6 +2134,26 @@ public class TestUserMgr {
 		Mockito.when(stringUtil.equals(Mockito.anyString(), Mockito.nullable(String.class))).thenReturn(true);
 		Mockito.when(daoManager.getXXPortalUser()).thenReturn(userDao);
 		Mockito.when(stringUtil.validatePassword(Mockito.anyString(), Mockito.any(String[].class))).thenReturn(false);
+		Mockito.when(userDao.findByLoginId(Mockito.anyString())).thenReturn(user);
+		XXPortalUserRoleDao xPortalUserRoleDao = Mockito.mock(XXPortalUserRoleDao.class);
+		Mockito.when(daoManager.getXXPortalUserRole()).thenReturn(xPortalUserRoleDao);
+		List<XXPortalUserRole> xPortalUserRoleList = new ArrayList<XXPortalUserRole>();
+		XXPortalUserRole XXPortalUserRole = new XXPortalUserRole();
+		XXPortalUserRole.setId(userId);
+		XXPortalUserRole.setUserId(userId);
+		XXPortalUserRole.setUserRole("ROLE_USER");
+		xPortalUserRoleList.add(XXPortalUserRole);
+		XXUserPermissionDao xUserPermissionDao = Mockito.mock(XXUserPermissionDao.class);
+		XXGroupPermissionDao xGroupPermissionDao = Mockito.mock(XXGroupPermissionDao.class);
+		Mockito.when(daoManager.getXXUserPermission()).thenReturn(xUserPermissionDao);
+		List<XXUserPermission> xUserPermissionsList = new ArrayList<XXUserPermission>();
+		List<XXGroupPermission> xGroupPermissionList = new ArrayList<XXGroupPermission>();
+		Mockito.when(xUserPermissionDao.findByUserPermissionIdAndIsAllowed(userProfile.getId())).thenReturn(xUserPermissionsList);
+		Mockito.when(daoManager.getXXGroupPermission()).thenReturn(xGroupPermissionDao);
+		Mockito.when(xGroupPermissionDao.findbyVXPortalUserId(userProfile.getId())).thenReturn(xGroupPermissionList);
+		XXPortalUserRoleDao roleDao = Mockito.mock(XXPortalUserRoleDao.class);
+		Mockito.when(daoManager.getXXPortalUserRole()).thenReturn(roleDao);
+		Mockito.when(roleDao.findByParentId(Mockito.anyLong())).thenReturn(xPortalUserRoleList);
 		Mockito.when(restErrorUtil.createRESTException("serverMsg.userMgrNewPassword",MessageEnums.INVALID_PASSWORD, null, null, pwdChange.getLoginId())).thenThrow(new WebApplicationException());
 		thrown.expect(WebApplicationException.class);
 		userMgr.changePassword(pwdChange);
@@ -2139,10 +2240,7 @@ public class TestUserMgr {
 		user.setPassword(encryptedPwd);
 		Mockito.when(daoManager.getXXPortalUser()).thenReturn(userDao);
 		Mockito.when(userDao.getById(userProfile.getId())).thenReturn(user);
-		Mockito.when(stringUtil.validateEmail(Mockito.anyString())).thenReturn(true);
-		Mockito.doNothing().when(rangerBizUtil).blockAuditorRoleUser();
-		Mockito.when(stringUtil.validatePassword(Mockito.anyString(), Mockito.any(String[].class))).thenReturn(false);
-		Mockito.when(restErrorUtil.createRESTException("serverMsg.userMgrNewPassword", MessageEnums.INVALID_PASSWORD, null, null, user.getId().toString())).thenThrow(new WebApplicationException());
+		Mockito.when(restErrorUtil.createRESTException(HttpServletResponse.SC_FORBIDDEN, "Logged-In user is not allowed to access requested user data", true)).thenThrow(new WebApplicationException());
 		thrown.expect(WebApplicationException.class);
 		userMgr.updateUserWithPass(userProfile);
 	}

--- a/security-admin/src/test/java/org/apache/ranger/biz/TestXUserMgr.java
+++ b/security-admin/src/test/java/org/apache/ranger/biz/TestXUserMgr.java
@@ -107,7 +107,6 @@ import org.apache.ranger.ugsyncutil.model.UsersGroupRoleAssignments;
 import org.apache.ranger.view.VXAuditMap;
 import org.apache.ranger.view.VXAuditMapList;
 import org.apache.ranger.view.VXGroup;
-import org.apache.ranger.view.VXGroupGroup;
 import org.apache.ranger.view.VXGroupList;
 import org.apache.ranger.view.VXGroupPermission;
 import org.apache.ranger.view.VXGroupUser;
@@ -418,15 +417,6 @@ public class TestXUserMgr {
 		return vxGroupUser;
 	}
 
-	private VXGroupGroup vxGroupGroup(){
-		VXGroupGroup vXGroupGroup = new VXGroupGroup();
-		vXGroupGroup.setId(userId);
-		vXGroupGroup.setName("group user test");
-		vXGroupGroup.setOwner("Admin");
-		vXGroupGroup.setUpdatedBy("User");
-		return vXGroupGroup;
-	}
-
 	private XXGroupGroup xxGroupGroup(){
 		XXGroupGroup xXGroupGroup = new XXGroupGroup();
 		xXGroupGroup.setId(userId);
@@ -643,7 +633,8 @@ public class TestXUserMgr {
 		loggedInUser.setName("testuser");
 		loggedInUser.setUserRoleList(loggedInUserRole);
 		Mockito.when(xUserService.getXUserByUserName("admin")).thenReturn(loggedInUser);
-		
+		Mockito.when(restErrorUtil.createRESTException(HttpServletResponse.SC_FORBIDDEN, "Logged-In user is not allowed to access requested user data", true)).thenThrow(new WebApplicationException());
+		thrown.expect(WebApplicationException.class);
 		VXUser dbvxUser = xUserMgr.getXUser(userId);
 		Mockito.verify(userMgr).createDefaultAccountUser((VXPortalUser) Mockito.any());
 		Assert.assertNotNull(dbvxUser);
@@ -785,6 +776,13 @@ public class TestXUserMgr {
 		VXUserPermission vXUserPermission = vxUserPermission();
 		Mockito.when(xUserPermissionService.createResource((VXUserPermission) Mockito.any())).thenReturn(vXUserPermission);
 		Mockito.when(sessionMgr.getActiveUserSessionsForPortalUserId(userId)).thenReturn(userSessions);
+		VXUser loggedInUser = vxUser();
+		List<String> loggedInUserRole = new ArrayList<String>();
+		loggedInUserRole.add(RangerConstants.ROLE_SYS_ADMIN);
+		loggedInUser.setId(8L);
+		loggedInUser.setName("testuser");
+		loggedInUser.setUserRoleList(loggedInUserRole);
+		Mockito.when(xUserService.getXUserByUserName("admin")).thenReturn(loggedInUser);
 		VXUser dbvxUser = xUserMgr.updateXUser(vxUser);
 		Assert.assertNotNull(dbvxUser);
 		Assert.assertEquals(dbvxUser.getId(), vxUser.getId());
@@ -1117,8 +1115,6 @@ public class TestXUserMgr {
 		List<XXGroupGroup> xXGroupGroups = new ArrayList<XXGroupGroup>();
 		XXGroupGroup xXGroupGroup = xxGroupGroup();
 		xXGroupGroups.add(xXGroupGroup);
-		Mockito.when(daoManager.getXXGroupGroup()).thenReturn(xXGroupGroupDao);
-		Mockito.when(xXGroupGroupDao.findByGroupId(userId)).thenReturn(xXGroupGroups);
 		XXGroupPermissionDao xXGroupPermissionDao= Mockito.mock(XXGroupPermissionDao.class);
 		Mockito.when(daoManager.getXXGroupPermission()).thenReturn(xXGroupPermissionDao);
 		List<XXGroupPermission> xXGroupPermissions=new ArrayList<XXGroupPermission>();
@@ -1678,9 +1674,7 @@ public class TestXUserMgr {
 	@Test
 	public void test37setUserRolesByExternalID() {
 		setup();
-		XXPortalUserRoleDao xPortalUserRoleDao = Mockito.mock(XXPortalUserRoleDao.class);
 		VXUser vXUser = vxUser();
-		VXPortalUser userProfile = userProfile();
 		List<VXString> vStringRolesList = new ArrayList<VXString>();
 		VXString vXStringObj = new VXString();
 		vXStringObj.setValue("ROLE_USER");
@@ -1700,10 +1694,7 @@ public class TestXUserMgr {
 		List<VXGroupPermission> groupPermList = new ArrayList<VXGroupPermission>();
 		VXGroupPermission groupPermission = vxGroupPermission();
 		groupPermList.add(groupPermission);
-		Mockito.when(daoManager.getXXPortalUserRole()).thenReturn(xPortalUserRoleDao);
-		Mockito.when(xPortalUserRoleDao.findByUserId(userId)).thenReturn(xPortalUserRoleList);
 		Mockito.when(xUserMgr.getXUser(userId)).thenReturn(vXUser);
-		Mockito.when(userMgr.getUserProfileByLoginId(vXUser.getName())).thenReturn(userProfile);
 		
 		List<String> permissionList = new ArrayList<String>();
 		permissionList.add(RangerConstants.MODULE_USER_GROUPS);
@@ -1715,11 +1706,9 @@ public class TestXUserMgr {
 		loggedInUser.setName("testuser");
 		loggedInUser.setUserRoleList(loggedInUserRole);
 		Mockito.when(xUserService.getXUserByUserName("admin")).thenReturn(loggedInUser);
-		
-		XXModuleDefDao mockxxModuleDefDao = Mockito.mock(XXModuleDefDao.class);
-		Mockito.when(daoManager.getXXModuleDef()).thenReturn(mockxxModuleDefDao);
-		Mockito.when(mockxxModuleDefDao.findAccessibleModulesByUserId(8L, 8L)).thenReturn(permissionList);
-		
+
+		Mockito.when(restErrorUtil.createRESTException(HttpServletResponse.SC_FORBIDDEN, "Logged-In user is not allowed to access requested user data", true)).thenThrow(new WebApplicationException());
+		thrown.expect(WebApplicationException.class);
 		VXStringList vXStringList = xUserMgr.setUserRolesByExternalID(userId,vStringRolesList);
 		Assert.assertNotNull(vXStringList);
 	}
@@ -1749,7 +1738,6 @@ public class TestXUserMgr {
 		VXGroupPermission groupPermission = vxGroupPermission();
 		groupPermList.add(groupPermission);
 		Mockito.when(xUserMgr.getXUser(userId)).thenReturn(vXUser);
-		Mockito.when(userMgr.getUserProfileByLoginId(vXUser.getName())).thenReturn(null);
 		
 		List<String> permissionList = new ArrayList<String>();
 		permissionList.add(RangerConstants.MODULE_USER_GROUPS);
@@ -1761,12 +1749,8 @@ public class TestXUserMgr {
 		loggedInUser.setName("testuser");
 		loggedInUser.setUserRoleList(loggedInUserRole);
 		Mockito.when(xUserService.getXUserByUserName("admin")).thenReturn(loggedInUser);
-		
-		XXModuleDefDao mockxxModuleDefDao = Mockito.mock(XXModuleDefDao.class);
-		Mockito.when(daoManager.getXXModuleDef()).thenReturn(mockxxModuleDefDao);
-		Mockito.when(mockxxModuleDefDao.findAccessibleModulesByUserId(8L, 8L)).thenReturn(permissionList);
-		
-		Mockito.when(restErrorUtil.createRESTException("User ID doesn't exist.",MessageEnums.INVALID_INPUT_DATA)).thenThrow(new WebApplicationException());
+
+		Mockito.when(restErrorUtil.createRESTException(HttpServletResponse.SC_FORBIDDEN, "Logged-In user is not allowed to access requested user data", true)).thenThrow(new WebApplicationException());
 		thrown.expect(WebApplicationException.class);
 		xUserMgr.setUserRolesByExternalID(userId, vStringRolesList);
 	}
@@ -1806,7 +1790,6 @@ public class TestXUserMgr {
 	public void test40setUserRolesByName() {
 		destroySession();
 		setup();
-		XXPortalUserRoleDao xPortalUserRoleDao = Mockito.mock(XXPortalUserRoleDao.class);
 		VXPortalUser userProfile = userProfile();
 		List<VXString> vStringRolesList = new ArrayList<VXString>();
 		VXString vXStringObj = new VXString();
@@ -1827,13 +1810,10 @@ public class TestXUserMgr {
 		List<VXGroupPermission> groupPermList = new ArrayList<VXGroupPermission>();
 		VXGroupPermission groupPermission = vxGroupPermission();
 		groupPermList.add(groupPermission);
-		Mockito.when(daoManager.getXXPortalUserRole()).thenReturn(xPortalUserRoleDao);
-		Mockito.when(xPortalUserRoleDao.findByUserId(userId)).thenReturn(xPortalUserRoleList);
-		Mockito.when(userMgr.getUserProfileByLoginId(userProfile.getLoginId())).thenReturn(userProfile);
-		VXStringList vXStringList = xUserMgr.setUserRolesByName(userProfile.getLoginId(), vStringRolesList);
-		Assert.assertNotNull(vXStringList);
 		Mockito.when(restErrorUtil.createRESTException("Login ID doesn't exist.",MessageEnums.INVALID_INPUT_DATA)).thenThrow(new WebApplicationException());
 		thrown.expect(WebApplicationException.class);
+		VXStringList vXStringList = xUserMgr.setUserRolesByName(userProfile.getLoginId(), vStringRolesList);
+		Assert.assertNotNull(vXStringList);
 		xUserMgr.setUserRolesByName(null, vStringRolesList);
 	}
 
@@ -1841,7 +1821,6 @@ public class TestXUserMgr {
 	public void test41setUserRolesByName() {
 		destroySession();
 		setup();
-		XXPortalUserRoleDao xPortalUserRoleDao = Mockito.mock(XXPortalUserRoleDao.class);
 		VXPortalUser userProfile = userProfile();
 		List<VXString> vStringRolesList = new ArrayList<VXString>();
 		VXString vXStringObj = new VXString();
@@ -1862,13 +1841,10 @@ public class TestXUserMgr {
 		List<VXGroupPermission> groupPermList = new ArrayList<VXGroupPermission>();
 		VXGroupPermission groupPermission = vxGroupPermission();
 		groupPermList.add(groupPermission);
-		Mockito.when(daoManager.getXXPortalUserRole()).thenReturn(xPortalUserRoleDao);
-		Mockito.when(xPortalUserRoleDao.findByUserId(userId)).thenReturn(xPortalUserRoleList);
-		Mockito.when(userMgr.getUserProfileByLoginId(userProfile.getLoginId())).thenReturn(userProfile);
-		VXStringList vXStringList = xUserMgr.setUserRolesByName(userProfile.getLoginId(), vStringRolesList);
-		Assert.assertNotNull(vXStringList);
 		Mockito.when(restErrorUtil.createRESTException("Login ID doesn't exist.",MessageEnums.INVALID_INPUT_DATA)).thenThrow(new WebApplicationException());
 		thrown.expect(WebApplicationException.class);
+		VXStringList vXStringList = xUserMgr.setUserRolesByName(userProfile.getLoginId(), vStringRolesList);
+		Assert.assertNotNull(vXStringList);
 		xUserMgr.setUserRolesByName(null, vStringRolesList);
 	}
 
@@ -1876,9 +1852,7 @@ public class TestXUserMgr {
 	public void test42getUserRolesByExternalID() {
 		destroySession();
 		setup();
-		XXPortalUserRoleDao xPortalUserRoleDao = Mockito.mock(XXPortalUserRoleDao.class);
 		VXUser vXUser = vxUser();
-		VXPortalUser userProfile = userProfile();
 		List<VXString> vStringRolesList = new ArrayList<VXString>();
 		VXString vXStringObj = new VXString();
 		vXStringObj.setValue("ROLE_USER");
@@ -1898,10 +1872,7 @@ public class TestXUserMgr {
 		List<VXGroupPermission> groupPermList = new ArrayList<VXGroupPermission>();
 		VXGroupPermission groupPermission = vxGroupPermission();
 		groupPermList.add(groupPermission);
-		Mockito.when(daoManager.getXXPortalUserRole()).thenReturn(xPortalUserRoleDao);
-		Mockito.when(xPortalUserRoleDao.findByUserId(userId)).thenReturn(xPortalUserRoleList);
 		Mockito.when(xUserMgr.getXUser(userId)).thenReturn(vXUser);
-		Mockito.when(userMgr.getUserProfileByLoginId(vXUser.getName())).thenReturn(userProfile);
 		
 		List<String> permissionList = new ArrayList<String>();
 		permissionList.add(RangerConstants.MODULE_USER_GROUPS);
@@ -1913,11 +1884,8 @@ public class TestXUserMgr {
 		loggedInUser.setName("testuser");
 		loggedInUser.setUserRoleList(loggedInUserRole);
 		Mockito.when(xUserService.getXUserByUserName("admin")).thenReturn(loggedInUser);
-		
-		XXModuleDefDao mockxxModuleDefDao = Mockito.mock(XXModuleDefDao.class);
-		Mockito.when(daoManager.getXXModuleDef()).thenReturn(mockxxModuleDefDao);
-		Mockito.when(mockxxModuleDefDao.findAccessibleModulesByUserId(8L, 8L)).thenReturn(permissionList);
-		
+		Mockito.when(restErrorUtil.createRESTException(HttpServletResponse.SC_FORBIDDEN, "Logged-In user is not allowed to access requested user data", true)).thenThrow(new WebApplicationException());
+		thrown.expect(WebApplicationException.class);
 		VXStringList vXStringList = xUserMgr.getUserRolesByExternalID(userId);
 		Assert.assertNotNull(vXStringList);
 		Mockito.when(restErrorUtil.createRESTException("Please provide a valid ID",MessageEnums.INVALID_INPUT_DATA)).thenThrow(new WebApplicationException());
@@ -1930,9 +1898,7 @@ public class TestXUserMgr {
 	public void test43getUserRolesByExternalID() {
 		destroySession();
 		setup();
-		XXPortalUserRoleDao xPortalUserRoleDao = Mockito.mock(XXPortalUserRoleDao.class);
 		VXUser vXUser = vxUser();
-		VXPortalUser userProfile = userProfile();
 		List<VXString> vStringRolesList = new ArrayList<VXString>();
 		VXString vXStringObj = new VXString();
 		vXStringObj.setValue("ROLE_USER");
@@ -1952,10 +1918,7 @@ public class TestXUserMgr {
 		List<VXGroupPermission> groupPermList = new ArrayList<VXGroupPermission>();
 		VXGroupPermission groupPermission = vxGroupPermission();
 		groupPermList.add(groupPermission);
-		Mockito.when(daoManager.getXXPortalUserRole()).thenReturn(xPortalUserRoleDao);
-		Mockito.when(xPortalUserRoleDao.findByUserId(userId)).thenReturn(xPortalUserRoleList);
 		Mockito.when(xUserMgr.getXUser(userId)).thenReturn(vXUser);
-		Mockito.when(userMgr.getUserProfileByLoginId(vXUser.getName())).thenReturn(userProfile);
 		
 		List<String> permissionList = new ArrayList<String>();
 		permissionList.add(RangerConstants.MODULE_USER_GROUPS);
@@ -1967,11 +1930,8 @@ public class TestXUserMgr {
 		loggedInUser.setName("testuser");
 		loggedInUser.setUserRoleList(loggedInUserRole);
 		Mockito.when(xUserService.getXUserByUserName("admin")).thenReturn(loggedInUser);
-		
-		XXModuleDefDao mockxxModuleDefDao = Mockito.mock(XXModuleDefDao.class);
-		Mockito.when(daoManager.getXXModuleDef()).thenReturn(mockxxModuleDefDao);
-		Mockito.when(mockxxModuleDefDao.findAccessibleModulesByUserId(8L, 8L)).thenReturn(permissionList);
-		
+		Mockito.when(restErrorUtil.createRESTException(HttpServletResponse.SC_FORBIDDEN, "Logged-In user is not allowed to access requested user data", true)).thenThrow(new WebApplicationException());
+		thrown.expect(WebApplicationException.class);
 		VXStringList vXStringList = xUserMgr.getUserRolesByExternalID(userId);
 		Assert.assertNotNull(vXStringList);
 		Mockito.when(restErrorUtil.createRESTException("User ID doesn't exist.",MessageEnums.INVALID_INPUT_DATA)).thenThrow(new WebApplicationException());
@@ -2011,6 +1971,15 @@ public class TestXUserMgr {
 		Mockito.when(daoManager.getXXPortalUserRole()).thenReturn(xPortalUserRoleDao);
 		Mockito.when(xPortalUserRoleDao.findByUserId(userId)).thenReturn(xPortalUserRoleList);
 		Mockito.when(userMgr.getUserProfileByLoginId(userProfile.getLoginId())).thenReturn(userProfile);
+		VXUser loggedInUser = vxUser();
+		List<String> loggedInUserRole = new ArrayList<String>();
+		loggedInUserRole.add(RangerConstants.ROLE_SYS_ADMIN);
+		loggedInUser.setId(8L);
+		loggedInUser.setName("admin");
+		loggedInUser.setUserRoleList(loggedInUserRole);
+		Mockito.when(xUserService.getXUserByUserName("admin")).thenReturn(loggedInUser);
+		VXUser testuser = vxUser();
+		Mockito.when(xUserService.getXUserByUserName("testuser")).thenReturn(testuser);
 		VXStringList vXStringList = xUserMgr.getUserRolesByName(userProfile.getLoginId());
 		Assert.assertNotNull(vXStringList);
 		Mockito.when(restErrorUtil.createRESTException("Please provide a valid userName",MessageEnums.INVALID_INPUT_DATA)).thenThrow(new WebApplicationException());
@@ -2050,6 +2019,15 @@ public class TestXUserMgr {
 		Mockito.when(daoManager.getXXPortalUserRole()).thenReturn(xPortalUserRoleDao);
 		Mockito.when(xPortalUserRoleDao.findByUserId(userId)).thenReturn(xPortalUserRoleList);
 		Mockito.when(userMgr.getUserProfileByLoginId(userProfile.getLoginId())).thenReturn(userProfile);
+		VXUser loggedInUser = vxUser();
+		List<String> loggedInUserRole = new ArrayList<String>();
+		loggedInUserRole.add(RangerConstants.ROLE_SYS_ADMIN);
+		loggedInUser.setId(8L);
+		loggedInUser.setName("admin");
+		loggedInUser.setUserRoleList(loggedInUserRole);
+		Mockito.when(xUserService.getXUserByUserName("admin")).thenReturn(loggedInUser);
+		VXUser testuser = vxUser();
+		Mockito.when(xUserService.getXUserByUserName("testuser")).thenReturn(testuser);
 		VXStringList vXStringList = xUserMgr.getUserRolesByName(userProfile.getLoginId());
 		Assert.assertNotNull(vXStringList);
 		Mockito.when(restErrorUtil.createRESTException("Please provide a valid userName",MessageEnums.INVALID_INPUT_DATA)).thenThrow(new WebApplicationException());
@@ -2077,10 +2055,6 @@ public class TestXUserMgr {
 		testSearchCriteria.addParam("name", userName);
 		Mockito.when(xUserService.getXUserByUserName(userName)).thenReturn(vxUser);
 		Mockito.when(xUserService.searchXUsers(testSearchCriteria)).thenReturn(vXUserListSort);
-		VXGroupUserList vxGroupUserList = vxGroupUserList();
-		Mockito.when(xGroupUserService.searchXGroupUsers((SearchCriteria) Mockito.any())).thenReturn(vxGroupUserList);
-		VXGroup group = vxGroup();
-		Mockito.when(xGroupService.readResource(Mockito.anyLong())).thenReturn(group);
 		VXUserList dbVXUserList = xUserMgr.searchXUsers(testSearchCriteria);
 		Assert.assertNotNull(dbVXUserList);
 		testSearchCriteria.addParam("isvisible", "true");
@@ -2374,45 +2348,6 @@ public class TestXUserMgr {
 	}
 
 	@Test
-	public void test56createXGroupGroup() {
-		setup();
-		VXUser vxUser = vxUser();
-		vxUser.setUserSource(RangerCommonEnums.USER_EXTERNAL);
-		VXGroupGroup vXGroupGroup = vxGroupGroup();
-		Mockito.when(xGroupGroupService.createResource((VXGroupGroup) Mockito.any())).thenReturn(vXGroupGroup);
-		VXGroupGroup dbvXGroupGroup = xUserMgr.createXGroupGroup(vXGroupGroup);
-		Assert.assertNotNull(dbvXGroupGroup);
-		Assert.assertEquals(dbvXGroupGroup.getId(), vXGroupGroup.getId());
-		Assert.assertEquals(dbvXGroupGroup.getName(), vXGroupGroup.getName());
-		Mockito.verify(xGroupGroupService).createResource((VXGroupGroup) Mockito.any());
-	}
-
-	@Test
-	public void test57updateXGroupGroup() {
-		setup();
-		VXUser vxUser = vxUser();
-		vxUser.setUserSource(RangerCommonEnums.USER_EXTERNAL);
-		VXGroupGroup vXGroupGroup = vxGroupGroup();
-		Mockito.when(xGroupGroupService.updateResource((VXGroupGroup) Mockito.any())).thenReturn(vXGroupGroup);
-		VXGroupGroup dbvXGroupGroup = xUserMgr.updateXGroupGroup(vXGroupGroup);
-		Assert.assertNotNull(dbvXGroupGroup);
-		Assert.assertEquals(dbvXGroupGroup.getId(), vXGroupGroup.getId());
-		Assert.assertEquals(dbvXGroupGroup.getName(), vXGroupGroup.getName());
-		Mockito.verify(xGroupGroupService).updateResource((VXGroupGroup) Mockito.any());
-	}
-
-	@Test
-	public void test58deleteXGroupGroup() {
-		setup();
-		VXUser vxUser = vxUser();
-		vxUser.setUserSource(RangerCommonEnums.USER_EXTERNAL);
-		VXGroupGroup vXGroupGroup = vxGroupGroup();
-		Mockito.when(xGroupGroupService.deleteResource((Long) Mockito.any())).thenReturn(true);
-		xUserMgr.deleteXGroupGroup(vXGroupGroup.getId(),true);
-		Mockito.verify(xGroupGroupService).deleteResource((Long) Mockito.any());
-	}
-
-	@Test
 	public void test59deleteXGroupUser() {
 		setup();
 		VXUser vxUser = vxUser();
@@ -2477,10 +2412,6 @@ public class TestXUserMgr {
 		testSearchCriteria.addParam("name", userName);
 		Mockito.when(xUserService.getXUserByUserName(userName)).thenReturn(vxUser);
 		Mockito.when(xUserService.searchXUsers(testSearchCriteria)).thenReturn(vXUserListSort);
-		VXGroupUserList vxGroupUserList = vxGroupUserList();
-		Mockito.when(xGroupUserService.searchXGroupUsers((SearchCriteria) Mockito.any())).thenReturn(vxGroupUserList);
-		VXGroup vXGroup = vxGroup();
-		Mockito.when(xGroupService.readResource(Mockito.anyLong())).thenReturn(vXGroup);
 		VXUserList dbVXUserList = xUserMgr.searchXUsers(testSearchCriteria);
 		Assert.assertNotNull(dbVXUserList);
 		testSearchCriteria.addParam("isvisible", "true");
@@ -2647,6 +2578,13 @@ public class TestXUserMgr {
 		UserSessionBase userSession = Mockito.mock(UserSessionBase.class);
 		Set<UserSessionBase> userSessions = new HashSet<UserSessionBase>();
 		userSessions.add(userSession);
+		VXUser loggedInUser = vxUser();
+		List<String> loggedInUserRole = new ArrayList<String>();
+		loggedInUserRole.add(RangerConstants.ROLE_SYS_ADMIN);
+		loggedInUser.setId(8L);
+		loggedInUser.setName("testuser");
+		loggedInUser.setUserRoleList(loggedInUserRole);
+		Mockito.when(xUserService.getXUserByUserName("admin")).thenReturn(loggedInUser);
 		VXUser dbvxUser = xUserMgr.updateXUser(vxUser);
 		Assert.assertNotNull(dbvxUser);
 		Assert.assertEquals(dbvxUser.getId(), vxUser.getId());
@@ -2777,18 +2715,25 @@ public class TestXUserMgr {
 	public void test78checkAccess() {
 		destroySession();
 		setupUser();
+		VXUser vxUser = vxUser();
 		Mockito.when(restErrorUtil.create403RESTException(Mockito.anyString())).thenThrow(new WebApplicationException());
 		thrown.expect(WebApplicationException.class);
-		xUserMgr.checkAccess("testuser2");
+		xUserMgr.checkAccess(vxUser);
 	}
 
 	@Test
 	public void test79checkAccess() {
 		destroySession();
+		VXUser vxUser = vxUser();
+		VXUser loggedInUser = vxUser();
+		List<String> loggedInUserRole = new ArrayList<String>();
+		loggedInUserRole.add(RangerConstants.ROLE_SYS_ADMIN);
+		loggedInUser.setId(8L);
+		loggedInUser.setName("admin");
+		loggedInUser.setUserRoleList(loggedInUserRole);
 		Mockito.when(restErrorUtil.generateRESTException((VXResponse)Mockito.any())).thenThrow(new WebApplicationException());
 		thrown.expect(WebApplicationException.class);
-		VXPortalUser vXPortalUser = userProfile();
-		xUserMgr.checkAccess(vXPortalUser.getLoginId());
+		xUserMgr.checkAccess(vxUser);
 	}
 
 	@Test
@@ -3133,8 +3078,6 @@ public class TestXUserMgr {
 		vXAuditMaps.add(vXAuditMap);
 		XXGroupGroupDao xXGroupGroupDao = Mockito.mock(XXGroupGroupDao.class);
 		List<XXGroupGroup> xXGroupGroups = new ArrayList<XXGroupGroup>();
-		Mockito.when(daoManager.getXXGroupGroup()).thenReturn(xXGroupGroupDao);
-		Mockito.when(xXGroupGroupDao.findByGroupId(userId)).thenReturn(xXGroupGroups);
 		XXGroupPermissionDao xXGroupPermissionDao= Mockito.mock(XXGroupPermissionDao.class);
 		Mockito.when(daoManager.getXXGroupPermission()).thenReturn(xXGroupPermissionDao);
 		List<XXGroupPermission> xXGroupPermissions=new ArrayList<XXGroupPermission>();
@@ -3174,9 +3117,7 @@ public class TestXUserMgr {
 		Mockito.when(xAuditMapService.searchXAuditMaps((SearchCriteria) Mockito.any())).thenReturn(new VXAuditMapList());
 		XXGroupGroup xXGroupGroup = xxGroupGroup();
 		xXGroupGroups.add(xXGroupGroup);
-		Mockito.when(xXGroupGroupDao.findByGroupId(userId)).thenReturn(xXGroupGroups);
 		xUserMgr.deleteXGroup(vXGroup.getId(), force);
-		Mockito.when(xXGroupGroupDao.findByGroupId(userId)).thenReturn(new ArrayList<XXGroupGroup>());
 		XXGroupPermission xGroupPermissionObj = xxGroupPermission();
 		xXGroupPermissions.add(xGroupPermissionObj);
 		Mockito.when(xXGroupPermissionDao.findByGroupId(vXGroup.getId())).thenReturn(xXGroupPermissions);
@@ -3396,7 +3337,7 @@ public class TestXUserMgr {
 		vxUser.setUserSource(RangerCommonEnums.USER_UNIX);
 		Mockito.when(xUserService.readResourceWithOutLogin(5L)).thenReturn(vxUser);
 		Mockito.when(xUserService.getXUserByUserName("testuser")).thenReturn(loggedInUser);
-		Mockito.when(restErrorUtil.create403RESTException("Logged-In user is not allowed to access requested user data.")).thenThrow(new WebApplicationException());
+		Mockito.when(restErrorUtil.createRESTException(HttpServletResponse.SC_FORBIDDEN, "Logged-In user is not allowed to access requested user data", true)).thenThrow(new WebApplicationException());
 		thrown.expect(WebApplicationException.class);
 		xUserMgr.getXUser(5L);
 	}
@@ -3431,7 +3372,7 @@ public class TestXUserMgr {
 		vxUser.setUserSource(RangerCommonEnums.USER_UNIX);
 		Mockito.when(xUserService.readResourceWithOutLogin(5L)).thenReturn(vxUser);
 		Mockito.when(xUserService.getXUserByUserName("testuser")).thenReturn(loggedInUser);
-		Mockito.when(restErrorUtil.create403RESTException("Logged-In user is not allowed to access requested user data.")).thenThrow(new WebApplicationException());
+		Mockito.when(restErrorUtil.createRESTException(HttpServletResponse.SC_FORBIDDEN, "Logged-In user is not allowed to access requested user data", true)).thenThrow(new WebApplicationException());
 		thrown.expect(WebApplicationException.class);
 		xUserMgr.getXUser(5L);
 	}
@@ -3466,7 +3407,7 @@ public class TestXUserMgr {
 		vxUser.setUserSource(RangerCommonEnums.USER_UNIX);
 		Mockito.when(xUserService.readResourceWithOutLogin(5L)).thenReturn(vxUser);
 		Mockito.when(xUserService.getXUserByUserName("testuser")).thenReturn(loggedInUser);
-		Mockito.when(restErrorUtil.create403RESTException("Logged-In user is not allowed to access requested user data.")).thenThrow(new WebApplicationException());
+		Mockito.when(restErrorUtil.createRESTException(HttpServletResponse.SC_FORBIDDEN, "Logged-In user is not allowed to access requested user data", true)).thenThrow(new WebApplicationException());
 		thrown.expect(WebApplicationException.class);
 		xUserMgr.getXUser(5L);
 	}
@@ -3501,7 +3442,7 @@ public class TestXUserMgr {
 		vxUser.setUserSource(RangerCommonEnums.USER_UNIX);
 		Mockito.when(xUserService.readResourceWithOutLogin(5L)).thenReturn(vxUser);
 		Mockito.when(xUserService.getXUserByUserName("testuser")).thenReturn(loggedInUser);
-		Mockito.when(restErrorUtil.create403RESTException("Logged-In user is not allowed to access requested user data.")).thenThrow(new WebApplicationException());
+		Mockito.when(restErrorUtil.createRESTException(HttpServletResponse.SC_FORBIDDEN, "Logged-In user is not allowed to access requested user data", true)).thenThrow(new WebApplicationException());
 		thrown.expect(WebApplicationException.class);
 		xUserMgr.getXUser(5L);
 	}
@@ -3546,7 +3487,7 @@ public class TestXUserMgr {
 		Assert.assertNotNull(expectedVXUser);
 		Assert.assertEquals(expectedVXUser.getName(), vxUser.getName());
 		destroySession();
-		Mockito.when(restErrorUtil.create403RESTException("Logged-In user is not allowed to access requested user data.")).thenThrow(new WebApplicationException());
+		Mockito.when(restErrorUtil.createRESTException(HttpServletResponse.SC_FORBIDDEN, "Logged-In user is not allowed to access requested user data", true)).thenThrow(new WebApplicationException());
 		thrown.expect(WebApplicationException.class);
 		xUserMgr.getXUser(8L);
 	}
@@ -3863,6 +3804,14 @@ public class TestXUserMgr {
 		Mockito.when(xUserPermissionDao.findByModuleIdAndPortalUserId(null, null)).thenReturn(xUserPermissionObj);
 		Mockito.when(xUserPermissionService.populateViewBean(xUserPermissionObj)).thenReturn(userPermission);
 		Mockito.when(xUserPermissionService.updateResource((VXUserPermission) Mockito.any())).thenReturn(userPermission);
+		Mockito.when(daoManager.getXXPortalUser()).thenReturn(xXPortalUserDao);
+		VXUser loggedInUser = vxUser();
+		List<String> loggedInUserRole = new ArrayList<String>();
+		loggedInUserRole.add(RangerConstants.ROLE_SYS_ADMIN);
+		loggedInUser.setId(8L);
+		loggedInUser.setName("testuser");
+		loggedInUser.setUserRoleList(loggedInUserRole);
+		Mockito.when(xUserService.getXUserByUserName("admin")).thenReturn(loggedInUser);
 		int createdOrUpdatedUserCount = xUserMgr.createOrUpdateXUsers(users);
 		Assert.assertEquals(createdOrUpdatedUserCount, 1);
 	}
@@ -3923,6 +3872,14 @@ public class TestXUserMgr {
 		Mockito.when(xUserService.createResource((VXUser) Mockito.any())).thenReturn(vXUser);
 		Mockito.when(xUserPermissionService.populateViewBean(xUserPermissionObj)).thenReturn(userPermission);
 		Mockito.when(xUserPermissionService.updateResource((VXUserPermission) Mockito.any())).thenReturn(userPermission);
+		Mockito.when(daoManager.getXXPortalUser()).thenReturn(userDao);
+		VXUser loggedInUser = vxUser();
+		List<String> loggedInUserRole = new ArrayList<String>();
+		loggedInUserRole.add(RangerConstants.ROLE_SYS_ADMIN);
+		loggedInUser.setId(8L);
+		loggedInUser.setName("testuser");
+		loggedInUser.setUserRoleList(loggedInUserRole);
+		Mockito.when(xUserService.getXUserByUserName("admin")).thenReturn(loggedInUser);
 		xUserMgr.createOrUpdateXUsers(users);
 
 		vXUser.setPassword("*****");
@@ -3974,6 +3931,13 @@ public class TestXUserMgr {
 		xUserPermissionObj.setUserId(userId);
 		xUserPermissionsList.add(xUserPermissionObj);
 		Mockito.when(xUserPermissionDao.findByUserPermissionId(vXPortalUser.getId())).thenReturn(xUserPermissionsList);
+		VXUser loggedInUser = vxUser();
+		List<String> loggedInUserRole = new ArrayList<String>();
+		loggedInUserRole.add(RangerConstants.ROLE_SYS_ADMIN);
+		loggedInUser.setId(8L);
+		loggedInUser.setName("testuser");
+		loggedInUser.setUserRoleList(loggedInUserRole);
+		Mockito.when(xUserService.getXUserByUserName("admin")).thenReturn(loggedInUser);
 		xUserMgr.createOrUpdateXUsers(users);
 		vXUserList.clear();
 		vXUser.setUserSource(RangerCommonEnums.USER_APP);

--- a/security-admin/src/test/java/org/apache/ranger/rest/TestRoleREST.java
+++ b/security-admin/src/test/java/org/apache/ranger/rest/TestRoleREST.java
@@ -238,6 +238,7 @@ public class TestRoleREST {
         RangerRoleList rangerRoleList = new RangerRoleList();
         Mockito.when(searchUtil.getSearchFilter(Mockito.any(HttpServletRequest.class), eq(roleService.sortFields))).
                 thenReturn(Mockito.mock(SearchFilter.class));
+        Mockito.when(bizUtil.isUserRangerAdmin(Mockito.anyString())).thenReturn(true);
         RangerRoleList returnedRangerRoleList = roleRest.getAllRoles(Mockito.mock(HttpServletRequest.class));
         Assert.assertNotNull(returnedRangerRoleList);
         Assert.assertEquals(returnedRangerRoleList.getListSize(), rangerRoleList.getListSize());

--- a/security-admin/src/test/java/org/apache/ranger/rest/TestServiceREST.java
+++ b/security-admin/src/test/java/org/apache/ranger/rest/TestServiceREST.java
@@ -1285,10 +1285,9 @@ public class TestServiceREST {
 	@Test
 	public void test33getPolicyForVersionNumber() throws Exception {
 		RangerPolicy rangerPolicy = rangerPolicy();
-		Mockito.when(svcStore.getPolicyForVersionNumber(Id, 1)).thenReturn(
-				rangerPolicy);
-		RangerPolicy dbRangerPolicy = serviceREST.getPolicyForVersionNumber(Id,
-				1);
+		Mockito.when(svcStore.getPolicyForVersionNumber(Id, 1)).thenReturn(rangerPolicy);
+		Mockito.when(bizUtil.isAdmin()).thenReturn(true);
+		RangerPolicy dbRangerPolicy = serviceREST.getPolicyForVersionNumber(Id, 1);
 		Assert.assertNotNull(dbRangerPolicy);
 		Mockito.verify(svcStore).getPolicyForVersionNumber(Id, 1);
 	}
@@ -2290,7 +2289,7 @@ public class TestServiceREST {
 	}
 
 	public void mockValidateGrantRevokeRequest(){
-		Mockito.when(userMgr.getXUserByUserName(Mockito.anyString())).thenReturn(Mockito.mock(VXUser.class));
+		Mockito.when(xUserService.getXUserByUserName(Mockito.anyString())).thenReturn(Mockito.mock(VXUser.class));
 		Mockito.when(userMgr.getGroupByGroupName(Mockito.anyString())).thenReturn(Mockito.mock(VXGroup.class));
 		Mockito.when(daoManager.getXXRole().findByRoleName(Mockito.anyString())).thenReturn(Mockito.mock(XXRole.class));
 	}
@@ -2779,6 +2778,7 @@ public class TestServiceREST {
 		Mockito.when(daoManager.getXXPolicy()).thenReturn(xXPolicyDao);
 		Mockito.when(daoManager.getXXPolicy().findPolicy(policyName,serviceName,zoneName)).thenReturn(xxPolicy);
 		Mockito.when(policyService.getPopulatedViewObject(xxPolicy)).thenReturn(rangerPolicy);
+		Mockito.when(bizUtil.isAdmin()).thenReturn(true);
 		RangerPolicy dbRangerPolicy = serviceREST.getPolicyByName(serviceName, policyName, zoneName);
 		Assert.assertNotNull(dbRangerPolicy);
 		Assert.assertEquals(dbRangerPolicy, rangerPolicy);
@@ -2797,6 +2797,7 @@ public class TestServiceREST {
 		Mockito.when(daoManager.getXXPolicy()).thenReturn(xXPolicyDao);
 		Mockito.when(daoManager.getXXPolicy().findPolicy(policyName,serviceName,null)).thenReturn(xxPolicy);
 		Mockito.when(policyService.getPopulatedViewObject(xxPolicy)).thenReturn(rangerPolicy);
+		Mockito.when(bizUtil.isAdmin()).thenReturn(true);
 		RangerPolicy dbRangerPolicy = serviceREST.getPolicyByName(serviceName, policyName, null);
 		Assert.assertNotNull(dbRangerPolicy);
 		Assert.assertEquals(dbRangerPolicy, rangerPolicy);

--- a/security-admin/src/test/java/org/apache/ranger/rest/TestTagREST.java
+++ b/security-admin/src/test/java/org/apache/ranger/rest/TestTagREST.java
@@ -499,10 +499,12 @@ public class TestTagREST {
 	
 	@Test
 	public void test16getTagTypes(){
+		boolean isAdmin = true;
 		List<String> ret = new ArrayList<String>();
 		ret.add(name);
 		
 		try {
+			Mockito.when(bizUtil.isAdmin()).thenReturn(isAdmin);
 			Mockito.when(tagStore.getTagTypes()).thenReturn(ret);
 		} catch (Exception e) {
 		}
@@ -760,6 +762,7 @@ public class TestTagREST {
 	
 	@Test
 	public void test26getAllTags() {
+		boolean isAdmin = true;
 		List<RangerTag> ret = new ArrayList<RangerTag>();
 		RangerTag rangerTag = new RangerTag();
 		rangerTag.setId(id);
@@ -767,6 +770,7 @@ public class TestTagREST {
 		ret.add(rangerTag);
 		
 		try {
+			Mockito.when(bizUtil.isAdmin()).thenReturn(isAdmin);
 			Mockito.when(tagStore.getTags((SearchFilter)Mockito.any())).thenReturn(ret);
 		} catch (Exception e) {
 		}
@@ -784,9 +788,10 @@ public class TestTagREST {
 	
 	@Test
 	public void test60getAllTags() {
+		boolean isAdmin = true;
 		List<RangerTag> ret = new ArrayList<RangerTag>();
-		
 		try {
+			Mockito.when(bizUtil.isAdmin()).thenReturn(isAdmin);
 			Mockito.when(tagStore.getTags((SearchFilter)Mockito.any())).thenReturn(ret);
 		} catch (Exception e) {
 		}
@@ -1118,6 +1123,7 @@ public class TestTagREST {
 	
 	@Test
 	public void test37getAllServiceResources() {
+		boolean isAdmin = true;
 		List<RangerServiceResource> ret = new ArrayList<RangerServiceResource>();
 		RangerServiceResource rangerServiceResource =  new RangerServiceResource();
 		rangerServiceResource.setId(id);
@@ -1125,6 +1131,7 @@ public class TestTagREST {
 		ret.add(rangerServiceResource);
 		
 		try {
+			Mockito.when(bizUtil.isAdmin()).thenReturn(isAdmin);
 			Mockito.when(tagStore.getServiceResources((SearchFilter)Mockito.any())).thenReturn(ret);
 		} catch (Exception e) {
 		}

--- a/security-admin/src/test/java/org/apache/ranger/rest/TestUserREST.java
+++ b/security-admin/src/test/java/org/apache/ranger/rest/TestUserREST.java
@@ -401,7 +401,7 @@ public class TestUserREST {
 
 		Mockito.verify(daoManager).getXXPortalUser();
 		Mockito.verify(xxPortalUserDao).getById(userId);
-		Mockito.verify(userManager).checkAccessForUpdate(xxPUser);
+		Mockito.verify(userManager).checkAccess(xxPUser);
 		Mockito.verify(userManager).changePassword(vxPasswordChange);
 	}
 
@@ -440,7 +440,7 @@ public class TestUserREST {
 
 		Mockito.verify(daoManager).getXXPortalUser();
 		Mockito.verify(xxPortalUserDao).getById(userId);
-		Mockito.verify(userManager).checkAccessForUpdate(xxPUser);
+		Mockito.verify(userManager).checkAccess(xxPUser);
 		Mockito.verify(userManager).changeEmailAddress(xxPUser, changeEmail);
 	}
 

--- a/security-admin/src/test/java/org/apache/ranger/rest/TestXUserREST.java
+++ b/security-admin/src/test/java/org/apache/ranger/rest/TestXUserREST.java
@@ -59,8 +59,6 @@ import org.apache.ranger.view.VXAuditMapList;
 import org.apache.ranger.view.VXAuthSession;
 import org.apache.ranger.view.VXAuthSessionList;
 import org.apache.ranger.view.VXGroup;
-import org.apache.ranger.view.VXGroupGroup;
-import org.apache.ranger.view.VXGroupGroupList;
 import org.apache.ranger.view.VXGroupList;
 import org.apache.ranger.view.VXGroupPermission;
 import org.apache.ranger.view.VXGroupPermissionList;
@@ -147,8 +145,6 @@ public class TestXUserREST {
 	@Mock VXGroupUser vXGroupUser;
 	@Mock XGroupUserService xGroupUserService;
 	@Mock VXGroupUserList vXGroupUserList;
-	@Mock VXGroupGroup vXGroupGroup;
-	@Mock VXGroupGroupList vXGroupGroupList;
 	@Mock XGroupGroupService xGroupGroupService;
 	@Mock VXPermMap vXPermMap;
 	@Mock RESTErrorUtil restErrorUtil;
@@ -645,92 +641,6 @@ public class TestXUserREST {
 		assertNotNull(testvxLong);
 		assertEquals(testvxLong.getValue(),vXLong.getValue());
 		assertEquals(testvxLong.getClass(),vXLong.getClass());
-	}
-	@Test
-	public void test32getXGroupGroup() {
-		VXGroupGroup compareTestVXGroup=createVXGroupGroup();
-		
-		Mockito.when(xUserMgr.getXGroupGroup(id)).thenReturn(compareTestVXGroup);
-		VXGroupGroup retVxGroup= xUserRest.getXGroupGroup(id);
-		
-		assertNotNull(retVxGroup);
-		assertEquals(compareTestVXGroup.getClass(),retVxGroup.getClass());
-		assertEquals(compareTestVXGroup.getId(),retVxGroup.getId());
-		Mockito.verify(xUserMgr).getXGroupGroup(id);
-	}	@Test
-	public void test33createXGroupGroup() {
-		VXGroupGroup compareTestVXGroup=createVXGroupGroup();
-		 
-		Mockito.when(xUserMgr.createXGroupGroup(compareTestVXGroup)).thenReturn(compareTestVXGroup);
-		VXGroupGroup retVxGroup= xUserRest.createXGroupGroup(compareTestVXGroup);
-			
-		assertNotNull(retVxGroup);
-		assertEquals(compareTestVXGroup.getClass(),retVxGroup.getClass());
-		assertEquals(compareTestVXGroup.getId(),retVxGroup.getId());
-		Mockito.verify(xUserMgr).createXGroupGroup(compareTestVXGroup);
-	}
-	@Test
-	public void test34updateXGroupGroup() {
-		VXGroupGroup compareTestVXGroup=createVXGroupGroup();
-		 
-		Mockito.when(xUserMgr.updateXGroupGroup(compareTestVXGroup)).thenReturn(compareTestVXGroup);
-		VXGroupGroup retVxGroup= xUserRest.updateXGroupGroup(compareTestVXGroup);
-			
-		assertNotNull(retVxGroup);
-		assertEquals(compareTestVXGroup.getClass(),retVxGroup.getClass());
-		assertEquals(compareTestVXGroup.getId(),retVxGroup.getId());
-		Mockito.verify(xUserMgr).updateXGroupGroup(compareTestVXGroup);
-	}
-	@Test
-	public void test35deleteXGroupGroup() {
-		boolean forceDelete = false;
-		
-		Mockito.doNothing().when(xUserMgr).deleteXGroupGroup(id, forceDelete);
-		xUserRest.deleteXGroupGroup(id,request);
-		Mockito.verify(xUserMgr).deleteXGroupGroup(id,forceDelete);
-	}
-	@SuppressWarnings("unchecked")
-	@Test
-	public void test36searchXGroupGroups() {
-		VXGroupGroupList testvXGroupGroupList=new VXGroupGroupList();
-		VXGroupGroup testVXGroup=createVXGroupGroup();
-		List<VXGroupGroup> testVXGroupGroups= new ArrayList<VXGroupGroup>();
-		testVXGroupGroups.add(testVXGroup);
-		testvXGroupGroupList.setVXGroupGroups(testVXGroupGroups);
-		
-		HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
-		SearchCriteria testSearchCriteria=createsearchCriteria();
-		
-		Mockito.when(searchUtil.extractCommonCriterias((HttpServletRequest)Mockito.any() ,(List<SortField>)Mockito.any())).thenReturn(testSearchCriteria);
-
-		Mockito.when(xUserMgr.searchXGroupGroups(testSearchCriteria)).thenReturn(testvXGroupGroupList);
-		VXGroupGroupList outputvXGroupGroupList=xUserRest.searchXGroupGroups(request);
-		
-		Mockito.verify(xUserMgr).searchXGroupGroups(testSearchCriteria);
-		Mockito.verify(searchUtil).extractCommonCriterias((HttpServletRequest)Mockito.any() ,(List<SortField>)Mockito.any());
-		
-		assertNotNull(outputvXGroupGroupList);
-		assertEquals(outputvXGroupGroupList.getClass(),testvXGroupGroupList.getClass());
-		assertEquals(outputvXGroupGroupList.getResultSize(),testvXGroupGroupList.getResultSize());
-	}
-	@SuppressWarnings("unchecked")
-	@Test
-	public void test37countXGroupGroups() {
-		HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
-		SearchCriteria testSearchCriteria=createsearchCriteria();
-				
-		Mockito.when(searchUtil.extractCommonCriterias((HttpServletRequest)Mockito.any() ,(List<SortField>)Mockito.any())).thenReturn(testSearchCriteria);
-		
-		vXLong.setValue(1);
-			
-		Mockito.when(xUserMgr.getXGroupGroupSearchCount(testSearchCriteria)).thenReturn(vXLong);
-		VXLong testvxLong=xUserRest.countXGroupGroups(request);
-		Mockito.verify(xUserMgr).getXGroupGroupSearchCount(testSearchCriteria);
-		Mockito.verify(searchUtil).extractCommonCriterias((HttpServletRequest)Mockito.any() ,(List<SortField>)Mockito.any());
-			
-		assertNotNull(testvxLong);
-		assertEquals(testvxLong.getClass(),vXLong.getClass());
-		assertEquals(testvxLong.getValue(),vXLong.getValue());
 	}
 	@Test
 	public void test38getXPermMapVXResourceNull() throws Exception{
@@ -2181,17 +2091,7 @@ public class TestXUserREST {
 		testVXGroupUser.setUserId(id);
 		return testVXGroupUser;
 	}
-	private VXGroupGroup createVXGroupGroup() {
-		VXGroupGroup testVXGroupGroup= new VXGroupGroup();
-		testVXGroupGroup.setName("testGroup");
-		testVXGroupGroup.setCreateDate(new Date());
-		testVXGroupGroup.setUpdateDate(new Date());
-		testVXGroupGroup.setUpdatedBy("Admin");
-		testVXGroupGroup.setOwner("Admin");
-		testVXGroupGroup.setId(id);
-		testVXGroupGroup.setParentGroupId(id);
-		return testVXGroupGroup;
-	}
+
 	private VXPermMap testcreateXPermMap(){
 		VXPermMap testVXPermMap= new VXPermMap();
 		testVXPermMap.setCreateDate(new Date());


### PR DESCRIPTION
## What changes were proposed in this pull request?

RANGER-4545: DELETE /assets/resources/{resource_id} API should return proper status code for non admin users
RANGER-4546: /assets/ugsyncAudits/{sync_source} API is accessible by user without permission on audit module
RANGER-4548: Return proper error message in the response for /tags/tags, /tags/resources and /tags/types API for non admin users
RANGER-4547: The reponse metrics (pagination values) for the /assets/ugsyncAudits/{sync_source} API is not proper
RANGER-4549: Non admin users cannot access /public/v2/api/roles/names and /public/v2/api/roles/name/{name} API, but can access /public/v2/api/roles API
RANGER-4551: No response returned for /assets/policyList/{service_name} API
RANGER-4550: API request to /assets/resource/{id} returns no response
RANGER-4552: Response metrics for /assets/report is not proper, and pagination does not work
RANGER-4553: Response metrics for /xaudit/trx_log not proper
RANGER-4554: Response metrics for /assets/resources not proper
RANGER-4555: Response metrics for /assets/assets API not proper
RANGER-4573: /xaudit/trx_log API not accessible by keyadmin user
RANGER-4578: /xuser/groupgroups and /xuser/groupusers APIs allow creation of entities even without groupId / userId fields in the request
RANGER-4574: /public/v2/api/service/{service_name}/policy/{policy_name} API returns policies for users without access to the policy
RANGER-4575: /plugins/policy/{policy_id}/version/{version_number} API returns policies for users without access to the policy
RANGER-4576: User without access to policy is able to fetch policy details using /plugins/policies/{service_type}/for-resource API endpoint
RANGER-4577: UI and API behaviour for fetching users not consistent for keyadmin users
RANGER-4589: keyadmin user can update the user password via UI but cannot update the user password using /users/{user_id}/passwordchange API
RANGER-4588: /xaudit/trx_log/{trx_log_id} is not accessible by keyadmin user
RANGER-4591: keyadmin user can access non kms related admin audits using /assets/report/{transaction_id} API
RANGER-4594: keyadmin user can mark ROLE_USER users as disabled by setting status to 0 using /users API
RANGER-4595: keyadmin user able to view the user permission objects via /users API
RANGER-4596: keyadmin can fetch the details of admin and auditor users through /users API endpoint
RANGER-4598: ROLE_USER cannot acccess /xusers/groups API but can access /xusers/groups/groupName/{group_name} API
RANGER-4586: XUserREST and UserREST API improvement for keyadmin users
Change-Id: I1fa52a99049d81e58c40d071211d62b278ff8ef1

## How was this patch tested?

Tested affected REST APIs using curl command and found the response as per the expectation.
