### PR TITLE
RANGER-4942: Fix docker build with Dockerfile.ranger-build and update env variables with ENV key=value format

### DIFF
--- a/dev-support/ranger-docker/Dockerfile.ranger
+++ b/dev-support/ranger-docker/Dockerfile.ranger
@@ -22,9 +22,10 @@ ARG RANGER_DB_TYPE
 ARG TARGETARCH
 ARG RANGER_ADMIN_JAVA_VERSION
 
-RUN if [ "${OS_NAME}" == "UBUNTU" ]; then\
-    ENV JAVA_HOME      /usr/lib/jvm/java-${RANGER_ADMIN_JAVA_VERSION}-openjdk-${TARGETARCH}\
-    update-java-alternatives --set /usr/lib/jvm/java-1.${RANGER_ADMIN_JAVA_VERSION}.0-openjdk-${TARGETARCH};\
+ENV JAVA_HOME=/usr/lib/jvm/java-1.${RANGER_ADMIN_JAVA_VERSION}.0-openjdk-${TARGETARCH}
+
+RUN if [ "${OS_NAME}" = "UBUNTU" ]; then\
+    update-java-alternatives --set "$JAVA_HOME";\
     fi
 
 COPY ./dist/version                               /home/ranger/dist/

--- a/dev-support/ranger-docker/Dockerfile.ranger-base
+++ b/dev-support/ranger-docker/Dockerfile.ranger-base
@@ -19,7 +19,7 @@ FROM ubuntu:${UBUNTU_VERSION}
 
 ARG TARGETARCH
 ARG RANGER_BASE_JAVA_VERSION
-ENV OS_NAME UBUNTU
+ENV OS_NAME=UBUNTU
 
 # Install tzdata, Python, Java, python-requests
 RUN apt-get update && \
@@ -29,11 +29,11 @@ RUN apt-get update && \
     pip3 install requests
 
 # Set environment variables
-ENV JAVA_HOME      /usr/lib/jvm/java-${RANGER_BASE_JAVA_VERSION}-openjdk-${TARGETARCH}
-ENV RANGER_DIST    /home/ranger/dist
-ENV RANGER_SCRIPTS /home/ranger/scripts
-ENV RANGER_HOME    /opt/ranger
-ENV PATH           /usr/java/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ENV JAVA_HOME=/usr/lib/jvm/java-${RANGER_BASE_JAVA_VERSION}-openjdk-${TARGETARCH}
+ENV RANGER_DIST=/home/ranger/dist
+ENV RANGER_SCRIPTS=/home/ranger/scripts
+ENV RANGER_HOME=/opt/ranger
+ENV PATH=/usr/java/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 RUN update-java-alternatives --set /usr/lib/jvm/java-1.${RANGER_BASE_JAVA_VERSION}.0-openjdk-${TARGETARCH}
 

--- a/dev-support/ranger-docker/Dockerfile.ranger-base-ubi
+++ b/dev-support/ranger-docker/Dockerfile.ranger-base-ubi
@@ -19,7 +19,7 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:${UBI_VERSION}
 
 USER root
 ARG RANGER_BASE_UBI_JAVA_VERSION
-ENV OS_NAME RHEL
+ENV OS_NAME=RHEL
 
 RUN microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs \
     install -y java-${RANGER_BASE_UBI_JAVA_VERSION}-openjdk-devel \
@@ -49,13 +49,14 @@ RUN microdnf install -y sudo
 RUN microdnf install -y initscripts
 RUN microdnf install -y openssh-clients
 RUN microdnf install -y openssh-server
+RUN microdnf install -y wget
 RUN pip3 install apache-ranger
 
 # Set environment variables
-ENV RANGER_HOME    /opt/ranger
-ENV RANGER_DIST    /home/ranger/dist
-ENV RANGER_SCRIPTS /home/ranger/scripts
-ENV PATH           /usr/java/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ENV RANGER_HOME=/opt/ranger
+ENV RANGER_DIST=/home/ranger/dist
+ENV RANGER_SCRIPTS=/home/ranger/scripts
+ENV PATH=/usr/java/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 RUN sudo sed -i 's/^HOME_MODE.*/HOME_MODE 0755/' /etc/login.defs
 

--- a/dev-support/ranger-docker/Dockerfile.ranger-build
+++ b/dev-support/ranger-docker/Dockerfile.ranger-build
@@ -19,20 +19,21 @@ FROM ranger-base:latest
 ARG RANGER_BUILD_JAVA_VERSION
 ARG TARGETARCH
 
