### PR TITLE
RANGER-4920: kms docker - Fix kms service url, volume support for configs

### DIFF
--- a/dev-support/ranger-docker/config/ranger-kms/dbks-site.xml
+++ b/dev-support/ranger-docker/config/ranger-kms/dbks-site.xml
@@ -1,0 +1,455 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<configuration>
+
+  <!-- Blacklist for authorization -->
+
+  <property>
+    <name>hadoop.kms.blacklist.DECRYPT_EEK</name>
+    <value>hdfs</value>
+    <description>
+          Blacklist for decrypt EncryptedKey
+          CryptoExtension operations
+    </description>
+  </property>
+
+        <!-- Encryption key Password -->
+
+        <property>
+                <name>ranger.db.encrypt.key.password</name>
+                <value>Str0ngPassw0rd</value>
+                <description>
+                        Password used for encrypting Master Key
+                </description>
+        </property>
+
+        <property>
+                <name>ranger.kms.service.masterkey.password.cipher</name>
+                <value>AES</value>
+                <description>
+                        Cipher used for encrypting Master Key
+                </description>
+        </property>
+
+        <property>
+               <name>ranger.kms.service.masterkey.password.size</name>
+               <value>256</value>
+                <description>
+                        Size of masterkey
+                </description>
+       </property>
+
+        <property>
+                <name>ranger.kms.service.masterkey.password.salt.size</name>
+                <value>8</value>
+                <description>
+                        Salt size to encrypt Master Key
+                </description>
+        </property>
+
+        <property>
+                <name>ranger.kms.service.masterkey.password.salt</name>
+                <value>abcdefghijklmnopqrstuvwxyz01234567890</value>
+                <description>
+                        Salt to encrypt Master Key
+                </description>
+        </property>
+
+
+        <property>
+                <name>ranger.kms.service.masterkey.password.iteration.count</name>
+                <value>1000</value>
+                <description>
+                        Iteration count to encrypt Master Key
+                </description>
+        </property>
+
+        <property>
+                <name>ranger.kms.service.masterkey.password.encryption.algorithm</name>
+                <value>PBEWithMD5AndDES</value>
+                <description>
+                        Algorithm to encrypt Master Key
+                </description>
+        </property>
+
+        <property>
+                <name>ranger.kms.service.masterkey.password.md.algorithm</name>
+                <value>SHA</value>
+                <description>
+                        Message Digest algorithn to encrypt Master Key
+                </description>
+        </property>
+
+        <!-- db Details -->
+  
+  <property>
+    <name>ranger.ks.jpa.jdbc.url</name>
+    <value>jdbc:log4jdbc:mysql://localhost:3306/rangerkms</value>
+    <description>
+      URL for Database
+    </description>
+  </property>
+    
+  <property>
+    <name>ranger.ks.jpa.jdbc.user</name>
+    <value>kmsadmin</value>
+    <description>
+      Database username used for operation
+    </description>
+  </property>
+  
+  <property>
+    <name>ranger.ks.jpa.jdbc.password</name>
+    <value>kmsadmin</value>
+    <description>
+      Database user's password 
+    </description>
+  </property>
+
+  <property>
+    <name>ranger.ks.jpa.jdbc.credential.provider.path</name>
+    <value>/tmp/kms.jceks</value>
+    <description>
+      Credential provider path
+    </description>
+  </property>
+
+  <property>
+    <name>ranger.ks.jpa.jdbc.credential.alias</name>
+    <value>ranger.ks.jdbc.password</value>
+    <description>
+      Credential alias used for password
+    </description>
+  </property>
+
+  <property>
+    <name>ranger.ks.masterkey.credential.alias</name>
+    <value>ranger.ks.masterkey.password</value>
+    <description>
+      Credential alias used for masterkey
+    </description>
+  </property>
+
+  <property>
+    <name>ranger.ks.jpa.jdbc.dialect</name>
+    <value>org.eclipse.persistence.platform.database.MySQLPlatform</value>
+    <description>
+      Dialect used for database
+    </description>    
+  </property>
+  
+  <property>
+    <name>ranger.ks.jpa.jdbc.driver</name>
+    <value>net.sf.log4jdbc.DriverSpy</value>
+    <description>
+      Driver used for database
+    </description>    
+  </property>
+  
+  <property>
+    <name>ranger.ks.jdbc.sqlconnectorjar</name>
+    <value>/usr/share/java/mysql-connector-java.jar</value>
+    <description>
+      Driver used for database
+    </description>    
+  </property>  
+  
+  <!-- Ranger KMS Kerberos Config -->
+  <property>
+  	<name>ranger.ks.kerberos.principal</name>
+  	<value>rangerkms/_HOST@REALM</value>
+  </property>
+
+  <property>
+  	<name>ranger.ks.kerberos.keytab</name>
+  	<value></value>
+  </property>
+
+  <!-- Key-Secure Config START-->
+
+  <property>
+        <name>ranger.kms.keysecure.enabled</name>
+        <value>false</value>
+        <description></description>
+  </property>
+
+  <property>
+        <name>ranger.kms.keysecure.UserPassword.Authentication</name>
+        <value>true</value>
+        <description></description>
+  </property>
+  <property>
+        <name>ranger.kms.keysecure.masterkey.name</name>
+        <value>safenetmasterkey</value>
+        <description>Safenet key secure master key name</description>
+  </property>
+    <property>
+        <name>ranger.kms.keysecure.login.username</name>
+        <value>user1</value>
+        <description>Safenet key secure username</description>
+  </property>
+  <property>
+        <name>ranger.kms.keysecure.login.password</name>
+        <value>t1e2s3t4</value>
+        <description>Safenet key secure user password</description>
+  </property>
+  <property>
+        <name>ranger.kms.keysecure.login.password.alias</name>
+        <value>ranger.ks.login.password</value>
+        <description>Safenet key secure user password</description>
+  </property>
+  <property>
+        <name>ranger.kms.keysecure.hostname</name>
+        <value>SunPKCS11-keysecurehn</value>
+        <description>Safenet key secure hostname</description>
+  </property>
+  <property>
+        <name>ranger.kms.keysecure.masterkey.size</name>
+        <value>256</value>
+        <description>key size</description>
+  </property>
+  <property>
+        <name>ranger.kms.keysecure.sunpkcs11.cfg.filepath</name>
+        <value>/opt/safenetConf/64/8.3.1/sunpkcs11.cfg</value>
+        <description>Location of Safenet key secure library configuration file</description>
+  </property>
+  <property>
+        <name>ranger.kms.keysecure.provider.type</name>
+        <value>SunPKCS11</value>
+        <description>Security Provider for key secure</description>
+  </property>
+
+  <!-- Key-Secure Config END-->
+   <!--Azure Key Vault START-->
+   <property>
+        <name>ranger.kms.azurekeyvault.enabled</name>
+        <value>false</value>
+        <description>Flag for Azure Key Vault</description>
+  </property>
+  <property>
+        <name>ranger.kms.azure.keyvault.ssl.enabled</name>
+        <value>false</value>
+        <description>Flag for Azure authentication via certificate or password</description>
+  </property>
+  <property>
+        <name>ranger.kms.azure.client.id</name>
+        <value></value>
+        <description>Azure Client Id</description>
+  </property>
+  <property>
+        <name>ranger.kms.azure.client.secret</name>
+        <value></value>
+        <description>Azure Client Secret</description>
+  </property>
+    <property>
+        <name>ranger.kms.azure.client.secret.alias</name>
+        <value>ranger.ks.azure.client.secret</value>
+        <description>Azure Client Secret Alias</description>
+  </property>
+  <property>
+        <name>ranger.kms.azure.keyvault.certificate.path</name>
+        <value>/home/machine/Desktop/azureAuthCertificate/keyvault-MyCert.pfx</value>
+        <description>Azure key vault cerificate path</description>
+  </property>
+  <property>
+        <name>ranger.kms.azure.keyvault.certificate.password</name>
+        <value></value>
+        <description>Azure key vault cerificate password</description>
+  </property>
+   <property>
+        <name>ranger.kms.azure.masterkey.name</name>
+        <value></value>
+        <description>Azure master key name</description>
+  </property>
+  <property>
+        <name>ranger.kms.azure.masterkey.type</name>
+        <value></value>
+        <description>Azure key type: RSA, RSA_HSM, EC, EC_HSM</description>
+  </property>
+    <property>
+        <name>ranger.kms.azure.zonekey.encryption.algorithm</name>
+        <value></value>
+        <description>Encryption Algo : RSA_OAEP, RSA_OAEP_256, RSA1_5</description>
+  </property>
+   <property>
+        <name>ranger.kms.azurekeyvault.url</name>
+        <value></value>
+        <description>Azure Key Vault url</description>
+  </property>
+   <!--Azure Key Vault END-->
+
+    <!--AWS KMS START-->
+    <property>
+        <name>ranger.kms.awskms.enabled</name>
+        <value>false</value>
+        <description>Flag for AWS KMS</description>
+    </property>
+    <property>
+        <name>ranger.kms.awskms.masterkey.id</name>
+        <value></value>
+        <description>AWS KMS Master key id</description>
+    </property>
+    <property>
+        <name>ranger.kms.aws.client.accesskey</name>
+        <value></value>
+        <description>AWS Client Access Key</description>
+    </property>
+    <property>
+        <name>ranger.kms.aws.client.secretkey</name>
+        <value></value>
+        <description>AWS Client Secret Key</description>
+    </property>
+    <property>
+        <name>ranger.kms.aws.client.secretkey.alias</name>
+        <value>ranger.ks.aws.client.secretkey</value>
+        <description>AWS Client Secret Key Alias</description>
+    </property>
+    <property>
+        <name>ranger.kms.aws.client.region</name>
+        <value></value>
+        <description>AWS Region</description>
+    </property>
+    <!--AWS KMS END-->
+
+	<!-- Google Cloud KMS start -->
+	<property>
+		<name>ranger.kms.gcp.enabled</name>
+		<value>false</value>
+		<description>Flag for Google Cloud HSM e.g - true or false</description>
+	</property>
+	<property>
+		<name>ranger.kms.gcp.keyring.id</name>
+		<value></value>
+		<description>Name of KeyRing.</description>
+	</property>
+	<property>
+		<name>ranger.kms.gcp.cred.file</name>
+		<value></value>
+		<description>Absolute path of downloaded json credential file, e.g - /path/to/credFile.json</description>
+	</property>
+	<property>
+		<name>ranger.kms.gcp.project.id</name>
+		<value></value>
+		<description>Name of project on Google Cloud HSM.</description>
+	</property>
+	<property>
+		<name>ranger.kms.gcp.location.id</name>
+		<value></value>
+		<description>GCP KeyRing location id, e.g - us-east1, global etc.</description>
+	</property>
+	<property>
+		<name>ranger.kms.gcp.masterkey.name</name>
+		<value></value>
+		<description>GCP Master Key Name.</description>
+	</property>
+	<!-- Google Cloud KMS end -->
+
+    <!--Tencent KMS START-->
+    <property>
+        <name>ranger.kms.tencentkms.enabled</name>
+        <value>false</value>
+        <description>Flag for Tencent KMS</description>
+    </property>
+    <property>
+        <name>ranger.kms.tencent.client.id</name>
+        <value></value>
+        <description>Tencent Client Id</description>
+    </property>
+    <property>
+        <name>ranger.kms.tencent.client.secret</name>
+        <value></value>
+        <description>Tencent Client Secret</description>
+    </property>
+    <property>
+        <name>ranger.kms.tencent.client.secret.alias</name>
+        <value>ranger.ks.tencent.client.secret</value>
+        <description>Tencent Client Secret Alias</description>
+    </property>
+    <property>
+        <name>ranger.kms.tencent.client.region</name>
+        <value>ap-beijing</value>
+        <description>Tencent Client Id</description>
+    </property>
+    <property>
+        <name>ranger.kms.tencent.masterkey.id</name>
+        <value></value>
+        <description>Tencent master key name</description>
+    </property>
+    <!--Tencent KMS END-->
+
+    <!-- HSM Config -->
+  <property>
+  	<name>ranger.ks.hsm.type</name>
+  	<value>LunaProvider</value>
+  	<description></description>
+  </property>
+  
+  <property>
+  	<name>ranger.ks.hsm.enabled</name>
+  	<value>false</value>
+  	<description></description>
+  </property>
+  
+  <property>
+  	<name>ranger.ks.hsm.partition.name</name>
+  	<value></value>
+  	<description></description>
+  </property>
+  
+  <property>
+  	<name>ranger.ks.hsm.partition.password</name>
+  	<value></value>
+  	<description></description>
+  </property>
+  
+  <property>
+  	<name>ranger.ks.hsm.partition.password.alias</name>
+  	<value>ranger.kms.hsm.partition.password</value>
+  	<description></description>
+  </property>  
+  
+  <property>
+	<name>ranger.ks.db.ssl.enabled</name>
+	<value>false</value>
+  </property>
+    <property>
+	<name>ranger.ks.db.ssl.required</name>
+	<value>false</value>
+  </property>
+    <property>
+	<name>ranger.ks.db.ssl.verifyServerCertificate</name>
+	<value>false</value>
+  </property>
+  <property>
+	<name>ranger.ks.db.ssl.auth.type</name>
+	<value>2-way</value>
+  </property>
+  <property>
+	<name>ranger.ks.db.ssl.certificateFile</name>
+	<value></value>
+  </property>
+  <property>
+	<name>ranger.truststore.file.type</name>
+	<value>jks</value>
+  </property>
+  <property>
+	<name>ranger.keystore.file.type</name>
+	<value>jks</value>
+  </property>
+</configuration>

