### PR TITLE
RANGER-5075: fix for plugin installation failures due to missing libraries

### DIFF
--- a/credentialbuilder/pom.xml
+++ b/credentialbuilder/pom.xml
@@ -53,6 +53,11 @@
             <version>${commons.collections.version}</version>
         </dependency>
         <dependency>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+            <version>${commons.logging.version}</version>
+        </dependency>
+        <dependency>
             <groupId>net.minidev</groupId>
             <artifactId>json-smart</artifactId>
             <version>${jsonsmart.version}</version>

--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -50,6 +50,12 @@
         </dependency>
         <dependency>
             <groupId>org.apache.ranger</groupId>
+            <artifactId>ldapconfigcheck</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.ranger</groupId>
             <artifactId>ranger-atlas-plugin</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
@@ -62,6 +68,18 @@
         </dependency>
         <dependency>
             <groupId>org.apache.ranger</groupId>
+            <artifactId>ranger-authn</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.ranger</groupId>
+            <artifactId>ranger-common-ha</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.ranger</groupId>
             <artifactId>ranger-elasticsearch-plugin</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
@@ -69,6 +87,12 @@
         <dependency>
             <groupId>org.apache.ranger</groupId>
             <artifactId>ranger-elasticsearch-plugin-shim</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.ranger</groupId>
+            <artifactId>ranger-examples-distro</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
@@ -128,6 +152,12 @@
         </dependency>
         <dependency>
             <groupId>org.apache.ranger</groupId>
+            <artifactId>ranger-kms</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.ranger</groupId>
             <artifactId>ranger-kms-plugin</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
@@ -165,6 +195,12 @@
         <dependency>
             <groupId>org.apache.ranger</groupId>
             <artifactId>ranger-kylin-plugin-shim</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.ranger</groupId>
+            <artifactId>ranger-metrics</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/distro/src/main/assembly/hbase-agent.xml
+++ b/distro/src/main/assembly/hbase-agent.xml
@@ -98,20 +98,20 @@
         <includeDependencies>true</includeDependencies>
         <unpack>false</unpack>
         <includes>
+          <include>com.fasterxml.woodstox:woodstox-core</include>
           <include>commons-cli:commons-cli</include>
           <include>commons-collections:commons-collections</include>
-          <include>org.apache.commons:commons-configuration2:jar:${commons.configuration.version}</include>
           <include>commons-io:commons-io:jar:${commons.io.version}</include>
           <include>commons-lang:commons-lang</include>
           <include>commons-logging:commons-logging:jar:${commons.logging.version}</include>
-          <include>org.apache.commons:commons-lang3:jar:${commons.lang3.version}</include>
           <include>org.apache.commons:commons-compress:jar:${commons.compress.version}</include>
-          <include>org.slf4j:slf4j-api:jar:${slf4j-api.version}</include>
-          <include>org.apache.hadoop:hadoop-common:jar:${hadoop.version}</include>
+          <include>org.apache.commons:commons-configuration2:jar:${commons.configuration.version}</include>
+          <include>org.apache.commons:commons-lang3:jar:${commons.lang3.version}</include>
           <include>org.apache.hadoop:hadoop-auth:jar:${hadoop.version}</include>
-          <include>org.codehaus.woodstox:stax2-api</include>
-          <include>com.fasterxml.woodstox:woodstox-core</include>
+          <include>org.apache.hadoop:hadoop-common:jar:${hadoop.version}</include>
           <include>org.apache.hadoop.thirdparty:hadoop-shaded-guava:jar:${hadoop-shaded-guava.version}</include>
+          <include>org.codehaus.woodstox:stax2-api</include>
+          <include>org.slf4j:slf4j-api:jar:${slf4j-api.version}</include>
         </includes>
       </binaries>
     </moduleSet>

--- a/distro/src/main/assembly/hdfs-agent.xml
+++ b/distro/src/main/assembly/hdfs-agent.xml
@@ -49,20 +49,20 @@
         <includeDependencies>true</includeDependencies>
         <unpack>false</unpack>
         <includes>
-          <include>commons-cli:commons-cli</include>
-          <include>commons-collections:commons-collections</include>
-          <include>org.apache.commons:commons-configuration2:jar:${commons.configuration.version}</include>
-          <include>org.apache.commons:commons-lang3:jar:${commons.lang3.version}</include>
-          <include>org.apache.commons:commons-compress:jar:${commons.compress.version}</include>
-          <include>commons-io:commons-io:jar:${commons.io.version}</include>
-          <include>commons-lang:commons-lang</include>
-          <include>commons-logging:commons-logging:jar:${commons.logging.version}</include>
-          <include>org.slf4j:slf4j-api:jar:${slf4j-api.version}</include>
-          <include>org.apache.hadoop:hadoop-common:jar:${hadoop.version}</include>
-          <include>org.apache.hadoop:hadoop-auth:jar:${hadoop.version}</include>
-          <include>org.codehaus.woodstox:stax2-api</include>
-          <include>com.fasterxml.woodstox:woodstox-core</include>
-          <include>org.apache.hadoop.thirdparty:hadoop-shaded-guava:jar:${hadoop-shaded-guava.version}</include>
+            <include>com.fasterxml.woodstox:woodstox-core</include>
+            <include>commons-cli:commons-cli</include>
+            <include>commons-collections:commons-collections</include>
+            <include>commons-io:commons-io:jar:${commons.io.version}</include>
+            <include>commons-lang:commons-lang</include>
+            <include>commons-logging:commons-logging:jar:${commons.logging.version}</include>
+            <include>org.apache.commons:commons-compress:jar:${commons.compress.version}</include>
+            <include>org.apache.commons:commons-configuration2:jar:${commons.configuration.version}</include>
+            <include>org.apache.commons:commons-lang3:jar:${commons.lang3.version}</include>
+            <include>org.apache.hadoop:hadoop-auth:jar:${hadoop.version}</include>
+            <include>org.apache.hadoop:hadoop-common:jar:${hadoop.version}</include>
+            <include>org.apache.hadoop.thirdparty:hadoop-shaded-guava:jar:${hadoop-shaded-guava.version}</include>
+            <include>org.codehaus.woodstox:stax2-api</include>
+            <include>org.slf4j:slf4j-api:jar:${slf4j-api.version}</include>
         </includes>
      </binaries>
     </moduleSet>

