### PR TITLE
RANGER-5001: RANGER-4977: Support ignoreDescendantDeny & fix hbase scan authorization 

### DIFF
--- a/agents-common/src/main/java/org/apache/ranger/plugin/policyengine/RangerAccessRequest.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/policyengine/RangerAccessRequest.java
@@ -32,6 +32,8 @@ public interface RangerAccessRequest {
 
 	boolean isAccessTypeAny();
 
+	default boolean ignoreDescendantDeny() { return true; }
+
 	boolean isAccessTypeDelegatedAdmin();
 
 	String getUser();

--- a/agents-common/src/main/java/org/apache/ranger/plugin/policyengine/RangerAccessRequestImpl.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/policyengine/RangerAccessRequestImpl.java
@@ -50,13 +50,14 @@ public class RangerAccessRequestImpl implements RangerAccessRequest {
 	private String               action;
 	private String               requestData;
 	private String               sessionId;
-	private Map<String, Object>  context;
-	private String				 clusterName;
-	private String				 clusterType;
+	private Map<String, Object> context;
+	private String              clusterName;
+	private String              clusterType;
+	private Boolean             isDescendantDenyIgnored = true;
 
-	private boolean isAccessTypeAny;
-	private boolean isAccessTypeDelegatedAdmin;
-	private ResourceMatchingScope resourceMatchingScope = ResourceMatchingScope.SELF;
+	private boolean                                   isAccessTypeAny;
+	private boolean                                   isAccessTypeDelegatedAdmin;
+	private ResourceMatchingScope                     resourceMatchingScope         = ResourceMatchingScope.SELF;
 	private Map<String, ResourceElementMatchingScope> resourceElementMatchingScopes = Collections.emptyMap();
 
 	public RangerAccessRequestImpl() {
@@ -80,6 +81,7 @@ public class RangerAccessRequestImpl implements RangerAccessRequest {
 		setSessionId(null);
 		setContext(null);
 		setClusterName(null);
+		setIgnoreDescendantDeny(null);
 	}
 
 	public RangerAccessRequestImpl(RangerAccessRequest request) {
@@ -101,6 +103,7 @@ public class RangerAccessRequestImpl implements RangerAccessRequest {
 		setResourceElementMatchingScopes(request.getResourceElementMatchingScopes());
 		setClientIPAddress(request.getClientIPAddress());
 		setClusterType(request.getClusterType());
+		setIgnoreDescendantDeny(request.ignoreDescendantDeny());
 	}
 
 	@Override
@@ -111,6 +114,11 @@ public class RangerAccessRequestImpl implements RangerAccessRequest {
 	@Override
 	public String getAccessType() {
 		return accessType;
+	}
+
+	@Override
+	public boolean ignoreDescendantDeny() {
+		return isDescendantDenyIgnored == null || isDescendantDenyIgnored;
 	}
 
 	@Override
@@ -134,7 +142,9 @@ public class RangerAccessRequestImpl implements RangerAccessRequest {
 	}
 
 	@Override
-	public String getClientIPAddress() { return clientIPAddress;}
+	public String getClientIPAddress() {
+		return clientIPAddress;
+	}
 
 	@Override
 	public String getRemoteIPAddress() {
@@ -142,7 +152,9 @@ public class RangerAccessRequestImpl implements RangerAccessRequest {
 	}
 
 	@Override
-	public List<String> getForwardedAddresses() { return forwardedAddresses; }
+	public List<String> getForwardedAddresses() {
+		return forwardedAddresses;
+	}
 
 	@Override
 	public String getClientType() {
@@ -175,7 +187,9 @@ public class RangerAccessRequestImpl implements RangerAccessRequest {
 	}
 
 	@Override
-	public Map<String, ResourceElementMatchingScope> getResourceElementMatchingScopes() { return this.resourceElementMatchingScopes; }
+	public Map<String, ResourceElementMatchingScope> getResourceElementMatchingScopes() {
+		return this.resourceElementMatchingScopes;
+	}
 
 	@Override
 	public boolean isAccessTypeAny() {
@@ -202,6 +216,10 @@ public class RangerAccessRequestImpl implements RangerAccessRequest {
 		this.accessType            = accessType;
 		isAccessTypeAny            = StringUtils.equals(accessType, RangerPolicyEngine.ANY_ACCESS);
 		isAccessTypeDelegatedAdmin = StringUtils.equals(accessType, RangerPolicyEngine.ADMIN_ACCESS);
+	}
+
+	public void setIgnoreDescendantDeny(Boolean isDescendantDenyIgnored) {
+		this.isDescendantDenyIgnored = isDescendantDenyIgnored == null || isDescendantDenyIgnored;
 	}
 
 	public void setUser(String user) {
@@ -247,7 +265,7 @@ public class RangerAccessRequestImpl implements RangerAccessRequest {
 	public void setSessionId(String sessionId) {
 		this.sessionId = sessionId;
 	}
-	
+
 	public String getClusterName() {
 		return clusterName;
 	}
@@ -289,7 +307,7 @@ public class RangerAccessRequestImpl implements RangerAccessRequest {
 		}
 	}
 
-	public void extractAndSetClientIPAddress(boolean useForwardedIPAddress, String[]trustedProxyAddresses) {
+	public void extractAndSetClientIPAddress(boolean useForwardedIPAddress, String[] trustedProxyAddresses) {
 		String ip = getRemoteIPAddress();
 		if (ip == null) {
 			ip = getClientIPAddress();
@@ -328,7 +346,7 @@ public class RangerAccessRequestImpl implements RangerAccessRequest {
 	}
 
 	@Override
-	public String toString( ) {
+	public String toString() {
 		StringBuilder sb = new StringBuilder();
 
 		toString(sb);
@@ -344,16 +362,16 @@ public class RangerAccessRequestImpl implements RangerAccessRequest {
 		sb.append("user={").append(user).append("} ");
 
 		sb.append("userGroups={");
-		if(userGroups != null) {
-			for(String userGroup : userGroups) {
+		if (userGroups != null) {
+			for (String userGroup : userGroups) {
 				sb.append(userGroup).append(" ");
 			}
 		}
 		sb.append("} ");
 
 		sb.append("userRoles={");
-		if(userRoles != null) {
-			for(String role : userRoles) {
+		if (userRoles != null) {
+			for (String role : userRoles) {
 				sb.append(role).append(" ");
 			}
 		}
@@ -373,8 +391,8 @@ public class RangerAccessRequestImpl implements RangerAccessRequest {
 		sb.append("clusterType={").append(clusterType).append("} ");
 
 		sb.append("context={");
-		if(context != null) {
-			for(Map.Entry<String, Object> e : context.entrySet()) {
+		if (context != null) {
+			for (Map.Entry<String, Object> e : context.entrySet()) {
 				Object val = e.getValue();
 
 				if (!(val instanceof RangerAccessRequest)) { // to avoid recursive calls
@@ -388,6 +406,7 @@ public class RangerAccessRequestImpl implements RangerAccessRequest {
 
 		return sb;
 	}
+
 	@Override
 	public RangerAccessRequest getReadOnlyCopy() {
 		return new RangerAccessRequestReadOnly(this);

--- a/agents-common/src/main/java/org/apache/ranger/plugin/policyengine/RangerAccessRequestReadOnly.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/policyengine/RangerAccessRequestReadOnly.java
@@ -54,6 +54,9 @@ public class RangerAccessRequestReadOnly implements RangerAccessRequest {
 	public boolean isAccessTypeAny() { return source.isAccessTypeAny(); }
 
 	@Override
+	public boolean ignoreDescendantDeny() { return source.ignoreDescendantDeny(); }
+
+	@Override
 	public boolean isAccessTypeDelegatedAdmin() { return source.isAccessTypeDelegatedAdmin(); }
 
 	@Override

--- a/agents-common/src/main/java/org/apache/ranger/plugin/policyengine/RangerAccessRequestWrapper.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/policyengine/RangerAccessRequestWrapper.java
@@ -48,6 +48,9 @@ public class RangerAccessRequestWrapper implements RangerAccessRequest {
     public String getAccessType() { return accessType; }
 
     @Override
+    public boolean ignoreDescendantDeny() { return request.ignoreDescendantDeny(); }
+
+    @Override
     public boolean isAccessTypeAny() { return isAccessTypeAny; }
 
     @Override

--- a/agents-common/src/main/java/org/apache/ranger/plugin/policyengine/RangerPolicyEngineImpl.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/policyengine/RangerPolicyEngineImpl.java
@@ -52,6 +52,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.apache.ranger.plugin.policyengine.PolicyEvaluatorForTag.MATCH_TYPE_COMPARATOR;
 
@@ -680,6 +681,10 @@ public class RangerPolicyEngineImpl implements RangerPolicyEngine {
 			}
 			RangerAccessRequestUtil.setAllRequestedAccessTypes(request.getContext(), allRequestedAccesses);
 			RangerAccessRequestUtil.setIsAnyAccessInContext(request.getContext(), Boolean.TRUE);
+			if (!request.ignoreDescendantDeny()) {
+				Set<Set<String>> accessGroups = allRequestedAccesses.stream().map(Collections::singleton).collect(Collectors.toSet());
+				RangerAccessRequestUtil.setAllRequestedAccessTypeGroups(request, accessGroups);
+			}
 		}
 
 		ret = evaluatePoliciesForOneAccessTypeNoAudit(request, policyType, zoneName, policyRepository, tagPolicyRepository);

--- a/agents-common/src/main/java/org/apache/ranger/plugin/policyengine/RangerTagAccessRequest.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/policyengine/RangerTagAccessRequest.java
@@ -61,6 +61,7 @@ public class RangerTagAccessRequest extends RangerAccessRequestImpl {
 		super.setForwardedAddresses(request.getForwardedAddresses());
 		super.setSessionId(request.getSessionId());
 		super.setResourceMatchingScope(request.getResourceMatchingScope());
+		super.setIgnoreDescendantDeny(request.ignoreDescendantDeny());
 	}
 	public RangerPolicyResourceMatcher.MatchType getMatchType() {
 		return matchType;

--- a/agents-common/src/main/java/org/apache/ranger/plugin/policyevaluator/RangerDefaultPolicyEvaluator.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/policyevaluator/RangerDefaultPolicyEvaluator.java
@@ -539,7 +539,7 @@ public class RangerDefaultPolicyEvaluator extends RangerAbstractPolicyEvaluator 
 			LOG.debug("==> RangerDefaultPolicyEvaluator.updateAccessResult(" + result + ", " + matchType +", " + isAllowed + ", " + reason + ", " + getPolicyId() + ")");
 		}
 		if (!isAllowed) {
-			if (matchType != RangerPolicyResourceMatcher.MatchType.DESCENDANT) {
+			if (matchType != RangerPolicyResourceMatcher.MatchType.DESCENDANT || !result.getAccessRequest().ignoreDescendantDeny()) {
 				result.setIsAllowed(false);
 				result.setPolicyPriority(getPolicyPriority());
 				result.setPolicyId(getPolicyId());
@@ -876,11 +876,13 @@ public class RangerDefaultPolicyEvaluator extends RangerAbstractPolicyEvaluator 
 							}
 						}
 					}
-					/* At least one access is allowed - this evaluator need not be checked for other accesses as the test below
+					/* At least one access is allowed or denied - this evaluator need not be checked for other accesses as the test below
 					 * implies that there is only one access group in the request
 					 */
 					if (oneRequest.isAccessTypeAny() || RangerAccessRequestUtil.getIsAnyAccessInContext(oneRequest.getContext())) {
-						if (allowResult != null) {
+						if (oneRequest.ignoreDescendantDeny() && allowResult != null) {
+							break;
+						} else if (!oneRequest.ignoreDescendantDeny() && denyResult != null) {
 							break;
 						}
 					}

--- a/agents-common/src/test/resources/policyengine/test_policyengine_tag_hive_filebased.json
+++ b/agents-common/src/test/resources/policyengine/test_policyengine_tag_hive_filebased.json
@@ -225,13 +225,37 @@
   },
 
   "tests":[
-    {"name":"DENY 'select from employee.personal;' for user1 using EXPIRES_ON tag",
+    {"name":"ALLOW 'select from employee.personal;' for user1 using EXPIRES_ON tag",
       "request":{
         "resource":{"elements":{"database":"employee", "table":"personal"}}, "resourceMatchingScope": "SELF_OR_DESCENDANTS",
         "accessType":"select","user":"user1","userGroups":[],"requestData":"select from employee.personal;' for user1"
 
       },
       "result":{"isAudited":true,"isAllowed":true,"policyId":101}
+    },
+    {"name":"DENY 'select from employee.personal;' for user1 using EXPIRES_ON tag with isDescendantDenyIgnored=false",
+      "request":{
+        "resource":{"elements":{"database":"employee", "table":"personal"}}, "resourceMatchingScope": "SELF_OR_DESCENDANTS", "isDescendantDenyIgnored": false,
+        "accessType":"select","user":"user1","userGroups":[],"requestData":"select from employee.personal;' for user1 with isDescendantDenyIgnored=false"
+
+      },
+      "result":{"isAudited":true,"isAllowed":false,"policyId":5}
+    },
+    {"name":"ALLOW 'use employee;' for user1 using EXPIRES_ON tag",
+      "request":{
+        "resource":{"elements":{"database":"employee"}},
+        "accessType":"","user":"user1","userGroups":[],"requestData":"use employee;' for user1 using EXPIRES_ON tag"
+
+      },
+      "result":{"isAudited":true,"isAllowed":true,"policyId":101}
+    },
+    {"name":"DENY 'use employee;' for user1 using EXPIRES_ON tag with isDescendantDenyIgnored=false",
+      "request":{
+        "resource":{"elements":{"database":"employee"}}, "isDescendantDenyIgnored": false,
+        "accessType":"","user":"user1","userGroups":[],"requestData":"use employee;' for user1 using EXPIRES_ON tag with isDescendantDenyIgnored=false"
+
+      },
+      "result":{"isAudited":true,"isAllowed":false,"policyId":5}
     },
     {"name":"ALLOW 'select ssn from employee.personal;' for user1 using EXPIRES_ON tag",
       "request":{

--- a/hbase-agent/src/main/java/org/apache/ranger/authorization/hbase/AuthorizationSession.java
+++ b/hbase-agent/src/main/java/org/apache/ranger/authorization/hbase/AuthorizationSession.java
@@ -64,6 +64,8 @@ public class AuthorizationSession {
 	boolean _superUser = false; // is this session for a super user?
 	private RangerAccessRequest.ResourceMatchingScope _resourceMatchingScope = RangerAccessRequest.ResourceMatchingScope.SELF;
 
+	private boolean _ignoreDescendantDeny = true;
+
 	// internal state per-authorization
 	RangerAccessRequest _request;
 	RangerAccessResult _result;
@@ -195,7 +197,7 @@ public class AuthorizationSession {
 		request.setClientIPAddress(_remoteAddress);
 		request.setResourceMatchingScope(_resourceMatchingScope);
 		request.setAccessTime(new Date());
-		
+		request.setIgnoreDescendantDeny(_ignoreDescendantDeny);
 		_request = request;
 		if (LOG.isDebugEnabled()) {
 			LOG.debug("Built request: " + request.toString());
@@ -375,6 +377,10 @@ public class AuthorizationSession {
 
 	AuthorizationSession resourceMatchingScope(RangerAccessRequest.ResourceMatchingScope scope) {
 		_resourceMatchingScope = scope;
+		return this;
+	}
+	AuthorizationSession ignoreDescendantDeny(boolean ignoreDescendantDeny) {
+		_ignoreDescendantDeny = ignoreDescendantDeny;
 		return this;
 	}
 }

--- a/hbase-agent/src/main/java/org/apache/ranger/authorization/hbase/RangerAuthorizationCoprocessor.java
+++ b/hbase-agent/src/main/java/org/apache/ranger/authorization/hbase/RangerAuthorizationCoprocessor.java
@@ -441,6 +441,7 @@ public class RangerAuthorizationCoprocessor implements AccessControlService.Inte
 					LOG.debug("evaluateAccess: family level access for [" + family + "] is evaluated to " + isColumnFamilyAuthorized + ". Checking if [" + family + "] descendants have access.");
 				}
 				session.resourceMatchingScope(RangerAccessRequest.ResourceMatchingScope.SELF_OR_DESCENDANTS)
+						.ignoreDescendantDeny(false)
 						.buildRequest()
 						.authorize();
 				auditEvent = auditHandler.getAndDiscardMostRecentEvent(); // capture it only for failure
@@ -488,6 +489,7 @@ public class RangerAuthorizationCoprocessor implements AccessControlService.Inte
 				}
 				// Restore the headMatch setting
 				session.resourceMatchingScope(RangerAccessRequest.ResourceMatchingScope.SELF);
+				session.ignoreDescendantDeny(true);
 			} else {
 				LOG.debug("evaluateAccess: columns collection not empty.  Skipping Family level check, will do finer level access check.");
 				Set<String> accessibleColumns = new HashSet<String>(); // will be used in to populate our results cache for the filter

--- a/hbase-agent/src/test/java/org/apache/ranger/authorization/hbase/TestPolicyEngine.java
+++ b/hbase-agent/src/test/java/org/apache/ranger/authorization/hbase/TestPolicyEngine.java
@@ -82,6 +82,12 @@ public class TestPolicyEngine {
 
 		runTestsFromResourceFiles(hbaseTestResourceFiles);
 	}
+	@Test
+	public void testPolicyEngine_hbase_ignoreDescendantDeny() {
+		String[] hbaseTestResourceFiles = { "/policyengine/test_policyengine_hbase_ignoreDenyDescendant.json" };
+
+		runTestsFromResourceFiles(hbaseTestResourceFiles);
+	}
 
 	private void runTestsFromResourceFiles(String[] resourceNames) {
 		for(String resourceName : resourceNames) {

--- a/hbase-agent/src/test/resources/policyengine/test_policyengine_hbase_ignoreDenyDescendant.json
+++ b/hbase-agent/src/test/resources/policyengine/test_policyengine_hbase_ignoreDenyDescendant.json
@@ -1,0 +1,55 @@
+{
+  "serviceName":"hbasedev",
+
+  "serviceDef":{
+    "name":"hbase",
+    "id":2,
+    "resources":[
+      {"name":"table","level":1,"parent":"","mandatory":true,"lookupSupported":true,"matcher":"org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher","matcherOptions":{"wildCard":true, "ignoreCase":true},"label":"HBase Table","description":"HBase Table"},
+      {"name":"column-family","level":2,"parent":"table","mandatory":true,"lookupSupported":true,"matcher":"org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher","matcherOptions":{"wildCard":true, "ignoreCase":true},"label":"HBase Column-Family","description":"HBase Column-Family"},
+      {"name":"column","level":3,"parent":"column-family","mandatory":true,"lookupSupported":true,"matcher":"org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher","matcherOptions":{"wildCard":true, "ignoreCase":true},"label":"HBase Column","description":"HBase Column"}
+    ],
+    "accessTypes":[
+      {"name":"read","label":"Read"},
+      {"name":"write","label":"Write"},
+      {"name":"create","label":"Create"},
+      {"name":"admin","label":"Admin","impliedGrants":["read","write","create"]}
+    ]
+  },
+
+  "policies":[
+    {"id":1,"name":"table=finance; column-family=restricted, column=restricted_column","isEnabled":true,"isAuditEnabled":true,
+      "resources":{"table":{"values":["finance"]},"column-family":{"values":["restricted_cf"]}, "column":{"values":["restricted_column"]}},
+      "denyPolicyItems":[
+        {"accesses":[{"type":"read","isAllowed":true}],"users":["user1"],"groups":[],"delegateAdmin":false}
+      ]
+    }
+  ,
+    {"id":2,"name":"table=finance; column-family=restricted,column=*","isEnabled":true,"isAuditEnabled":true,
+      "resources":{"table":{"values":["finance"]},"column-family":{"values":["restricted_cf"]}, "column":{"values":["*"]}},
+      "policyItems":[
+        {"accesses":[{"type":"read","isAllowed":true}],"users":["user1"],"groups":[],"delegateAdmin":false}
+      ]
+    }
+  ],
+
+  "tests":[
+    {"name":"TEST!!! DENY 'get' for restricted column family when isDescendantDenyIgnored=false",
+      "request":{
+        "resource":{"elements":{"table":"finance","column-family":"restricted_cf"}},
+        "resourceMatchingScope": "SELF_OR_DESCENDANTS","isDescendantDenyIgnored": "false",
+        "accessType":"read","user":"user1","requestData":"deny get as there is a restricted column. Expected behavior for scan"
+      },
+      "result":{"isAudited":true,"isAllowed":false,"policyId":1}
+    },
+    {"name":"TEST!!! Allow 'get' for restricted column family when isDescendantDenyIgnored=true",
+      "request":{
+        "resource":{"elements":{"table":"finance","column-family":"restricted_cf"}},
+        "resourceMatchingScope": "SELF_OR_DESCENDANTS",
+        "accessType":"read","user":"user1","requestData":"allow get as restricted column policy not considered. Not expected behavior"
+      },
+      "result":{"isAudited":true,"isAllowed":true,"policyId":2}
+    }
+
+  ]
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?
RANGER-5001: Support for ignoreDescendantDeny
RANGER-4977: Use ignoreDescendantDeny in hbase plugin so that if there is any denied column then the column family is returned in the filter during the scan operation (and further authorization is done at column level later). 


## How was this patch tested?
Added new unit tests
Existing unit tests pass