--- a/dev-support/ranger-docker/config/ranger-kms/kms-logback.xml
+++ b/dev-support/ranger-docker/config/ranger-kms/kms-logback.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<configuration scan="true">
+  <appender name="kms-audit" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <!--See http://logback.qos.ch/manual/appenders.html#RollingFileAppender-->
+    <!--and http://logback.qos.ch/manual/appenders.html#TimeBasedRollingPolicy-->
+    <!--for further documentation-->
+    <Append>true</Append>
+    <File>${kms.log.dir}/kms-audit-${hostname}-${user}.log</File>
+    <encoder>
+      <pattern>%d{ISO8601} %m%n</pattern>
+    </encoder>
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <fileNamePattern>${kms.log.dir}/kms-audit-${hostname}-${user}.log.%d{yyyy-MM-dd}</fileNamePattern>
+      <maxHistory>15</maxHistory>
+      <cleanHistoryOnStart>true</cleanHistoryOnStart>
+    </rollingPolicy>
+  </appender>
+  <appender name="kms-metric" class="ch.qos.logback.core.FileAppender">
+    <!--See also http://logback.qos.ch/manual/appenders.html#RollingFileAppender-->
+    <Append>false</Append>
+    <File>${kms.log.dir}/ranger_kms_metric_data_for_${metric.type}.log</File>
+    <encoder>
+      <pattern>%m%n</pattern>
+    </encoder>
+  </appender>
+  <appender name="kms" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <!--See http://logback.qos.ch/manual/appenders.html#RollingFileAppender-->
+    <!--and http://logback.qos.ch/manual/appenders.html#TimeBasedRollingPolicy-->
+    <!--for further documentation-->
+    <File>${kms.log.dir}/ranger-kms-${hostname}-${user}.log</File>
+    <Append>true</Append>
+    <encoder>
+      <pattern>%d{ISO8601} %-5p [%t] %c{1} \(%F:%L\) - %m%n</pattern>
+    </encoder>
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <fileNamePattern>${kms.log.dir}/ranger-kms-${hostname}-${user}.log.%d{yyyy-MM-dd}</fileNamePattern>
+      <maxHistory>15</maxHistory>
+      <cleanHistoryOnStart>true</cleanHistoryOnStart>
+    </rollingPolicy>
+  </appender>
+  <logger name="com.sun.jersey.server.wadl.generators.WadlGeneratorJAXBGrammarGenerator" level="OFF"/>
+  <logger name="kms-audit" additivity="false" level="INFO">
+    <appender-ref ref="kms-audit"/>
+  </logger>
+  <logger name="org.apache.hadoop" level="INFO"/>
+  <logger name="org.apache.hadoop.conf" level="INFO"/>
+  <logger name="org.apache.hadoop.crypto.key.kms.server.KMSMetricUtil" level="INFO">
+    <appender-ref ref="kms-metric"/>
+  </logger>
+  <logger name="org.apache.ranger" level="INFO"/>
+  <root level="WARN">
+    <appender-ref ref="kms"/>
+  </root>
+</configuration>