--- a/distro/src/main/assembly/hive-agent.xml
+++ b/distro/src/main/assembly/hive-agent.xml
@@ -90,20 +90,20 @@
         <includeDependencies>true</includeDependencies>
         <unpack>false</unpack>
         <includes>
+          <include>com.fasterxml.woodstox:woodstox-core</include>
           <include>commons-cli:commons-cli</include>
           <include>commons-collections:commons-collections</include>
-          <include>org.apache.commons:commons-configuration2:jar:${commons.configuration.version}</include>
-          <include>org.apache.commons:commons-lang3:jar:${commons.lang3.version}</include>
-          <include>org.apache.commons:commons-compress:jar:${commons.compress.version}</include>
           <include>commons-io:commons-io:jar:${commons.io.version}</include>
           <include>commons-lang:commons-lang</include>
           <include>commons-logging:commons-logging:jar:${commons.logging.version}</include>
-          <include>org.slf4j:slf4j-api:jar:${slf4j-api.version}</include>
-          <include>org.apache.hadoop:hadoop-common:jar:${hadoop.version}</include>
+          <include>org.apache.commons:commons-compress:jar:${commons.compress.version}</include>
+          <include>org.apache.commons:commons-configuration2:jar:${commons.configuration.version}</include>
+          <include>org.apache.commons:commons-lang3:jar:${commons.lang3.version}</include>
           <include>org.apache.hadoop:hadoop-auth:jar:${hadoop.version}</include>
-          <include>org.codehaus.woodstox:stax2-api</include>
-          <include>com.fasterxml.woodstox:woodstox-core</include>
+          <include>org.apache.hadoop:hadoop-common:jar:${hadoop.version}</include>
           <include>org.apache.hadoop.thirdparty:hadoop-shaded-guava:jar:${hadoop-shaded-guava.version}</include>
+          <include>org.codehaus.woodstox:stax2-api</include>
+          <include>org.slf4j:slf4j-api:jar:${slf4j-api.version}</include>
         </includes>
       </binaries>
     </moduleSet>

--- a/distro/src/main/assembly/kms.xml
+++ b/distro/src/main/assembly/kms.xml
@@ -334,20 +334,20 @@
                         <directoryMode>755</directoryMode>
                         <fileMode>644</fileMode>
                         <includes>
+                            <include>com.fasterxml.woodstox:woodstox-core</include>
                             <include>commons-cli:commons-cli</include>
                             <include>commons-collections:commons-collections</include>
-                            <include>org.apache.commons:commons-configuration2:jar:${commons.configuration.version}</include>
                             <include>commons-io:commons-io:jar:${commons.io.version}</include>
                             <include>commons-lang:commons-lang:jar:${commons.lang.version}</include>
                             <include>commons-logging:commons-logging:jar:${commons.logging.version}</include>
-                            <include>org.slf4j:slf4j-api:jar:${slf4j-api.version}</include>
-                            <include>org.apache.hadoop:hadoop-common:jar:${hadoop.version}</include>
+                            <include>org.apache.commons:commons-compress:jar:${commons.compress.version}</include>
+                            <include>org.apache.commons:commons-configuration2:jar:${commons.configuration.version}</include>
+                            <include>org.apache.commons:commons-lang3:jar:${commons.lang3.version}</include>
                             <include>org.apache.hadoop:hadoop-auth:jar:${hadoop.version}</include>
-                            <include>org.apache.ranger:ranger-plugins-cred</include>
-                            <include>org.apache.ranger:credentialbuilder</include>
-                            <include>org.codehaus.woodstox:stax2-api</include>
-                            <include>com.fasterxml.woodstox:woodstox-core</include>
+                            <include>org.apache.hadoop:hadoop-common:jar:${hadoop.version}</include>
                             <include>org.apache.hadoop.thirdparty:hadoop-shaded-guava:jar:${hadoop-shaded-guava.version}</include>
+                            <include>org.codehaus.woodstox:stax2-api</include>
+                            <include>org.slf4j:slf4j-api:jar:${slf4j-api.version}</include>
                         </includes>
                     </dependencySet>
                 </dependencySets>

--- a/distro/src/main/assembly/knox-agent.xml
+++ b/distro/src/main/assembly/knox-agent.xml
@@ -103,20 +103,20 @@
         <includeDependencies>true</includeDependencies>
         <unpack>false</unpack>
         <includes>
+          <include>com.fasterxml.woodstox:woodstox-core</include>
           <include>commons-cli:commons-cli</include>
           <include>commons-collections:commons-collections</include>
-          <include>org.apache.commons:commons-lang3:jar:${commons.lang3.version}</include>
-          <include>org.apache.commons:commons-configuration2:jar:${commons.configuration.version}</include>
           <include>commons-io:commons-io:jar:${commons.io.version}</include>
           <include>commons-lang:commons-lang</include>
           <include>commons-logging:commons-logging:jar:${commons.logging.version}</include>
-          <include>org.slf4j:slf4j-api:jar:${slf4j-api.version}</include>
-          <include>org.apache.hadoop:hadoop-common:jar:${hadoop.version}</include>
-          <include>org.apache.hadoop:hadoop-auth:jar:${hadoop.version}</include>
-          <include>org.codehaus.woodstox:stax2-api</include>
-          <include>com.fasterxml.woodstox:woodstox-core</include>
           <include>org.apache.commons:commons-compress:jar:${commons.compress.version}</include>
