### PR TITLE
RANGER-5066. Improve CI workflow

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -29,6 +29,9 @@ on:
   pull_request:
     branches: [ "master" ]
 
+env:
+  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
+
 jobs:
   build-8:
     runs-on: ubuntu-latest

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -104,7 +104,7 @@ jobs:
           cp version dev-support/ranger-docker/dist
       
       - name: Cache downloaded archives
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: dev-support/ranger-docker/downloads
           key: ${{ runner.os }}-ranger-downloads-${{ hashFiles('dev-support/ranger-docker/.env') }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -26,7 +26,6 @@ name: CI
 
 on:
   push:
-    branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
 
@@ -35,14 +34,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Cache for maven dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.m2/repository/*/*/*
+            !~/.m2/repository/org/apache/ranger
+          key: maven-repo-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            maven-repo-
       - name: Set up JDK 8
         uses: actions/setup-java@v4
         with:
           java-version: '8'
           distribution: 'temurin'
-          cache: maven
       - name: build (8)
-        run: mvn -T 8 clean install --no-transfer-progress -B -V
+        run: mvn -T 8 clean verify --no-transfer-progress -B -V
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -50,17 +57,27 @@ jobs:
           path: target/*
 
   build-11:
+    needs:
+      - build-8
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Cache for maven dependencies
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            ~/.m2/repository/*/*/*
+            !~/.m2/repository/org/apache/ranger
+          key: maven-repo-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            maven-repo-
       - name: Set up JDK 11
         uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'temurin'
-          cache: maven
       - name: build (11)
-        run: mvn -T 8 clean install -pl '!knox-agent' --no-transfer-progress -B -V
+        run: mvn -T 8 clean verify -pl '!knox-agent' --no-transfer-progress -B -V
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -70,7 +87,6 @@ jobs:
   docker-build:
     needs:
       - build-8
-      - build-11
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/pom.xml
+++ b/pom.xml
@@ -779,28 +779,6 @@
     </issueManagement>
     <repositories>
         <repository>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <id>apache.snapshots.https</id>
-            <name>Apache Development Snapshot Repository</name>
-            <url>https://repository.apache.org/content/repositories/snapshots</url>
-        </repository>
-        <repository>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-            <id>apache.public.https</id>
-            <name>Apache Development Snapshot Repository</name>
-            <url>https://repository.apache.org/content/repositories/public</url>
-        </repository>
-        <repository>
             <id>jetbrains-pty4j</id>
             <name>jetbrains-intellij-dependencies</name>
             <url>https://packages.jetbrains.team/maven/p/ij/intellij-dependencies</url>


### PR DESCRIPTION
## What changes were proposed in this pull request?

I would like to propose some improvements for the CI workflow:

- Use `actions/cache` instead of `setup-java`'s simple cache option.  This allows restoring "similar" caches, not just exact cache hits.
- Run `build-11` only after `build-8`.  If Java 8 build fails, no need to spend time trying with Java 11.  Run `build-11` and `docker-build` (test) concurrently.
- Run the workflow on `push` for any branch.  This allows contributors to run the workflow in their fork, to get CI feedback before opening PR.  (Without pushing to `master` in their fork.)

Also, remove Apache repo definitions.  Without this, build was timing out.

https://issues.apache.org/jira/browse/RANGER-5066

## How was this patch tested?

CI:
https://github.com/adoroszlai/ranger/actions/runs/12241913402