--- a/dev-support/ranger-docker/config/ranger-kms/kms-site.xml
+++ b/dev-support/ranger-docker/config/ranger-kms/kms-site.xml
@@ -1,0 +1,192 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<configuration>
+
+  <!-- KMS Backend KeyProvider -->
+
+  <property>
+    <name>hadoop.kms.key.provider.uri</name>
+    <value>dbks://http@localhost:9292/kms</value>
+    <description>
+      URI of the backing KeyProvider for the KMS.
+    </description>
+  </property>
+
+  <property>
+    <name>hadoop.security.keystore.JavaKeyStoreProvider.password</name>
+    <value>none</value>
+    <description>
+      If using the JavaKeyStoreProvider, the password for the keystore file.
+    </description>
+  </property>
+  
+  <!-- KMS Cache -->
+
+  <property>
+    <name>hadoop.kms.cache.enable</name>
+    <value>true</value>
+    <description>
+      Whether the KMS will act as a cache for the backing KeyProvider.
+      When the cache is enabled, operations like getKeyVersion, getMetadata,
+      and getCurrentKey will sometimes return cached data without consulting
+      the backing KeyProvider. Cached values are flushed when keys are deleted
+      or modified.
+    </description>
+  </property>
+
+  <property>
+    <name>hadoop.kms.cache.timeout.ms</name>
+    <value>600000</value>
+    <description>
+      Expiry time for the KMS key version and key metadata cache, in
+      milliseconds. This affects getKeyVersion and getMetadata.
+    </description>
+  </property>
+
+  <property>
+    <name>hadoop.kms.current.key.cache.timeout.ms</name>
+    <value>30000</value>
+    <description>
+      Expiry time for the KMS current key cache, in milliseconds. This
+      affects getCurrentKey operations.
+    </description>
+  </property>
+
+  <!-- KMS Audit -->
+
+  <property>
+    <name>hadoop.kms.audit.aggregation.window.ms</name>
+    <value>10000</value>
+    <description>
+      Duplicate audit log events within the aggregation window (specified in
+      ms) are quashed to reduce log traffic. A single message for aggregated
+      events is printed at the end of the window, along with a count of the
+      number of aggregated events.
+    </description>
+  </property>
+
+  <!-- KMS Security -->
+
+  <property>
+    <name>hadoop.kms.authentication.type</name>
+    <value>simple</value>
+    <description>
+      Authentication type for the KMS. Can be either &quot;simple&quot;
+      or &quot;kerberos&quot;.
+    </description>
+  </property>
+
+  <property>
+    <name>hadoop.kms.authentication.kerberos.keytab</name>
+    <value>${user.home}/kms.keytab</value>
+    <description>
+      Path to the keytab with credentials for the configured Kerberos principal.
+    </description>
+  </property>
+
+  <property>
+    <name>hadoop.kms.authentication.kerberos.principal</name>
+    <value>HTTP/localhost</value>
+    <description>
+      The Kerberos principal to use for the HTTP endpoint.
+      The principal must start with 'HTTP/' as per the Kerberos HTTP SPNEGO specification.
+    </description>
+  </property>
+
+  <property>
+    <name>hadoop.kms.authentication.kerberos.name.rules</name>
+    <value>DEFAULT</value>
+    <description>
+      Rules used to resolve Kerberos principal names.
+    </description>
+  </property>
+
+  <!-- Authentication cookie signature source -->
+
+  <property>
+    <name>hadoop.kms.authentication.signer.secret.provider</name>
+    <value>random</value>
+    <description>
+      Indicates how the secret to sign the authentication cookies will be
+      stored. Options are 'random' (default), 'string' and 'zookeeper'.
+      If using a setup with multiple KMS instances, 'zookeeper' should be used.
+    </description>
+  </property>
+
+  <!-- Configuration for 'zookeeper' authentication cookie signature source -->
+
+  <property>
+    <name>hadoop.kms.authentication.signer.secret.provider.zookeeper.path</name>
+    <value>/hadoop-kms/hadoop-auth-signature-secret</value>
+    <description>
+      The Zookeeper ZNode path where the KMS instances will store and retrieve
+      the secret from.
+    </description>
+  </property>
+
+  <property>
+    <name>hadoop.kms.authentication.signer.secret.provider.zookeeper.connection.string</name>
+    <value>#HOSTNAME#:#PORT#,...</value>
+    <description>
+      The Zookeeper connection string, a list of hostnames and port comma
+      separated.
+    </description>
+  </property>
+
+  <property>
+    <name>hadoop.kms.authentication.signer.secret.provider.zookeeper.auth.type</name>
+    <value>kerberos</value>
+    <description>
+      The Zookeeper authentication type, 'none' or 'sasl' (Kerberos).
+    </description>
+  </property>
+
+  <property>
+    <name>hadoop.kms.authentication.signer.secret.provider.zookeeper.kerberos.keytab</name>
+    <value>/etc/hadoop/conf/kms.keytab</value>
+    <description>
+      The absolute path for the Kerberos keytab with the credentials to
+      connect to Zookeeper.
+    </description>
+  </property>
+
+  <property>
+    <name>hadoop.kms.authentication.signer.secret.provider.zookeeper.kerberos.principal</name>
+    <value>kms/#HOSTNAME#</value>
+    <description>
+      The Kerberos service principal used to connect to Zookeeper.
+    </description>
+  </property>
+  
+  <property>
+  	<name>hadoop.kms.security.authorization.manager</name>
+  	<value>org.apache.ranger.authorization.kms.authorizer.RangerKmsAuthorizer</value>
+  </property>
+  
+  <property>
+  	<name>hadoop.kms.proxyuser.ranger.groups</name>
+  	<value>*</value>
+  </property>
+  
+  <property>
+  	<name>hadoop.kms.proxyuser.ranger.hosts</name>
+  	<value>*</value>
+  </property>
+  
+  <property>
+  	<name>hadoop.kms.proxyuser.ranger.users</name>
+  	<value>*</value>
+  </property>
+</configuration>

