### PR TITLE
RANGER-4965: Fix issue where ranger distro cannot package ranger trin…

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -660,6 +660,7 @@
                                         <descriptor>src/main/assembly/plugin-elasticsearch.xml</descriptor>
                                         <descriptor>src/main/assembly/plugin-schema-registry.xml</descriptor>
                                         <descriptor>src/main/assembly/plugin-presto.xml</descriptor>
+                                        <descriptor>src/main/assembly/plugin-trino.xml</descriptor>
                                     </descriptors>
                                 </configuration>
                             </execution>


### PR DESCRIPTION
…o plugin

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix. Create an issue in ASF JIRA before opening a pull request and
set the title of the pull request which starts with
the corresponding JIRA issue number. (e.g. RANGER-XXXX: Fix a typo in YYY))
Translation to English:

The problem occurs because the linux profile in distro/pom.xml is missing <descriptor>src/main/assembly/plugin-trino.xml</descriptor>
As a result, the trino plugin jar is not generated in the target directory during distro packaging

Solution steps:

 Add <descriptor>src/main/assembly/plugin-trino.xml</descriptor> to the descriptors list distro/pom.xml 


This should resolve the packaging issue for the ranger trino plugin.

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)
