### PR TITLE
RANGER-5068: Bump rat-plugin to 0.16.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -568,7 +568,7 @@
             <plugin>
                 <groupId>org.apache.rat</groupId>
                 <artifactId>apache-rat-plugin</artifactId>
-                <version>0.11</version>
+                <version>0.16.1</version>
                 <configuration>
                     <excludeSubProjects>false</excludeSubProjects>
                     <excludes>
@@ -579,6 +579,7 @@
                         <exclude>**/src/main/webapp/fonts/**</exclude>
                         <exclude>**/src/main/webapp/libs/**</exclude>
                         <exclude>.git/**</exclude>
+                        <exclude>.gitattributes/**</exclude>
                         <exclude>.github/pull_request_template.md</exclude>
                         <exclude>.pc/**</exclude>
                         <exclude>debian/**</exclude>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Bump `apache-rat-plugin` version to `0.16.1` 

This version of plugin is thread-safe

## How was this patch tested?

CI

Re-opened from #428 