### PR TITLE
RANGER-4942: Fix Dockerfiles of ./build_ranger_using_docker.sh

### DIFF
--- a/dev-support/ranger-docker/Dockerfile.ranger
+++ b/dev-support/ranger-docker/Dockerfile.ranger
@@ -22,9 +22,10 @@ ARG RANGER_DB_TYPE
 ARG TARGETARCH
 ARG RANGER_ADMIN_JAVA_VERSION
 
-RUN if [ "${OS_NAME}" == "UBUNTU" ]; then\
-    ENV JAVA_HOME      /usr/lib/jvm/java-${RANGER_ADMIN_JAVA_VERSION}-openjdk-${TARGETARCH}\
-    update-java-alternatives --set /usr/lib/jvm/java-1.${RANGER_ADMIN_JAVA_VERSION}.0-openjdk-${TARGETARCH};\
+ENV JAVA_HOME=/usr/lib/jvm/java-1.${RANGER_ADMIN_JAVA_VERSION}.0-openjdk-${TARGETARCH}
+
+RUN if [ "${OS_NAME}" = "UBUNTU" ]; then\
+    update-java-alternatives --set "$JAVA_HOME";\
     fi
 
 COPY ./dist/version                               /home/ranger/dist/

--- a/dev-support/ranger-docker/Dockerfile.ranger-base
+++ b/dev-support/ranger-docker/Dockerfile.ranger-base
@@ -19,7 +19,7 @@ FROM ubuntu:${UBUNTU_VERSION}
 
 ARG TARGETARCH
 ARG RANGER_BASE_JAVA_VERSION
-ENV OS_NAME UBUNTU
+ENV OS_NAME=UBUNTU
 
 # Install tzdata, Python, Java, python-requests
 RUN apt-get update && \
@@ -29,11 +29,11 @@ RUN apt-get update && \
     pip3 install requests
 
 # Set environment variables
-ENV JAVA_HOME      /usr/lib/jvm/java-${RANGER_BASE_JAVA_VERSION}-openjdk-${TARGETARCH}
-ENV RANGER_DIST    /home/ranger/dist
-ENV RANGER_SCRIPTS /home/ranger/scripts
-ENV RANGER_HOME    /opt/ranger
-ENV PATH           /usr/java/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ENV JAVA_HOME=/usr/lib/jvm/java-${RANGER_BASE_JAVA_VERSION}-openjdk-${TARGETARCH}
+ENV RANGER_DIST=/home/ranger/dist
+ENV RANGER_SCRIPTS=/home/ranger/scripts
+ENV RANGER_HOME=/opt/ranger
+ENV PATH=/usr/java/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 RUN update-java-alternatives --set /usr/lib/jvm/java-1.${RANGER_BASE_JAVA_VERSION}.0-openjdk-${TARGETARCH}
 

--- a/dev-support/ranger-docker/Dockerfile.ranger-build
+++ b/dev-support/ranger-docker/Dockerfile.ranger-build
@@ -19,20 +19,21 @@ FROM ranger-base:latest
 ARG RANGER_BUILD_JAVA_VERSION
 ARG TARGETARCH
 
+ENV JAVA_HOME=/usr/lib/jvm/java-1.${RANGER_BUILD_JAVA_VERSION}.0-openjdk-${TARGETARCH}
+
 # Install necessary packages to build Ranger
-RUN if [ "${OS_NAME}" == "UBUNTU" ]; then\
+RUN if [ "${OS_NAME}" = "UBUNTU" ]; then\
     apt-get update && apt-get -y install git maven build-essential\
-    update-java-alternatives --set /usr/lib/jvm/java-1.${RANGER_BUILD_JAVA_VERSION}.0-openjdk-${TARGETARCH}\
-    ENV JAVA_HOME  /usr/lib/jvm/java-${RANGER_BUILD_JAVA_VERSION}-openjdk-${TARGETARCH};\
+    update-java-alternatives --set "$JAVA_HOME";\
     fi
 
-RUN if [ "${OS_NAME}" == "RHEL" ]; then\
+RUN if [ "${OS_NAME}" = "RHEL" ]; then\
     microdnf install -y git maven gcc;\
     fi
 
 # Set environment variables
-ENV MAVEN_HOME /usr/share/maven
-ENV PATH       /usr/java/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/apache-maven/bin
+ENV MAVEN_HOME=/usr/share/maven
+ENV PATH=/usr/java/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/apache-maven/bin
 
 # setup ranger group, and users
 RUN mkdir -p /home/ranger/git && \


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR fixes some syntactic mistakes on the Dockerfiles involved in the Ranger build in a Dockerized environment. The 3 main issues I have fixed are:

- `RUN if [ "${OS_NAME}" == "UBUNTU" ]; then ...`: the commands enclosed in this if-condition will never be executed because the shell used for this command is `/bin/sh`, which requires a single `=` for string comparison.
- For some reasons, the `ENV JAVA_HOME /usr/lib/...` Dockerfile command is placed inside the `RUN` command. I put it before the `RUN` command in order to use the `JAVA_HOME` env variable in the shell script.
- Many env variables are initialized using the alternative syntax `ENV MY_ENV_VAR value1`, which is not compliant with the guidelines, that suggests using `ENV MY_ENV_VAR=value1`. I quote from the [`ENV` reference](https://docs.docker.com/reference/dockerfile/#env): 
  > The alternative syntax is supported for backward compatibility, but discouraged for the reasons outlined above, and may be removed in a future release.
  
  I rewrote only some of them, in case you preferred another PR for a general Dockerfile/compose improvements.



## How was this patch tested?

By running `./build_ranger_using_docker.sh`
