### PR TITLE
RANGER-5017: enable checkstyle in root pom.xml

### DIFF
--- a/agents-audit/pom.xml
+++ b/agents-audit/pom.xml
@@ -28,8 +28,6 @@
     <name>Audit Component</name>
     <description>Auth Audit</description>
     <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <securesm.version>1.2</securesm.version>
     </properties>

--- a/agents-common/pom.xml
+++ b/agents-common/pom.xml
@@ -28,8 +28,6 @@
     <name>Common library for Plugins</name>
     <description>Plugins Common</description>
     <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>

--- a/agents-cred/pom.xml
+++ b/agents-cred/pom.xml
@@ -28,8 +28,6 @@
     <name>Credential Support</name>
     <description>Plugins Common</description>
     <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>

--- a/agents-installer/pom.xml
+++ b/agents-installer/pom.xml
@@ -28,8 +28,6 @@
     <name>Installer Support Component</name>
     <description>Security Plugins Installer</description>
     <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>

--- a/credentialbuilder/pom.xml
+++ b/credentialbuilder/pom.xml
@@ -27,10 +27,6 @@
     <packaging>jar</packaging>
     <name>Credential Builder</name>
     <description>Credential Builder for non-hadoop java codebase</description>
-    <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>com.fasterxml.woodstox</groupId>

--- a/embeddedwebserver/pom.xml
+++ b/embeddedwebserver/pom.xml
@@ -28,8 +28,6 @@
     <name>Embedded Web Server Invoker</name>
     <description>Embedded Web Server Invoker</description>
     <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>

--- a/hbase-agent/pom.xml
+++ b/hbase-agent/pom.xml
@@ -28,8 +28,6 @@
     <name>HBase Security Plugin</name>
     <description>HBase Security Plugins</description>
     <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
         <hbase.jetty.version>9.4.51.v20230217</hbase.jetty.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/hdfs-agent/pom.xml
+++ b/hdfs-agent/pom.xml
@@ -28,8 +28,6 @@
     <name>Hdfs Security Plugin</name>
     <description>Hdfs Security Plugins</description>
     <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>

--- a/hive-agent/pom.xml
+++ b/hive-agent/pom.xml
@@ -28,8 +28,6 @@
     <name>Hive Security Plugin</name>
     <description>Hive Security Plugins</description>
     <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>

--- a/intg/pom.xml
+++ b/intg/pom.xml
@@ -25,10 +25,6 @@
     </parent>
 
     <artifactId>ranger-intg</artifactId>
-    <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.ranger</groupId>

--- a/jisql/pom.xml
+++ b/jisql/pom.xml
@@ -28,8 +28,6 @@
     <name>Jdbc SQL Connector</name>
     <description>Jdbc SQL Connector to execute sql statement in any db</description>
     <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>

--- a/kms/pom.xml
+++ b/kms/pom.xml
@@ -26,10 +26,6 @@
     <packaging>jar</packaging>
     <name>Key Management Service</name>
     <description>Key Management Service</description>
-    <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>asm</groupId>

--- a/knox-agent/pom.xml
+++ b/knox-agent/pom.xml
@@ -28,8 +28,6 @@
     <name>Knox Security Plugin</name>
     <description>Knox Security Plugins</description>
     <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
         <knox.jetty.version>9.4.51.v20230217</knox.jetty.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/plugin-atlas/pom.xml
+++ b/plugin-atlas/pom.xml
@@ -28,8 +28,6 @@
     <name>Atlas Security Plugin</name>
     <description>Atlas Security Plugins</description>
     <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>

--- a/plugin-elasticsearch/pom.xml
+++ b/plugin-elasticsearch/pom.xml
@@ -28,8 +28,6 @@
     <name>Elasticsearch Security Plugin</name>
     <description>Elasticsearch Security Plugin</description>
     <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>

--- a/plugin-kafka/pom.xml
+++ b/plugin-kafka/pom.xml
@@ -28,8 +28,6 @@
     <name>KAFKA Security Plugin</name>
     <description>KAFKA Security Plugin</description>
     <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>

--- a/plugin-kms/pom.xml
+++ b/plugin-kms/pom.xml
@@ -28,8 +28,6 @@
     <name>KMS Security Plugin</name>
     <description>KMS Security Plugin</description>
     <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>

--- a/plugin-kudu/pom.xml
+++ b/plugin-kudu/pom.xml
@@ -28,8 +28,6 @@
     <name>Kudu Security Plugin</name>
     <description>Kudu Security Plugin</description>
     <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>