+          <include>org.apache.commons:commons-configuration2:jar:${commons.configuration.version}</include>
+          <include>org.apache.commons:commons-lang3:jar:${commons.lang3.version}</include>
+          <include>org.apache.hadoop:hadoop-auth:jar:${hadoop.version}</include>
+          <include>org.apache.hadoop:hadoop-common:jar:${hadoop.version}</include>
           <include>org.apache.hadoop.thirdparty:hadoop-shaded-guava:jar:${hadoop-shaded-guava.version}</include>
+          <include>org.codehaus.woodstox:stax2-api</include>
+          <include>org.slf4j:slf4j-api:jar:${slf4j-api.version}</include>
         </includes>
       </binaries>
     </moduleSet>

--- a/distro/src/main/assembly/plugin-atlas.xml
+++ b/distro/src/main/assembly/plugin-atlas.xml
@@ -110,36 +110,22 @@
         <directoryMode>755</directoryMode>
         <fileMode>644</fileMode>
         <includes>
+          <include>com.fasterxml.woodstox:woodstox-core:jar:${fasterxml.woodstox.version}</include>
           <include>commons-cli:commons-cli</include>
           <include>commons-collections:commons-collections</include>
           <include>commons-io:commons-io:jar:${commons.io.version}</include>
           <include>commons-lang:commons-lang:jar:${commons.lang.version}</include>
           <include>commons-logging:commons-logging</include>
-          <include>org.slf4j:slf4j-api:jar:${slf4j-api.version}</include>
-          <include>org.apache.hadoop:hadoop-common:jar:${hadoop.version}</include>
-          <include>org.apache.hadoop:hadoop-auth:jar:${hadoop.version}</include>
-          <include>org.apache.ranger:ranger-plugins-cred</include>
-          <include>org.apache.ranger:credentialbuilder</include>
-          <include>com.fasterxml.woodstox:woodstox-core:jar:${fasterxml.woodstox.version}</include>
-          <include>org.codehaus.woodstox:stax2-api:jar:${codehaus.woodstox.stax2api.version}</include>
+          <include>org.apache.commons:commons-compress:jar:${commons.compress.version}</include>
           <include>org.apache.commons:commons-configuration2:jar:${commons.configuration.version}</include>
           <include>org.apache.commons:commons-lang3:jar:${commons.lang3.version}</include>
-          <include>org.apache.commons:commons-compress:jar:${commons.compress.version}</include>
+          <include>org.apache.hadoop:hadoop-auth:jar:${hadoop.version}</include>
+          <include>org.apache.hadoop:hadoop-common:jar:${hadoop.version}</include>
           <include>org.apache.hadoop.thirdparty:hadoop-shaded-guava:jar:${hadoop-shaded-guava.version}</include>
+          <include>org.apache.ranger:ranger-plugins-cred</include>
+          <include>org.codehaus.woodstox:stax2-api:jar:${codehaus.woodstox.stax2api.version}</include>
+          <include>org.slf4j:slf4j-api:jar:${slf4j-api.version}</include>
         </includes>
-      </binaries>
-    </moduleSet>
-
-    <moduleSet>
-      <useAllReactorProjects>true</useAllReactorProjects>
-      <includes>
-        <include>org.apache.ranger:ranger-plugins-installer</include>
-        <include>org.apache.ranger:credentialbuilder</include>
-      </includes>
-      <binaries>
-        <includeDependencies>false</includeDependencies>
-        <outputDirectory>install/lib</outputDirectory>
-        <unpack>false</unpack>
       </binaries>
     </moduleSet>
   </moduleSets>

--- a/distro/src/main/assembly/plugin-elasticsearch.xml
+++ b/distro/src/main/assembly/plugin-elasticsearch.xml
@@ -107,10 +107,8 @@
     <moduleSet>
       <useAllReactorProjects>true</useAllReactorProjects>
       <includes>
-        <include>org.apache.ranger:ranger-plugins-audit</include>
-        <include>org.apache.ranger:ranger-plugins-cred</include>
-        <include>org.apache.ranger:ranger-plugins-common</include>
-        <include>org.apache.ranger:ranger-elasticsearch-plugin</include>
+        <include>org.apache.ranger:ranger-plugins-installer</include>
+        <include>org.apache.ranger:credentialbuilder</include>
       </includes>
       <binaries>
         <outputDirectory>install/lib</outputDirectory>
@@ -119,32 +117,22 @@
         <directoryMode>755</directoryMode>
         <fileMode>644</fileMode>
         <includes>
+          <include>com.fasterxml.woodstox:woodstox-core</include>
           <include>commons-cli:commons-cli</include>
           <include>commons-collections:commons-collections</include>
           <include>commons-configuration:commons-configuration:jar:${commons.configuration.version}</include>
           <include>commons-io:commons-io:jar:${commons.io.version}</include>
           <include>commons-lang:commons-lang:jar:${commons.lang.version}</include>
           <include>commons-logging:commons-logging:jar:${commons.logging.version}</include>
-          <include>org.slf4j:slf4j-api:jar:${slf4j-api.version}</include>
-          <include>org.apache.hadoop:hadoop-common:jar:${hadoop.version}</include>
+          <include>org.apache.commons:commons-compress:jar:${commons.compress.version}</include>
+          <include>org.apache.commons:commons-configuration2:jar:${commons.configuration.version}</include>
+          <include>org.apache.commons:commons-lang3:jar:${commons.lang3.version}</include>
           <include>org.apache.hadoop:hadoop-auth:jar:${hadoop.version}</include>
