### PR TITLE
RANGER-5071: CI - Revert to ubuntu-22.04 runner

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -34,7 +34,7 @@ env:
 
 jobs:
   build-8:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
@@ -52,8 +52,6 @@ jobs:
         with:
           java-version: '8'
           distribution: 'temurin'
-      - name: Install missing libraries
-        run: sudo apt-get install -y libssl-dev
       - name: build (8)
         run: mvn -T 8 clean verify --no-transfer-progress -B -V
       - name: Upload artifacts
@@ -65,7 +63,7 @@ jobs:
   build-11:
     needs:
       - build-8
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
@@ -94,7 +92,7 @@ jobs:
   docker-build:
     needs:
       - build-8
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -52,6 +52,8 @@ jobs:
         with:
           java-version: '8'
           distribution: 'temurin'
+      - name: Install missing libraries
+        run: sudo apt-get install -y libssl-dev
       - name: build (8)
         run: mvn -T 8 clean verify --no-transfer-progress -B -V
       - name: Upload artifacts


### PR DESCRIPTION
## What changes were proposed in this pull request?

GitHub notifications on running pipelines indicate:

`ubuntu-latest pipelines will use ubuntu-24.04 soon. For more details, see https://github.com/actions/runner-images/issues/10636`

Recent CI builds are running on `ubuntu-24.04` which is causing PhantomJS dependent tests to fail.

Upgrade to `ubuntu-24.04` would have updated core libraries like OpenSSL and potentially removed older versions that PhantomJS depends on, such as libssl1.1. 

Switching to `ubuntu-22.04` to get the CI builds going.


## How was this patch tested?

Ongoing.