--- a/plugin-kylin/pom.xml
+++ b/plugin-kylin/pom.xml
@@ -28,8 +28,6 @@
     <name>Kylin Security Plugin</name>
     <description>Kylin Security Plugin</description>
     <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>

--- a/plugin-nestedstructure/pom.xml
+++ b/plugin-nestedstructure/pom.xml
@@ -29,8 +29,6 @@
     <description>NestedStructure Security Plugin</description>
 
     <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
         <commons.codec.version>1.11</commons.codec.version>
         <commons.logging.version>1.1.1</commons.logging.version>
         <json.path.version>2.9.0</json.path.version>

--- a/plugin-nifi-registry/pom.xml
+++ b/plugin-nifi-registry/pom.xml
@@ -28,8 +28,6 @@
     <name>NiFi Registry Security Plugin</name>
     <description>NiFi Registry Security Plugin</description>
     <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>

--- a/plugin-nifi/pom.xml
+++ b/plugin-nifi/pom.xml
@@ -28,8 +28,6 @@
     <name>NiFi Security Plugin</name>
     <description>NiFi Security Plugin</description>
     <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>

--- a/plugin-ozone/pom.xml
+++ b/plugin-ozone/pom.xml
@@ -28,8 +28,6 @@ limitations under the License.
     <name>Ozone Security Plugin</name>
     <description>Ozone Security Plugin</description>
     <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>

--- a/plugin-presto/pom.xml
+++ b/plugin-presto/pom.xml
@@ -28,8 +28,6 @@
     <name>Presto Security Plugin</name>
     <description>Presto Security Plugin</description>
     <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>

--- a/plugin-schema-registry/pom.xml
+++ b/plugin-schema-registry/pom.xml
@@ -31,8 +31,6 @@
 
     <properties>
         <avro.version>1.11.4</avro.version>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
         <jersey.version>2.22.1</jersey.version>
         <jettison.version>1.5.4</jettison.version>
         <schema.registry.version>0.9.1</schema.registry.version>

--- a/plugin-solr/pom.xml
+++ b/plugin-solr/pom.xml
@@ -28,8 +28,6 @@
     <name>SOLR Security Plugin</name>
     <description>SOLR Security Plugin</description>
     <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>

--- a/plugin-sqoop/pom.xml
+++ b/plugin-sqoop/pom.xml
@@ -28,8 +28,6 @@
     <name>Sqoop Security Plugin</name>
     <description>Sqoop Security Plugin</description>
     <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>

--- a/plugin-trino/pom.xml
+++ b/plugin-trino/pom.xml
@@ -31,8 +31,6 @@
     <description>Ranger Security Plugin for Trino</description>
 
     <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/plugin-yarn/pom.xml
+++ b/plugin-yarn/pom.xml
@@ -28,8 +28,6 @@
     <name>YARN Security Plugin</name>
     <description>YARN Security Plugin</description>
     <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -46,9 +46,9 @@
         <aws-java-sdk.version>1.12.765</aws-java-sdk.version>
         <bouncycastle.version>1.70</bouncycastle.version>
         <cglib.version>2.2.0-b23</cglib.version>
-        <checkstyle.failOnViolation>false</checkstyle.failOnViolation>
+        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
         <checkstyle.plugin.version>3.1.0</checkstyle.plugin.version>
-        <checkstyle.skip>true</checkstyle.skip>
+        <checkstyle.skip>false</checkstyle.skip>
         <checkstyle.version>8.29</checkstyle.version>
         <codehaus.woodstox.stax2api.version>4.2.1</codehaus.woodstox.stax2api.version>
         <com.microsoft.azure.adal4j.version>1.6.4</com.microsoft.azure.adal4j.version>

--- a/ranger-atlas-plugin-shim/pom.xml
+++ b/ranger-atlas-plugin-shim/pom.xml
@@ -28,8 +28,6 @@
     <name>Atlas Security Plugin Shim</name>
     <description>Atlas Security Plugins Shim</description>
     <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>

--- a/ranger-authn/pom.xml
+++ b/ranger-authn/pom.xml
@@ -31,8 +31,6 @@
     <description>Ranger Authentication module</description>
 
     <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/ranger-common-ha/pom.xml
+++ b/ranger-common-ha/pom.xml
@@ -29,8 +29,6 @@
     <name>Ranger HA Common Library</name>
     <description>Ranger HA Common Library</description>
     <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/ranger-elasticsearch-plugin-shim/pom.xml
+++ b/ranger-elasticsearch-plugin-shim/pom.xml
@@ -28,8 +28,6 @@
     <name>Elasticsearch Security Plugin Shim</name>
     <description>Elasticsearch Security Plugin Shim</description>
     <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>