+          <include>org.apache.hadoop:hadoop-common:jar:${hadoop.version}</include>
           <include>org.apache.ranger:ranger-plugins-cred</include>
-          <include>org.apache.ranger:credentialbuilder</include>
           <include>org.apache.hadoop.thirdparty:hadoop-shaded-guava:jar:${hadoop-shaded-guava.version}</include>
+          <include>org.slf4j:slf4j-api:jar:${slf4j-api.version}</include>
         </includes>
-      </binaries>
-    </moduleSet>
-
-    <moduleSet>
-      <useAllReactorProjects>true</useAllReactorProjects>
-      <includes>
-        <include>org.apache.ranger:ranger-plugins-installer</include>
-        <include>org.apache.ranger:credentialbuilder</include>
-      </includes>
-      <binaries>
-        <outputDirectory>install/lib</outputDirectory>
-        <includeDependencies>true</includeDependencies>
-        <unpack>false</unpack>
       </binaries>
     </moduleSet>
   </moduleSets>

--- a/distro/src/main/assembly/plugin-kafka.xml
+++ b/distro/src/main/assembly/plugin-kafka.xml
@@ -49,6 +49,7 @@
 				<directoryMode>755</directoryMode>
 				<fileMode>644</fileMode>
 				<includes>
+					<include>org.apache.commons:commons-compress:jar:${commons.compress.version}</include>
 					<include>org.apache.commons:commons-configuration2:jar:${commons.configuration.version}</include>
 					<include>org.apache.hadoop:hadoop-common:jar:${hadoop.version}</include>
 					<include>org.apache.hadoop:hadoop-common-plus:jar:${hadoop.version}</include>
@@ -102,10 +103,8 @@
 		<moduleSet>
 			<useAllReactorProjects>true</useAllReactorProjects>
 			<includes>
-				<include>org.apache.ranger:ranger-kafka-plugin</include>
-				<include>org.apache.ranger:ranger-plugins-audit</include>
-				<include>org.apache.ranger:ranger-plugins-cred</include>
-				<include>org.apache.ranger:ranger-plugins-common</include>
+				<include>org.apache.ranger:ranger-plugins-installer</include>
+				<include>org.apache.ranger:credentialbuilder</include>
 			</includes>
 			<binaries>
 				<outputDirectory>install/lib</outputDirectory>
@@ -114,34 +113,22 @@
 				<directoryMode>755</directoryMode>
 				<fileMode>644</fileMode>
 				<includes>
+					<include>com.fasterxml.woodstox:woodstox-core</include>
 					<include>commons-cli:commons-cli</include>
 					<include>commons-collections:commons-collections</include>
-					<include>org.apache.commons:commons-configuration2:jar:${commons.configuration.version}</include>
 					<include>commons-io:commons-io:jar:${commons.io.version}</include>
 					<include>commons-lang:commons-lang:jar:${commons.lang.version}</include>
 					<include>commons-logging:commons-logging</include>
-					<include>org.slf4j:slf4j-api:jar:${slf4j-api.version}</include>
+					<include>org.apache.commons:commons-compress:jar:${commons.compress.version}</include>
+					<include>org.apache.commons:commons-configuration2:jar:${commons.configuration.version}</include>
+					<include>org.apache.commons:commons-lang3:jar:${commons.lang3.version}</include>
 					<include>org.apache.hadoop:hadoop-common:jar:${hadoop.version}</include>
 					<include>org.apache.hadoop:hadoop-auth:jar:${hadoop.version}</include>
+					<include>org.apache.hadoop.thirdparty:hadoop-shaded-guava:jar:${hadoop-shaded-guava.version}</include>
 					<include>org.apache.ranger:ranger-plugins-cred</include>
-					<include>org.apache.ranger:credentialbuilder</include>
 					<include>org.codehaus.woodstox:stax2-api</include>
-					<include>com.fasterxml.woodstox:woodstox-core</include>
-                                        <include>org.apache.hadoop.thirdparty:hadoop-shaded-guava:jar:${hadoop-shaded-guava.version}</include>
+					<include>org.slf4j:slf4j-api:jar:${slf4j-api.version}</include>
 				</includes>
-			</binaries>
-		</moduleSet>
-
-		<moduleSet>
-			<useAllReactorProjects>true</useAllReactorProjects>
-			<includes>
-				<include>org.apache.ranger:ranger-plugins-installer</include>
-				<include>org.apache.ranger:credentialbuilder</include>
-			</includes>
-			<binaries>
-				<outputDirectory>install/lib</outputDirectory>
-				<includeDependencies>false</includeDependencies>
-				<unpack>false</unpack>
 			</binaries>
 		</moduleSet>
 	</moduleSets>

--- a/distro/src/main/assembly/plugin-kms.xml
+++ b/distro/src/main/assembly/plugin-kms.xml
@@ -80,10 +80,8 @@
     <moduleSet>
       <useAllReactorProjects>true</useAllReactorProjects>
       <includes>
-        <include>org.apache.ranger:ranger-plugins-audit</include>
-        <include>org.apache.ranger:ranger-plugins-cred</include>
-        <include>org.apache.ranger:ranger-plugins-common</include>
-        <include>org.apache.ranger:ranger-kms-plugin</include>
+        <include>org.apache.ranger:ranger-plugins-installer</include>
+        <include>org.apache.ranger:credentialbuilder</include>
       </includes>
       <binaries>
         <outputDirectory>install/lib</outputDirectory>
@@ -92,34 +90,22 @@
         <directoryMode>755</directoryMode>
         <fileMode>644</fileMode>
         <includes>
+          <include>com.fasterxml.woodstox:woodstox-core</include>
           <include>commons-cli:commons-cli</include>
           <include>commons-collections:commons-collections</include>
