### PR TITLE
RANGER-5016: Deprecate use of version field in docker-compose.yaml

### DIFF
--- a/dev-support/ranger-docker/docker-compose.ranger-base-ubi.yml
+++ b/dev-support/ranger-docker/docker-compose.ranger-base-ubi.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   ranger-base:
     build:

--- a/dev-support/ranger-docker/docker-compose.ranger-base.yml
+++ b/dev-support/ranger-docker/docker-compose.ranger-base.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   ranger-base:
     build:

--- a/dev-support/ranger-docker/docker-compose.ranger-build.yml
+++ b/dev-support/ranger-docker/docker-compose.ranger-build.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   ranger-build:
     build:

--- a/dev-support/ranger-docker/docker-compose.ranger-hadoop.yml
+++ b/dev-support/ranger-docker/docker-compose.ranger-hadoop.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   ranger-hadoop:
     build:

--- a/dev-support/ranger-docker/docker-compose.ranger-hbase.yml
+++ b/dev-support/ranger-docker/docker-compose.ranger-hbase.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   ranger-hbase:
     build:

--- a/dev-support/ranger-docker/docker-compose.ranger-hive.yml
+++ b/dev-support/ranger-docker/docker-compose.ranger-hive.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   ranger-hive:
     build:

--- a/dev-support/ranger-docker/docker-compose.ranger-kafka.yml
+++ b/dev-support/ranger-docker/docker-compose.ranger-kafka.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   ranger-kafka:
     build:

--- a/dev-support/ranger-docker/docker-compose.ranger-kms.yml
+++ b/dev-support/ranger-docker/docker-compose.ranger-kms.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   ranger-kms:
     build:

--- a/dev-support/ranger-docker/docker-compose.ranger-knox.yml
+++ b/dev-support/ranger-docker/docker-compose.ranger-knox.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   ranger-knox:
     build:

--- a/dev-support/ranger-docker/docker-compose.ranger-mysql.yml
+++ b/dev-support/ranger-docker/docker-compose.ranger-mysql.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   ranger-db:
     build:

--- a/dev-support/ranger-docker/docker-compose.ranger-ozone.yml
+++ b/dev-support/ranger-docker/docker-compose.ranger-ozone.yml
@@ -1,20 +1,3 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-version: "3"
 services:
   datanode:
     image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}

--- a/dev-support/ranger-docker/docker-compose.ranger-postgres-mounted.yml
+++ b/dev-support/ranger-docker/docker-compose.ranger-postgres-mounted.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   ranger-db:
     build:

--- a/dev-support/ranger-docker/docker-compose.ranger-postgres.yml
+++ b/dev-support/ranger-docker/docker-compose.ranger-postgres.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   ranger-db:
     build:

--- a/dev-support/ranger-docker/docker-compose.ranger-tagsync.yml
+++ b/dev-support/ranger-docker/docker-compose.ranger-tagsync.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   ranger-tagsync:
     build:

--- a/dev-support/ranger-docker/docker-compose.ranger-trino.yml
+++ b/dev-support/ranger-docker/docker-compose.ranger-trino.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   trino:
     build:

--- a/dev-support/ranger-docker/docker-compose.ranger-usersync.yml
+++ b/dev-support/ranger-docker/docker-compose.ranger-usersync.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   ranger-usersync:
     build:

--- a/dev-support/ranger-docker/docker-compose.ranger.yml
+++ b/dev-support/ranger-docker/docker-compose.ranger.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   ranger:
     build:


### PR DESCRIPTION
## What changes were proposed in this pull request?

Since Docker Compose V2, `version` field is no longer supported, hence removing it.


## How was this patch tested?

CI docker tests