--- a/ranger-examples/conditions-enrichers/pom.xml
+++ b/ranger-examples/conditions-enrichers/pom.xml
@@ -25,10 +25,6 @@
     <artifactId>conditions-enrichers</artifactId>
     <name>Ranger Examples - Conditions and ContextEnrichers</name>
     <description>Ranger Examples - Conditions and ContextEnrichers</description>
-    <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.ranger</groupId>

--- a/ranger-examples/plugin-sampleapp/pom.xml
+++ b/ranger-examples/plugin-sampleapp/pom.xml
@@ -26,10 +26,6 @@
     <packaging>jar</packaging>
     <name>Ranger Examples - Ranger Plugin for SampleApp</name>
     <description>Ranger Examples - SampleApp</description>
-    <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/ranger-examples/sample-client/pom.xml
+++ b/ranger-examples/sample-client/pom.xml
@@ -26,10 +26,6 @@
 
     <artifactId>sample-client</artifactId>
     <packaging>jar</packaging>
-    <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>ch.qos.logback</groupId>

--- a/ranger-examples/sampleapp/pom.xml
+++ b/ranger-examples/sampleapp/pom.xml
@@ -26,10 +26,6 @@
     <packaging>jar</packaging>
     <name>Ranger Examples - SampleApp</name>
     <description>Ranger Examples - SampleApp</description>
-    <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>ch.qos.logback</groupId>

--- a/ranger-hbase-plugin-shim/pom.xml
+++ b/ranger-hbase-plugin-shim/pom.xml
@@ -28,8 +28,6 @@
     <name>HBase Security Plugin Shim</name>
     <description>HBase Security Plugins Shim</description>
     <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>

--- a/ranger-hdfs-plugin-shim/pom.xml
+++ b/ranger-hdfs-plugin-shim/pom.xml
@@ -28,8 +28,6 @@
     <name>Hdfs Security Plugin Shim</name>
     <description>Hdfs Security Plugins Shim</description>
     <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>

--- a/ranger-hive-plugin-shim/pom.xml
+++ b/ranger-hive-plugin-shim/pom.xml
@@ -28,8 +28,6 @@
     <name>Hive Security Plugin Shim</name>
     <description>Hive Security Plugins Shim</description>
     <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>

--- a/ranger-kafka-plugin-shim/pom.xml
+++ b/ranger-kafka-plugin-shim/pom.xml
@@ -28,8 +28,6 @@
     <name>KAFKA Security Plugin Shim</name>
     <description>KAFKA Security Plugin shim</description>
     <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>

--- a/ranger-kms-plugin-shim/pom.xml
+++ b/ranger-kms-plugin-shim/pom.xml
@@ -28,8 +28,6 @@
     <name>KMS Security Plugin Shim</name>
     <description>KMS Security Plugin Shim</description>
     <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>

--- a/ranger-knox-plugin-shim/pom.xml
+++ b/ranger-knox-plugin-shim/pom.xml
@@ -28,8 +28,6 @@
     <name>Knox Security Plugin Shim</name>
     <description>Knox Security Plugins Shim</description>
     <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>

--- a/ranger-kylin-plugin-shim/pom.xml
+++ b/ranger-kylin-plugin-shim/pom.xml
@@ -28,8 +28,6 @@
     <name>Kylin Security Plugin Shim</name>
     <description>Kylin Security Plugin Shim</description>
     <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>

--- a/ranger-metrics/pom.xml
+++ b/ranger-metrics/pom.xml
@@ -31,8 +31,6 @@
     <description>Ranger Metrics module</description>
 
     <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/ranger-ozone-plugin-shim/pom.xml
+++ b/ranger-ozone-plugin-shim/pom.xml
@@ -28,8 +28,6 @@
     <name>OZONE Security Plugin Shim</name>
     <description>OZONE Security Plugin Shim</description>
     <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>

--- a/ranger-plugin-classloader/pom.xml
+++ b/ranger-plugin-classloader/pom.xml
@@ -27,8 +27,6 @@
     <name>ranger-plugin-classloader</name>
     <description>Ranger Plugin ClassLoader</description>
     <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>

--- a/ranger-presto-plugin-shim/pom.xml
+++ b/ranger-presto-plugin-shim/pom.xml
@@ -28,8 +28,6 @@
     <name>Presto Security Plugin Shim</name>
     <description>Presto Security Plugin Shim</description>
     <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>

--- a/ranger-solr-plugin-shim/pom.xml
+++ b/ranger-solr-plugin-shim/pom.xml
@@ -28,8 +28,6 @@
     <name>SOLR Security Plugin Shim</name>
     <description>SOLR Security Plugin Shim</description>
     <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>

