### PR TITLE
RANGER-4939: Upgrade Elasticsearch version to 7.17.24

### DIFF
--- a/embeddedwebserver/src/main/java/org/apache/ranger/server/tomcat/ElasticSearchIndexBootStrapper.java
+++ b/embeddedwebserver/src/main/java/org/apache/ranger/server/tomcat/ElasticSearchIndexBootStrapper.java
@@ -50,8 +50,8 @@ import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.client.indices.CreateIndexRequest;
 import org.elasticsearch.client.indices.CreateIndexResponse;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.unit.TimeValue;
-import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.xcontent.XContentType;
 
 
 public class ElasticSearchIndexBootStrapper extends Thread {

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
         <derby.version>10.14.2.0</derby.version>
         <dnsjava.version>2.1.7</dnsjava.version>
         <eclipse.jpa.version>2.7.12</eclipse.jpa.version>
-        <elasticsearch.version>7.10.2</elasticsearch.version>
+        <elasticsearch.version>7.17.24</elasticsearch.version>
         <enunciate.version>2.13.2</enunciate.version>
         <spotbugs.plugin.version>4.7.3.5</spotbugs.plugin.version>
         <googlecode.log4jdbc.version>1.2</googlecode.log4jdbc.version>

--- a/ranger-elasticsearch-plugin-shim/src/main/java/org/apache/ranger/authorization/elasticsearch/plugin/RangerElasticsearchPlugin.java
+++ b/ranger-elasticsearch-plugin-shim/src/main/java/org/apache/ranger/authorization/elasticsearch/plugin/RangerElasticsearchPlugin.java
@@ -37,7 +37,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
-import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.plugins.ActionPlugin;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Ranger 4939: Upgrade Elasticsearch version to 7.17.24

Elasticsearch version 7.10.2 is affected by a high vulnerability CVE-2023-31418. You must upgrade to version 7.17.22 to fix this vulnerability. 

For the moment, it is not easy to upgrade to a more current version than 7.17.22 since the Elastic API is not backwards compatible and changes the implementation a lot. 


## How was this patch tested?

By running ./build_ranger_using_docker.sh and unit test ElasticSearchAccessAuditsServiceTest
<img width="422" alt="ExampleDoc" src="https://github.com/user-attachments/assets/01d7a0e7-2091-4820-bafb-f3b8a3da9af1">
<img width="713" alt="DocsElastic" src="https://github.com/user-attachments/assets/8de35c6f-d163-4c9c-b061-412470989041">
<img width="1738" alt="AuditsApacheRanger" src="https://github.com/user-attachments/assets/e23b5dee-c3e1-4883-bfdd-0f111a30c7d2">