--- a/dev-support/ranger-docker/config/ranger-kms/ranger-kms-site.xml
+++ b/dev-support/ranger-docker/config/ranger-kms/ranger-kms-site.xml
@@ -1,0 +1,78 @@
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+
+
+<configuration>
+	<property>
+		<name>ranger.service.host</name>
+		<value>localhost</value>
+	</property>
+
+	<property>
+		<name>ranger.service.http.port</name>
+		<value>9292</value>
+	</property>
+	
+	<property>
+		<name>ranger.service.shutdown.port</name>
+		<value>7085</value>
+	</property>
+	
+	<property>
+		<name>ranger.contextName</name>
+		<value>/kms</value>
+	</property>			
+	
+	<property>
+		<name>xa.webapp.dir</name>
+		<value>./webapp</value>
+	</property>	
+	<property>
+		<name>ranger.service.https.port</name>
+		<value>9393</value>
+	</property>
+	<property>
+		<name>ranger.service.https.attrib.ssl.enabled</name>
+		<value>false</value>
+	</property>
+	<property>
+		<name>ajp.enabled</name>
+		<value>false</value>
+	</property>
+	<property>
+		<name>ranger.service.https.attrib.client.auth</name>
+		<value>want</value>
+	</property>
+	<property>
+		<name>ranger.credential.provider.path</name>
+		<value>/etc/ranger/kms/rangerkms.jceks</value>
+	</property>
+	<property>
+		<name>ranger.service.https.attrib.keystore.file</name>
+		<value></value>
+	</property>
+	<property>
+		<name>ranger.service.https.attrib.keystore.keyalias</name>
+		<value>rangerkms</value>
+	</property>
+	<property>
+		<name>ranger.service.https.attrib.keystore.pass</name>
+		<value></value>
+	</property>
+	<property>
+		<name>ranger.service.https.attrib.keystore.credential.alias</name>
+		<value>keyStoreCredentialAlias</value>
+	</property>
+
+</configuration>