+ENV JAVA_HOME=/usr/lib/jvm/java-1.${RANGER_BUILD_JAVA_VERSION}.0-openjdk-${TARGETARCH}
+
 # Install necessary packages to build Ranger
-RUN if [ "${OS_NAME}" == "UBUNTU" ]; then\
-    apt-get update && apt-get -y install git maven build-essential\
-    update-java-alternatives --set /usr/lib/jvm/java-1.${RANGER_BUILD_JAVA_VERSION}.0-openjdk-${TARGETARCH}\
-    ENV JAVA_HOME  /usr/lib/jvm/java-${RANGER_BUILD_JAVA_VERSION}-openjdk-${TARGETARCH};\
+RUN if [ "${OS_NAME}" = "UBUNTU" ]; then\
+    apt-get update && apt-get -y install git maven build-essential;\
+    update-java-alternatives --set "$JAVA_HOME";\
     fi
 
-RUN if [ "${OS_NAME}" == "RHEL" ]; then\
+RUN if [ "${OS_NAME}" = "RHEL" ]; then\
     microdnf install -y git maven gcc;\
     fi
 
 # Set environment variables
-ENV MAVEN_HOME /usr/share/maven
-ENV PATH       /usr/java/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/apache-maven/bin
+ENV MAVEN_HOME=/usr/share/maven
+ENV PATH=/usr/java/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/apache-maven/bin
 
 # setup ranger group, and users
 RUN mkdir -p /home/ranger/git && \

--- a/dev-support/ranger-docker/Dockerfile.ranger-hadoop
+++ b/dev-support/ranger-docker/Dockerfile.ranger-hadoop
@@ -46,12 +46,12 @@ RUN tar xvfz /home/ranger/dist/hadoop-${HADOOP_VERSION}.tar.gz --directory=/opt/
     chmod 744 ${RANGER_SCRIPTS}/ranger-hadoop-setup.sh ${RANGER_SCRIPTS}/ranger-hadoop.sh ${RANGER_SCRIPTS}/ranger-hadoop-mkdir.sh && \
     chown hdfs:hadoop ${RANGER_SCRIPTS}/ranger-hadoop-mkdir.sh
 
-ENV HADOOP_HOME        /opt/hadoop
-ENV HADOOP_CONF_DIR    /opt/hadoop/etc/hadoop
-ENV HADOOP_HDFS_HOME   /opt/hadoop
-ENV HADOOP_MAPRED_HOME /opt/hadoop
-ENV HADOOP_COMMON_HOME /opt/hadoop
-ENV YARN_HOME          /opt/hadoop
-ENV PATH               /usr/java/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/hadoop/bin
+ENV HADOOP_HOME=/opt/hadoop
+ENV HADOOP_CONF_DIR=/opt/hadoop/etc/hadoop
+ENV HADOOP_HDFS_HOME=/opt/hadoop
+ENV HADOOP_MAPRED_HOME=/opt/hadoop
+ENV HADOOP_COMMON_HOME=/opt/hadoop
+ENV YARN_HOME=/opt/hadoop
+ENV PATH=/usr/java/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/hadoop/bin
 
 ENTRYPOINT [ "/home/ranger/scripts/ranger-hadoop.sh" ]

--- a/dev-support/ranger-docker/Dockerfile.ranger-hbase
+++ b/dev-support/ranger-docker/Dockerfile.ranger-hbase
@@ -38,7 +38,7 @@ RUN tar xvfz /home/ranger/dist/hbase-${HBASE_VERSION}-bin.tar.gz --directory=/op
     cp -f /home/ranger/scripts/ranger-hbase-plugin-install.properties /opt/ranger/ranger-hbase-plugin/install.properties && \
     chmod 744 ${RANGER_SCRIPTS}/ranger-hbase-setup.sh ${RANGER_SCRIPTS}/ranger-hbase.sh
 
-ENV HBASE_HOME /opt/hbase
-ENV PATH       /usr/java/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/hbase/bin
+ENV HBASE_HOME=/opt/hbase
+ENV PATH=/usr/java/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/hbase/bin
 
 ENTRYPOINT [ "/home/ranger/scripts/ranger-hbase.sh" ]