-          <include>org.apache.commons:commons-configuration2:jar:${commons.configuration.version}</include>
           <include>commons-io:commons-io:jar:${commons.io.version}</include>
           <include>commons-lang:commons-lang:jar:${commons.lang.version}</include>
           <include>commons-logging:commons-logging:jar:${commons.logging.version}</include>
-          <include>org.slf4j:slf4j-api:jar:${slf4j-api.version}</include>
-          <include>org.apache.hadoop:hadoop-common:jar:${hadoop.version}</include>
+          <include>org.apache.commons:commons-compress:jar:${commons.compress.version}</include>
+          <include>org.apache.commons:commons-configuration2:jar:${commons.configuration.version}</include>
+          <include>org.apache.commons:commons-lang3:jar:${commons.lang3.version}</include>
           <include>org.apache.hadoop:hadoop-auth:jar:${hadoop.version}</include>
-          <include>org.apache.ranger:ranger-plugins-cred</include>
-          <include>org.apache.ranger:credentialbuilder</include>
-          <include>org.codehaus.woodstox:stax2-api</include>
-          <include>com.fasterxml.woodstox:woodstox-core</include>
+          <include>org.apache.hadoop:hadoop-common:jar:${hadoop.version}</include>
           <include>org.apache.hadoop.thirdparty:hadoop-shaded-guava:jar:${hadoop-shaded-guava.version}</include>
+          <include>org.apache.ranger:ranger-plugins-cred</include>
+          <include>org.codehaus.woodstox:stax2-api</include>
+          <include>org.slf4j:slf4j-api:jar:${slf4j-api.version}</include>
         </includes>
-      </binaries>
-    </moduleSet>
-
-    <moduleSet>
-      <useAllReactorProjects>true</useAllReactorProjects>
-      <includes>
-        <include>org.apache.ranger:ranger-plugins-installer</include>
-        <include>org.apache.ranger:credentialbuilder</include>
-      </includes>
-      <binaries>
-        <outputDirectory>install/lib</outputDirectory>
-        <includeDependencies>false</includeDependencies>
-        <unpack>false</unpack>
       </binaries>
     </moduleSet>
   </moduleSets>

--- a/distro/src/main/assembly/plugin-kylin.xml
+++ b/distro/src/main/assembly/plugin-kylin.xml
@@ -90,20 +90,22 @@
             <directoryMode>755</directoryMode>
             <fileMode>644</fileMode>
             <includes>
+              <include>com.fasterxml.woodstox:woodstox-core</include>
               <include>commons-cli:commons-cli</include>
               <include>commons-collections:commons-collections</include>
-              <include>org.apache.commons:commons-configuration2:jar:${commons.configuration.version}</include>
               <include>commons-io:commons-io:jar:${commons.io.version}</include>
               <include>commons-lang:commons-lang:jar:${commons.lang.version}</include>
               <include>commons-logging:commons-logging:jar:${commons.logging.version}</include>
-              <include>org.slf4j:slf4j-api:jar:${slf4j-api.version}</include>
-              <include>org.apache.hadoop:hadoop-common:jar:${hadoop.version}</include>
+              <include>org.apache.commons:commons-compress:jar:${commons.compress.version}</include>
+              <include>org.apache.commons:commons-configuration2:jar:${commons.configuration.version}</include>
+              <include>org.apache.commons:commons-lang3:jar:${commons.lang3.version}</include>
               <include>org.apache.hadoop:hadoop-auth:jar:${hadoop.version}</include>
-              <include>org.apache.ranger:ranger-plugins-cred</include>
-              <include>org.apache.ranger:credentialbuilder</include>
-              <include>org.codehaus.woodstox:stax2-api</include>
-              <include>com.fasterxml.woodstox:woodstox-core</include>
+              <include>org.apache.hadoop:hadoop-common:jar:${hadoop.version}</include>
               <include>org.apache.hadoop.thirdparty:hadoop-shaded-guava:jar:${hadoop-shaded-guava.version}</include>
+              <include>org.apache.ranger:credentialbuilder</include>
+              <include>org.apache.ranger:ranger-plugins-cred</include>
+              <include>org.codehaus.woodstox:stax2-api</include>
+              <include>org.slf4j:slf4j-api:jar:${slf4j-api.version}</include>
             </includes>
           </dependencySet>
         </dependencySets>

--- a/distro/src/main/assembly/plugin-ozone.xml
+++ b/distro/src/main/assembly/plugin-ozone.xml
@@ -49,25 +49,27 @@
                 <includeDependencies>true</includeDependencies>
                 <unpack>false</unpack>
                 <includes>
-		            <include>org.apache.commons:commons-configuration2:jar:${commons.configuration.version}</include>
-                    <include>commons-configuration:commons-configuration:jar:${commons.configuration1.version}</include>
+                    <include>com.fasterxml.woodstox:woodstox-core:jar:${fasterxml.woodstox.version}</include>
+                    <include>com.kstruct:gethostname4j</include>
+                    <include>com.sun.jersey:jersey-bundle</include>
+                    <include>com.sun.jersey:jersey-core</include>
+                    <include>com.sun.jersey:jersey-client</include>
                     <include>commons-cli:commons-cli</include>
                     <include>commons-collections:commons-collections</include>
+                    <include>commons-configuration:commons-configuration:jar:${commons.configuration1.version}</include>
                     <include>commons-io:commons-io:jar:${commons.io.version}</include>
                     <include>commons-lang:commons-lang</include>
                     <include>commons-logging:commons-logging:jar:${commons.logging.version}</include>