--- a/dev-support/ranger-docker/docker-compose.ranger-kms.yml
+++ b/dev-support/ranger-docker/docker-compose.ranger-kms.yml
@@ -12,6 +12,8 @@ services:
     hostname: ranger-kms.example.com
     stdin_open: true
     tty: true
+    volumes:
+      - ./config/ranger-kms:/opt/ranger/kms/ews/webapp/WEB-INF/classes/conf
     networks:
       - ranger
     ports:
@@ -22,6 +24,7 @@ services:
     environment:
       - KMS_VERSION
       - RANGER_DB_TYPE
+      - KMS_IN_DOCKER=true
     command:
       - /home/ranger/scripts/ranger-kms.sh
 

--- a/dev-support/ranger-docker/scripts/create-ranger-services.py
+++ b/dev-support/ranger-docker/scripts/create-ranger-services.py
@@ -47,7 +47,7 @@ hbase = RangerService({'name': 'dev_hbase', 'type': 'hbase',
 
 kms = RangerService({'name': 'dev_kms', 'type': 'kms',
                      'configs': {'username': 'keyadmin', 'password': 'rangerR0cks!',
-                                 'provider': 'http://ranger-kms:9292'}})
+                                 'provider': 'dbks://http@ranger-kms:9292/kms'}})
 
 trino = RangerService({'name': 'dev_trino',
                        'type': 'trino',

--- a/plugin-kms/scripts/enable-kms-plugin.sh
+++ b/plugin-kms/scripts/enable-kms-plugin.sh
@@ -377,6 +377,13 @@ then
         	fi
 			archivefn="${HCOMPONENT_CONF_DIR}/.${orgfn}.${dt}"
         	newfn="${HCOMPONENT_CONF_DIR}/.${orgfn}-new.${dt}"
+          if [ "${KMS_IN_DOCKER}" ]; then
+            TEMP_DIR="${HCOMPONENT_
+            CONF_DIR}"/saved
+            mkdir "${TEMP_DIR}"
+            archivefn="${TEMP_DIR}/.${orgfn}.${dt}"
+            newfn="${TEMP_DIR}/.${orgfn}-new.${dt}"
+          fi
 			log "Saving current config file: ${fullpathorgfn} to ${archivefn} ..."
             cp ${fullpathorgfn} ${archivefn}
 			if [ $? -eq 0 ]


### PR DESCRIPTION


## What changes were proposed in this pull request?

1) Fixed service url for kms as key create operation was not succeeding
2) Introduced volume support for kms docker images so that image re-create is not required for change in configs 

## How was this patch tested?

1) Created kms docker image
2) Made some changes to kms-logback.xml
3) Restart kms docker container
4) updated kms-logback.xml correctly used now for logging (image re-create not required)
