### PR TITLE
RANGER-5087: Bump nimbus-jose-jwt to 10.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -172,7 +172,7 @@
         <mysql-connector-java.version>5.1.49</mysql-connector-java.version>
         <net.minidev.asm.version>1.0.2</net.minidev.asm.version>
         <netty-all.version>4.1.100.Final</netty-all.version>
-        <nimbus-jose-jwt.version>9.31</nimbus-jose-jwt.version>
+        <nimbus-jose-jwt.version>9.48</nimbus-jose-jwt.version>
         <noggit.version>0.8</noggit.version>
         <orc.core.version>1.6.7</orc.core.version>
         <orc.version>1.5.8</orc.version>

--- a/pom.xml
+++ b/pom.xml
@@ -172,7 +172,7 @@
         <mysql-connector-java.version>5.1.49</mysql-connector-java.version>
         <net.minidev.asm.version>1.0.2</net.minidev.asm.version>
         <netty-all.version>4.1.100.Final</netty-all.version>
-        <nimbus-jose-jwt.version>9.48</nimbus-jose-jwt.version>
+        <nimbus-jose-jwt.version>10.0.1</nimbus-jose-jwt.version>
         <noggit.version>0.8</noggit.version>
         <orc.core.version>1.6.7</orc.core.version>
         <orc.version>1.5.8</orc.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Bumps `nimbus-jose-jwt` to latest version-`9.48`
Details are added at [RANGER-5087](https://issues.apache.org/jira/browse/RANGER-5087)