--- a/dev-support/ranger-docker/Dockerfile.ranger-hive
+++ b/dev-support/ranger-docker/Dockerfile.ranger-hive
@@ -46,9 +46,9 @@ RUN tar xvfz /home/ranger/dist/apache-hive-${HIVE_VERSION}-bin.tar.gz --director
     cp -f /home/ranger/scripts/ranger-hive-plugin-install.properties /opt/ranger/ranger-hive-plugin/install.properties && \
     chmod 744 ${RANGER_SCRIPTS}/ranger-hive-setup.sh ${RANGER_SCRIPTS}/ranger-hive.sh
 
-ENV HIVE_HOME   /opt/hive
-ENV HADOOP_HOME /opt/hadoop
-ENV PATH        /usr/java/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/hive/bin:/opt/hadoop/bin
+ENV HIVE_HOME=/opt/hive
+ENV HADOOP_HOME=/opt/hadoop
+ENV PATH=/usr/java/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/hive/bin:/opt/hadoop/bin
 
 
 ENTRYPOINT [ "/home/ranger/scripts/ranger-hive.sh" ]

--- a/dev-support/ranger-docker/Dockerfile.ranger-kafka
+++ b/dev-support/ranger-docker/Dockerfile.ranger-kafka
@@ -37,7 +37,7 @@ RUN tar xvfz /home/ranger/dist/kafka_2.12-${KAFKA_VERSION}.tgz --directory=/opt/
     cp -f /home/ranger/scripts/ranger-kafka-plugin-install.properties /opt/ranger/ranger-kafka-plugin/install.properties && \
     chmod 744 ${RANGER_SCRIPTS}/ranger-kafka-setup.sh ${RANGER_SCRIPTS}/ranger-kafka.sh
 
-ENV KAFKA_HOME /opt/kafka
-ENV PATH       /usr/java/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/kafka/bin
+ENV KAFKA_HOME=/opt/kafka
+ENV PATH=/usr/java/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/kafka/bin
 
 ENTRYPOINT [ "/home/ranger/scripts/ranger-kafka.sh" ]

--- a/dev-support/ranger-docker/Dockerfile.ranger-knox
+++ b/dev-support/ranger-docker/Dockerfile.ranger-knox
@@ -40,8 +40,8 @@ RUN tar xvfz /home/ranger/dist/knox-${KNOX_VERSION}.tar.gz --directory=/opt/ && 
     cp -f /home/ranger/scripts/ranger-knox-sandbox.xml /opt/knox/conf/topologies/sandbox.xml && \
     chmod 744 ${RANGER_SCRIPTS}/ranger-knox-setup.sh ${RANGER_SCRIPTS}/ranger-knox.sh ${RANGER_SCRIPTS}/ranger-knox-expect.py
 
-ENV KNOX_HOME  /opt/knox
-ENV PATH       /usr/java/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/knox/bin
+ENV KNOX_HOME=/opt/knox
+ENV PATH=/usr/java/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/knox/bin
 
 RUN chmod a+rwx /home/ranger/scripts/ranger-knox-expect.py
 

--- a/dev-support/ranger-docker/Dockerfile.ranger-mysql
+++ b/dev-support/ranger-docker/Dockerfile.ranger-mysql
@@ -26,4 +26,4 @@ COPY config/my.cnf /home/mysql/.my.cnf
 RUN sed -i "s/skip-name-resolve/# skip-name-resolve/" /etc/mysql/mariadb.cnf
 RUN chown -R mysql:mysql /docker-entrypoint-initdb.d/ /home/mysql
 
-ENV MYSQL_ROOT_PASSWORD rangerR0cks!
+ENV MYSQL_ROOT_PASSWORD=rangerR0cks!

--- a/dev-support/ranger-docker/Dockerfile.ranger-postgres
+++ b/dev-support/ranger-docker/Dockerfile.ranger-postgres
@@ -22,4 +22,4 @@ USER 0
 RUN  mkdir -p /docker-entrypoint-initdb.d
 COPY config/init_postgres.sh /docker-entrypoint-initdb.d/
 RUN chown -R postgres:postgres /docker-entrypoint-initdb.d/
-ENV POSTGRES_PASSWORD rangerR0cks!
+ENV POSTGRES_PASSWORD=rangerR0cks!


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Fixes bugs in `Dockerfile.ranger-build` and `Dockerfile.ranger`
- Fixes docker build using `docker-compose.ranger-build.yml`
- Updates environment variables in Dockerfiles with the recommended format and drops legacy format.

## How was this patch tested?

- `docker-compose -f docker-compose.ranger-base.yml -f docker-compose.ranger-build.yml up -d`
- CI successful
- Verified all containers are running in local docker setup.
