### PR TITLE
RANGER-5065. Disable releases for apache.snapshots repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -779,6 +779,9 @@
     </issueManagement>
     <repositories>
         <repository>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>


### PR DESCRIPTION
## What changes were proposed in this pull request?

The Apache snapshot repository should be enabled only for snapshots.  `enabled` is true by default, so `releases` being omitted means it's enabled.

```
$ mvn --batch-mode --non-recursive eu.maveniverse.maven.plugins:toolbox:list-repositories | grep snapshot   
[INFO]  * apache.snapshots.https (https://repository.apache.org/content/repositories/snapshots, default, releases+snapshots)
[INFO]  * jetbrains-pty4j (https://packages.jetbrains.team/maven/p/ij/intellij-dependencies, default, releases+snapshots)
[INFO]  * apache.snapshots (https://repository.apache.org/snapshots, default, snapshots)
```

https://issues.apache.org/jira/browse/RANGER-5065

## How was this patch tested?

`apache.snapshots.https` is enabled only for snapshots:

```
$ mvn --batch-mode --non-recursive eu.maveniverse.maven.plugins:toolbox:list-repositories | grep snapshot   
[INFO]  * apache.snapshots.https (https://repository.apache.org/content/repositories/snapshots, default, snapshots)
[INFO]  * jetbrains-pty4j (https://packages.jetbrains.team/maven/p/ij/intellij-dependencies, default, releases+snapshots)
[INFO]  * apache.snapshots (https://repository.apache.org/snapshots, default, snapshots)
```