### PR TITLE
RANGER-5069: Add ability to Kafka authorizer to define super users through Kafka config

### DIFF
--- a/agents-common/src/main/java/org/apache/ranger/authorization/hadoop/config/RangerPluginConfig.java
+++ b/agents-common/src/main/java/org/apache/ranger/authorization/hadoop/config/RangerPluginConfig.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.net.URL;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -56,7 +57,7 @@ public class RangerPluginConfig extends RangerConfiguration {
     private       Set<String>               auditExcludedUsers  = Collections.emptySet();
     private       Set<String>               auditExcludedGroups = Collections.emptySet();
     private       Set<String>               auditExcludedRoles  = Collections.emptySet();
-    private       Set<String>               superUsers          = Collections.emptySet();
+    private       Set<String>               superUsers          = new HashSet<>();
     private       Set<String>               superGroups         = Collections.emptySet();
     private       Set<String>               serviceAdmins       = Collections.emptySet();
 
@@ -224,7 +225,7 @@ public class RangerPluginConfig extends RangerConfiguration {
     }
 
     public void setSuperUsersGroups(Set<String> users, Set<String> groups) {
-        superUsers  = CollectionUtils.isEmpty(users) ? Collections.emptySet() : new HashSet<>(users);
+        superUsers  = CollectionUtils.isEmpty(users) ? new HashSet<>() : new HashSet<>(users);
         superGroups = CollectionUtils.isEmpty(groups) ? Collections.emptySet() : new HashSet<>(groups);
 
         LOG.debug("superUsers={}, superGroups={}", superUsers, superGroups);
@@ -256,6 +257,12 @@ public class RangerPluginConfig extends RangerConfiguration {
 
     public boolean isServiceAdmin(String userName) {
         return serviceAdmins.contains(userName);
+    }
+
+    public void addSuperUsers(Collection<String> users) {
+        if (users != null) {
+            superUsers.addAll(users);
+        }
     }
 
     private void addResourcesForServiceType(String serviceType) {

--- a/plugin-kafka/src/test/java/org/apache/ranger/authorization/kafka/authorizer/KafkaTestUtils.java
+++ b/plugin-kafka/src/test/java/org/apache/ranger/authorization/kafka/authorizer/KafkaTestUtils.java
@@ -28,6 +28,7 @@ import java.security.SecureRandom;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.Properties;
 
@@ -85,6 +86,14 @@ public final class KafkaTestUtils {
 					new NewTopic("test", 1, (short) 1),
 					new NewTopic("dev", 1, (short) 1)
 			));
+		}
+	}
+
+	static void createTopic(Properties adminProps, String topic) {
+		try (AdminClient adminClient = AdminClient.create(adminProps)) {
+			adminClient.createTopics(Collections.singletonList(
+          new NewTopic(topic, 1, (short) 1)
+      ));
 		}
 	}
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Kafka plugin has been extended to add super users from Kafka config automatically. The Kafka side config property is `super.users` as described in [Kafka authorization documentation](https://kafka.apache.org/documentation/#security_authz). Principals with the `User:` prefix are added to Ranger plugin super users.


## How was this patch tested?

- `KafkaRangerAuthorizerTest` has been extended and run locally via `mvn -am -Pranger-kafka-plugin test`.
- Manual tests have been performed in a local environment consisting of a Ranger server and Kafka cluster equipped with the new Kafka plugin changes.
