### PR TITLE
RANGER-5092: Bump aws-java-sdk to 1.12.780

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <atlas.jackson.version>2.11.3</atlas.jackson.version>
         <atlas.jettison.version>1.3.7</atlas.jettison.version>
         <atlas.version>2.2.0</atlas.version>
-        <aws-java-sdk.version>1.12.765</aws-java-sdk.version>
+        <aws-java-sdk.version>1.12.780</aws-java-sdk.version>
         <bouncycastle.version>1.70</bouncycastle.version>
         <cglib.version>2.2.0-b23</cglib.version>
         <checkstyle.failOnViolation>false</checkstyle.failOnViolation>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Bumps  aws-java-sdk to latest version - 1.12.780
Details are added at [RANGER-5092](https://issues.apache.org/jira/browse/RANGER-5092)