--- a/ranger-sqoop-plugin-shim/pom.xml
+++ b/ranger-sqoop-plugin-shim/pom.xml
@@ -28,8 +28,6 @@
     <name>Sqoop Security Plugin Shim</name>
     <description>Sqoop Security Plugin Shim</description>
     <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>

--- a/ranger-storm-plugin-shim/pom.xml
+++ b/ranger-storm-plugin-shim/pom.xml
@@ -28,8 +28,6 @@
     <name>Storm Security Plugin shim</name>
     <description>Storm Security Plugins shim</description>
     <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>

--- a/ranger-tools/pom.xml
+++ b/ranger-tools/pom.xml
@@ -26,8 +26,6 @@
     <packaging>jar</packaging>
     <name>Ranger Tools</name>
     <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>

--- a/ranger-util/pom.xml
+++ b/ranger-util/pom.xml
@@ -25,10 +25,6 @@
     <artifactId>ranger-util</artifactId>
     <name>Ranger Util</name>
     <description>Common Utilities of Ranger</description>
-    <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.hadoop</groupId>

--- a/ranger-yarn-plugin-shim/pom.xml
+++ b/ranger-yarn-plugin-shim/pom.xml
@@ -28,8 +28,6 @@
     <name>YARN Security Plugin Shim</name>
     <description>YARN Security Plugin Shim</description>
     <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>

--- a/security-admin/pom.xml
+++ b/security-admin/pom.xml
@@ -27,8 +27,6 @@
     <name>Security Admin Web Application</name>
     <description>security-admin-tool java web application</description>
     <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <skipJSTests>false</skipJSTests>
     </properties>

--- a/storm-agent/pom.xml
+++ b/storm-agent/pom.xml
@@ -28,8 +28,6 @@
     <name>Storm Security Plugin</name>
     <description>Storm Security Plugins</description>
     <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>

--- a/tagsync/pom.xml
+++ b/tagsync/pom.xml
@@ -27,8 +27,6 @@
     <name>Tag Synchronizer</name>
     <description>Tag Synchronizer Java Process</description>
     <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>

--- a/ugsync-util/pom.xml
+++ b/ugsync-util/pom.xml
@@ -26,10 +26,6 @@
     <packaging>jar</packaging>
     <name>User Group Synchronizer Util</name>
     <description>User Group Synchronizer Util</description>
-    <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/ugsync/ldapconfigchecktool/ldapconfigcheck/pom.xml
+++ b/ugsync/ldapconfigchecktool/ldapconfigcheck/pom.xml
@@ -27,10 +27,6 @@
     <packaging>jar</packaging>
     <name>Ldap Config Check Tool</name>
     <description>Ldap configuration check tool</description>
-    <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>commons-cli</groupId>

--- a/ugsync/pom.xml
+++ b/ugsync/pom.xml
@@ -27,10 +27,6 @@
     <packaging>jar</packaging>
     <name>Unix User Group Synchronizer</name>
     <description>User, Group sync from sources such as Unix and LDAP</description>
-    <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>ch.qos.logback</groupId>

--- a/unixauthclient/pom.xml
+++ b/unixauthclient/pom.xml
@@ -27,10 +27,6 @@
     <packaging>jar</packaging>
     <name>Unix Authentication Client</name>
     <description>Unix authentication client</description>
-    <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>com.google.code.gson</groupId>

--- a/unixauthnative/pom.xml
+++ b/unixauthnative/pom.xml
@@ -27,10 +27,6 @@
     <packaging>uexe</packaging>
     <name>Unix Native Authenticator</name>
     <description>Unix authentication service</description>
-    <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
-    </properties>
     <build>
         <plugins>
             <plugin>

--- a/unixauthpam/pom.xml
+++ b/unixauthpam/pom.xml
@@ -27,10 +27,6 @@
     <packaging>uexe</packaging>
     <name>PAM Authenticator</name>
     <description>PAM authentication service</description>
-    <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
-    </properties>
     <build>
         <plugins>
             <plugin>

--- a/unixauthservice/pom.xml
+++ b/unixauthservice/pom.xml
@@ -27,10 +27,6 @@
     <packaging>jar</packaging>
     <name>Unix Authentication Service</name>
     <description>Unix authentication service</description>
-    <properties>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-        <checkstyle.skip>false</checkstyle.skip>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

checkstyle was disabled in root pom.xml and was selectively enabled in individual modules. Now that all modules have been updated for checkstyle compliance, checkstyle is now enabled in pom.xml.

## How was this patch tested?
Build completes successfully without any checkstyle errors