### PR TITLE
RANGER-5095: Bump atlas to 2.4.0 & spring-ldap-core to 2.4.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <atlas.jackson.databind.version>2.11.3</atlas.jackson.databind.version>
         <atlas.jackson.version>2.11.3</atlas.jackson.version>
         <atlas.jettison.version>1.3.7</atlas.jettison.version>
-        <atlas.version>2.2.0</atlas.version>
+        <atlas.version>2.4.0</atlas.version>
         <aws-java-sdk.version>1.12.765</aws-java-sdk.version>
         <bouncycastle.version>1.70</bouncycastle.version>
         <cglib.version>2.2.0-b23</cglib.version>

--- a/pom.xml
+++ b/pom.xml
@@ -207,7 +207,7 @@
         <sonar.language>java</sonar.language>
         <spotbugs.failOnViolation>false</spotbugs.failOnViolation>
         <spotbugs.plugin.version>4.7.3.5</spotbugs.plugin.version>
-        <spring-ldap-core.version>2.4.1</spring-ldap-core.version>
+        <spring-ldap-core.version>2.4.4</spring-ldap-core.version>
         <springframework.security.version>5.7.12</springframework.security.version>
         <springframework.test.version>5.3.39</springframework.test.version>
         <springframework.version>5.3.39</springframework.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR addresses the fix for [CVE-2023-20863](https://nvd.nist.gov/vuln/detail/CVE-2023-20863)

More detail are added at [RANGER-5095](https://issues.apache.org/jira/browse/RANGER-5095)