-                    <include>org.slf4j:slf4j-api:jar:${slf4j-api.version}</include>
-                    <include>org.apache.hadoop:hadoop-common:jar:${hadoop.version}</include>
-                    <include>org.apache.hadoop:hadoop-auth:jar:${hadoop.version}</include>
-                    <include>com.fasterxml.woodstox:woodstox-core:jar:${fasterxml.woodstox.version}</include>
-                    <include>org.codehaus.woodstox:stax2-api:jar:${codehaus.woodstox.stax2api.version}</include>
-                    <include>com.sun.jersey:jersey-core</include>
-                    <include>com.sun.jersey:jersey-client</include>
-                    <include>com.sun.jersey:jersey-bundle</include>
-                    <include>com.kstruct:gethostname4j</include>
                     <include>net.java.dev.jna:jna</include>
                     <include>net.java.dev.jna:jna-platform</include>
+                    <include>org.apache.commons:commons-compress:jar:${commons.compress.version}</include>
+                    <include>org.apache.commons:commons-configuration2:jar:${commons.configuration.version}</include>
+                    <include>org.apache.commons:commons-lang3:jar:${commons.lang3.version}</include>
+                    <include>org.apache.hadoop:hadoop-auth:jar:${hadoop.version}</include>
+                    <include>org.apache.hadoop:hadoop-common:jar:${hadoop.version}</include>
                     <include>org.apache.hadoop.thirdparty:hadoop-shaded-guava:jar:${hadoop-shaded-guava.version}</include>
+                    <include>org.codehaus.woodstox:stax2-api:jar:${codehaus.woodstox.stax2api.version}</include>
+                    <include>org.slf4j:slf4j-api:jar:${slf4j-api.version}</include>
                 </includes>
             </binaries>
         </moduleSet>

--- a/distro/src/main/assembly/plugin-presto.xml
+++ b/distro/src/main/assembly/plugin-presto.xml
@@ -135,18 +135,20 @@
                 <includeDependencies>true</includeDependencies>
                 <unpack>false</unpack>
                 <includes>
+                    <include>com.fasterxml.woodstox:woodstox-core</include>
                     <include>commons-cli:commons-cli</include>
                     <include>commons-collections:commons-collections</include>
-                    <include>org.apache.commons:commons-configuration2:jar:${commons.configuration.version}</include>
                     <include>commons-io:commons-io:jar:${commons.io.version}</include>
                     <include>commons-lang:commons-lang</include>
                     <include>commons-logging:commons-logging:jar:${commons.logging.version}</include>
-                    <include>org.slf4j:slf4j-api:jar:${slf4j-api.version}</include>
-                    <include>org.apache.hadoop:hadoop-common:jar:${hadoop.version}</include>
+                    <include>org.apache.commons:commons-compress:jar:${commons.compress.version}</include>
+                    <include>org.apache.commons:commons-configuration2:jar:${commons.configuration.version}</include>
+                    <include>org.apache.commons:commons-lang3:jar:${commons.lang3.version}</include>
                     <include>org.apache.hadoop:hadoop-auth:jar:${hadoop.version}</include>
-                    <include>org.codehaus.woodstox:stax2-api</include>
-                    <include>com.fasterxml.woodstox:woodstox-core</include>
+                    <include>org.apache.hadoop:hadoop-common:jar:${hadoop.version}</include>
                     <include>org.apache.hadoop.thirdparty:hadoop-shaded-guava:jar:${hadoop-shaded-guava.version}</include>
+                    <include>org.codehaus.woodstox:stax2-api</include>
+                    <include>org.slf4j:slf4j-api:jar:${slf4j-api.version}</include>
                 </includes>
             </binaries>
         </moduleSet>

--- a/distro/src/main/assembly/plugin-solr.xml
+++ b/distro/src/main/assembly/plugin-solr.xml
@@ -81,7 +81,8 @@
     <moduleSet>
       <useAllReactorProjects>true</useAllReactorProjects>
       <includes>
-        <include>org.apache.ranger:ranger-plugins-cred</include>
+        <include>org.apache.ranger:ranger-plugins-installer</include>
+        <include>org.apache.ranger:credentialbuilder</include>
       </includes>
       <binaries>
         <outputDirectory>install/lib</outputDirectory>
@@ -90,35 +91,23 @@
         <directoryMode>755</directoryMode>
         <fileMode>644</fileMode>
         <includes>
+          <include>com.fasterxml.woodstox:woodstox-core</include>
           <include>commons-cli:commons-cli</include>
           <include>commons-collections:commons-collections</include>
-          <include>org.apache.commons:commons-configuration2:jar:${commons.configuration.version}</include>
           <include>commons-io:commons-io:jar:${commons.io.version}</include>
           <include>commons-lang:commons-lang:jar:${commons.lang.version}</include>
           <include>commons-logging:commons-logging</include>
-          <include>org.slf4j:slf4j-api:jar:${slf4j-api.version}</include>
-          <include>org.apache.hadoop:hadoop-common:jar:${hadoop.version}</include>
+          <include>org.apache.commons:commons-compress:jar:${commons.compress.version}</include>
+          <include>org.apache.commons:commons-configuration2:jar:${commons.configuration.version}</include>
+          <include>org.apache.commons:commons-lang3:jar:${commons.lang3.version}</include>
           <include>org.apache.hadoop:hadoop-auth:jar:${hadoop.version}</include>
+          <include>org.apache.hadoop:hadoop-common:jar:${hadoop.version}</include>
+          <include>org.apache.hadoop.thirdparty:hadoop-shaded-guava:jar:${hadoop-shaded-guava.version}</include>
           <include>org.apache.ranger:ranger-plugins-cred</include>
-          <include>org.apache.ranger:credentialbuilder</include>
           <include>org.apache.ranger:ranger-solr-plugin</include>
           <include>org.codehaus.woodstox:stax2-api</include>
-          <include>com.fasterxml.woodstox:woodstox-core</include>
-          <include>org.apache.hadoop.thirdparty:hadoop-shaded-guava:jar:${hadoop-shaded-guava.version}</include>
+          <include>org.slf4j:slf4j-api:jar:${slf4j-api.version}</include>
         </includes>
