### PR TITLE
RANGER-5076: Fix hbase scan operation unit test

### DIFF
--- a/hbase-agent/src/test/java/org/apache/ranger/authorization/hbase/HBaseRangerAuthorizationTest.java
+++ b/hbase-agent/src/test/java/org/apache/ranger/authorization/hbase/HBaseRangerAuthorizationTest.java
@@ -1234,7 +1234,7 @@ public class HBaseRangerAuthorizationTest {
                     Assert.assertEquals(1,numRowsInResult);
                 }
                 catch (IOException ex) {
-                    // expected
+                    throw new Exception(ex);
                 }
                 conn.close();
                 return null;
@@ -1259,7 +1259,7 @@ public class HBaseRangerAuthorizationTest {
                     Assert.assertEquals(2,numRowsInResult);
                 }
                 catch (IOException ex) {
-                    // expected
+                    throw new Exception(ex);
                 }
                 conn.close();
                 return null;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix scan operaion unit test. Exception should be thrown for failed test rather than silently ignoring it


## How was this patch tested?

The unit test does not execute here due to https://issues.apache.org/jira/browse/RANGER-4686
The bug was discovered and fixed in a private fork