-      </binaries>
-    </moduleSet>
-
-    <moduleSet>
-      <useAllReactorProjects>true</useAllReactorProjects>
-      <includes>
-        <include>org.apache.ranger:ranger-plugins-installer</include>
-        <include>org.apache.ranger:credentialbuilder</include>
-      </includes>
-      <binaries>
-        <outputDirectory>install/lib</outputDirectory>
-        <includeDependencies>false</includeDependencies>
-        <unpack>false</unpack>
       </binaries>
     </moduleSet>
   </moduleSets>

--- a/distro/src/main/assembly/plugin-sqoop.xml
+++ b/distro/src/main/assembly/plugin-sqoop.xml
@@ -85,8 +85,8 @@
     <moduleSet>
       <useAllReactorProjects>true</useAllReactorProjects>
       <includes>
-        <include>org.apache.ranger:ranger-plugins-audit</include>
-        <include>org.apache.ranger:ranger-plugins-cred</include>
+        <include>org.apache.ranger:ranger-plugins-installer</include>
+        <include>org.apache.ranger:credentialbuilder</include>
       </includes>
       <binaries>
         <outputDirectory>install/lib</outputDirectory>
@@ -95,34 +95,22 @@
         <directoryMode>755</directoryMode>
         <fileMode>644</fileMode>
         <includes>
+          <include>com.fasterxml.woodstox:woodstox-core</include>
           <include>commons-cli:commons-cli</include>
           <include>commons-collections:commons-collections</include>
-          <include>org.apache.commons:commons-configuration2:jar:${commons.configuration.version}</include>
           <include>commons-io:commons-io:jar:${commons.io.version}</include>
           <include>commons-lang:commons-lang:jar:${commons.lang.version}</include>
           <include>commons-logging:commons-logging:jar:${commons.logging.version}</include>
-          <include>org.slf4j:slf4j-api:jar:${slf4j-api.version}</include>
-          <include>org.apache.hadoop:hadoop-common:jar:${hadoop.version}</include>
+          <include>org.apache.commons:commons-compress:jar:${commons.compress.version}</include>
+          <include>org.apache.commons:commons-configuration2:jar:${commons.configuration.version}</include>
+          <include>org.apache.commons:commons-lang3:jar:${commons.lang3.version}</include>
           <include>org.apache.hadoop:hadoop-auth:jar:${hadoop.version}</include>
-          <include>org.apache.ranger:ranger-plugins-cred</include>
-          <include>org.apache.ranger:credentialbuilder</include>
-          <include>org.codehaus.woodstox:stax2-api</include>
-          <include>com.fasterxml.woodstox:woodstox-core</include>
+          <include>org.apache.hadoop:hadoop-common:jar:${hadoop.version}</include>
           <include>org.apache.hadoop.thirdparty:hadoop-shaded-guava:jar:${hadoop-shaded-guava.version}</include>
+          <include>org.apache.ranger:ranger-plugins-cred</include>
+          <include>org.codehaus.woodstox:stax2-api</include>
+          <include>org.slf4j:slf4j-api:jar:${slf4j-api.version}</include>
         </includes>
-      </binaries>
-    </moduleSet>
-
-    <moduleSet>
-      <useAllReactorProjects>true</useAllReactorProjects>
-      <includes>
-        <include>org.apache.ranger:ranger-plugins-installer</include>
-        <include>org.apache.ranger:credentialbuilder</include>
-      </includes>
-      <binaries>
-        <outputDirectory>install/lib</outputDirectory>
-        <includeDependencies>false</includeDependencies>
-        <unpack>false</unpack>
       </binaries>
     </moduleSet>
   </moduleSets>

--- a/distro/src/main/assembly/plugin-trino.xml
+++ b/distro/src/main/assembly/plugin-trino.xml
@@ -128,20 +128,20 @@
                 <includeDependencies>true</includeDependencies>
                 <unpack>false</unpack>
                 <includes>
+                    <include>com.fasterxml.woodstox:woodstox-core</include>
                     <include>commons-cli:commons-cli</include>
                     <include>commons-collections:commons-collections</include>
-                    <include>org.apache.commons:commons-configuration2:jar:${commons.configuration.version}</include>
                     <include>commons-io:commons-io:jar:${commons.io.version}</include>
                     <include>commons-lang:commons-lang</include>
-                    <include>org.apache.commons:commons-lang3:jar:${commons.lang3.version}</include>
-                    <include>org.apache.commons:commons-compress:jar:${commons.compress.version}</include>
                     <include>commons-logging:commons-logging:jar:${commons.logging.version}</include>
-                    <include>org.slf4j:slf4j-api:jar:${slf4j-api.version}</include>
-                    <include>org.apache.hadoop:hadoop-common:jar:${hadoop.version}</include>
+                    <include>org.apache.commons:commons-compress:jar:${commons.compress.version}</include>
+                    <include>org.apache.commons:commons-configuration2:jar:${commons.configuration.version}</include>
+                    <include>org.apache.commons:commons-lang3:jar:${commons.lang3.version}</include>
                     <include>org.apache.hadoop:hadoop-auth:jar:${hadoop.version}</include>
-                    <include>org.codehaus.woodstox:stax2-api</include>
-                    <include>com.fasterxml.woodstox:woodstox-core</include>
+                    <include>org.apache.hadoop:hadoop-common:jar:${hadoop.version}</include>
                     <include>org.apache.hadoop.thirdparty:hadoop-shaded-guava:jar:${hadoop-shaded-guava.version}</include>
+                    <include>org.codehaus.woodstox:stax2-api</include>
+                    <include>org.slf4j:slf4j-api:jar:${slf4j-api.version}</include>
                 </includes>
             </binaries>
         </moduleSet>

--- a/distro/src/main/assembly/plugin-yarn.xml
+++ b/distro/src/main/assembly/plugin-yarn.xml
@@ -87,37 +87,6 @@
     <moduleSet>
       <useAllReactorProjects>true</useAllReactorProjects>
       <includes>
-        <include>org.apache.ranger:ranger-plugins-audit</include>
-        <include>org.apache.ranger:ranger-plugins-cred</include>
-      </includes>
-      <binaries>
-        <outputDirectory>install/lib</outputDirectory>
-        <includeDependencies>true</includeDependencies>
-        <unpack>false</unpack>
-        <directoryMode>755</directoryMode>
-        <fileMode>644</fileMode>
-        <includes>
-          <include>commons-cli:commons-cli</include>
-          <include>commons-collections:commons-collections</include>
-          <include>org.apache.commons:commons-configuration2:jar:${commons.configuration.version}</include>
-          <include>commons-io:commons-io:jar:${commons.io.version}</include>
-          <include>commons-lang:commons-lang:jar:${commons.lang.version}</include>
-          <include>commons-logging:commons-logging:jar:${commons.logging.version}</include>
-          <include>org.slf4j:slf4j-api:jar:${slf4j-api.version}</include>
-          <include>org.apache.hadoop:hadoop-common:jar:${hadoop.version}</include>
-          <include>org.apache.hadoop:hadoop-auth:jar:${hadoop.version}</include>
-          <include>org.apache.ranger:ranger-plugins-cred</include>
-          <include>org.apache.ranger:credentialbuilder</include>
-          <include>org.codehaus.woodstox:stax2-api</include>
-          <include>com.fasterxml.woodstox:woodstox-core</include>
-          <include>org.apache.hadoop.thirdparty:hadoop-shaded-guava:jar:${hadoop-shaded-guava.version}</include>
-        </includes>
-      </binaries>
-    </moduleSet>
-
-    <moduleSet>
-      <useAllReactorProjects>true</useAllReactorProjects>
-      <includes>
         <include>org.apache.ranger:ranger-plugins-installer</include>
         <include>org.apache.ranger:credentialbuilder</include>
       </includes>
@@ -128,9 +97,22 @@
         <directoryMode>755</directoryMode>
         <fileMode>644</fileMode>
         <includes>
+          <include>com.fasterxml.woodstox:woodstox-core</include>
+          <include>commons-cli:commons-cli</include>
+          <include>commons-collections:commons-collections</include>
+          <include>commons-io:commons-io:jar:${commons.io.version}</include>
+          <include>commons-lang:commons-lang:jar:${commons.lang.version}</include>
           <include>commons-logging:commons-logging:jar:${commons.logging.version}</include>
           <include>org.apache.commons:commons-compress:jar:${commons.compress.version}</include>
+          <include>org.apache.commons:commons-configuration2:jar:${commons.configuration.version}</include>
           <include>org.apache.commons:commons-lang3:jar:${commons.lang3.version}</include>
+          <include>org.apache.hadoop:hadoop-auth:jar:${hadoop.version}</include>
+          <include>org.apache.hadoop:hadoop-common:jar:${hadoop.version}</include>
+          <include>org.apache.hadoop.thirdparty:hadoop-shaded-guava:jar:${hadoop-shaded-guava.version}</include>
+          <include>org.apache.ranger:credentialbuilder</include>
+          <include>org.apache.ranger:ranger-plugins-cred</include>
+          <include>org.codehaus.woodstox:stax2-api</include>
+          <include>org.slf4j:slf4j-api:jar:${slf4j-api.version}</include>
         </includes>
       </binaries>
     </moduleSet>

--- a/distro/src/main/assembly/storm-agent.xml
+++ b/distro/src/main/assembly/storm-agent.xml
@@ -111,18 +111,22 @@
             <directoryMode>755</directoryMode>
             <fileMode>644</fileMode>
             <includes>
+              <include>com.fasterxml.woodstox:woodstox-core</include>
               <include>commons-cli:commons-cli</include>
               <include>commons-collections:commons-collections</include>
               <include>commons-configuration:commons-configuration</include>
               <include>commons-io:commons-io:jar:${commons.io.version}</include>
               <include>commons-lang:commons-lang:jar:${commons.lang.version}</include>
               <include>commons-logging:commons-logging</include>
-              <include>org.slf4j:slf4j-api:jar:${slf4j-api.version}</include>
-              <include>org.apache.hadoop:hadoop-common:jar</include>
+              <include>org.apache.commons:commons-compress:jar:${commons.compress.version}</include>
+              <include>org.apache.commons:commons-configuration2:jar:${commons.configuration.version}</include>
+              <include>org.apache.commons:commons-lang3:jar:${commons.lang3.version}</include>
               <include>org.apache.hadoop:hadoop-auth:jar</include>
-              <include>org.apache.ranger:ranger-plugins-cred</include>
-              <include>org.apache.ranger:credentialbuilder</include>
+              <include>org.apache.hadoop:hadoop-common:jar</include>
               <include>org.apache.hadoop.thirdparty:hadoop-shaded-guava:jar:${hadoop-shaded-guava.version}</include>
+              <include>org.apache.ranger:credentialbuilder</include>
+              <include>org.apache.ranger:ranger-plugins-cred</include>
+              <include>org.slf4j:slf4j-api:jar:${slf4j-api.version}</include>
             </includes>
           </dependencySet>
           <dependencySet>


### PR DESCRIPTION

## What changes were proposed in this pull request?
- updated plugins packaging to include libraries used during plugin installation, like commons-lang3, commons-compress
- updated dependencies for distro/pom.xml to ensure that the packaging starts only after build for all modules complete

## How was this patch tested?
- brought up Ranger and plugin services in docker setup and verified that failures seen during plugin installation (in creating key store/trust store) are no more present.