### PR TITLE
RANGER-5104: Ranger Upgrade is failing while executing the PatchPreSql057_ForUpdateToUniqueGUID_J10052

### DIFF
--- a/security-admin/scripts/db_setup.py
+++ b/security-admin/scripts/db_setup.py
@@ -203,13 +203,13 @@ class BaseDB(object):
 					#getting Java patch which needs to be run before this DB patch.
 					pre_dict = self.get_pre_post_java_patches(prefix_for_preSql_patch)
 					if pre_dict:
-						log ("[I] ruunig pre java patch:[{}]".format(pre_dict),"info")
+						log ("[I] Running Pre Java Patch:[{}]".format(pre_dict),"info")
 						self.execute_java_patches(xa_db_host, db_user, db_password, db_name, pre_dict)
 					self.import_db_patches(db_name, db_user, db_password, currentPatch)
 					#getting Java patch which needs to be run immediately after this DB patch.
 					post_dict = self.get_pre_post_java_patches(prefix_for_postSql_patch)
 					if post_dict:
-						log ("[I] ruunig post java patch:[{}]".format(post_dict),"info")
+						log ("[I] Running Post Java Patch:[{}]".format(post_dict),"info")
 						self.execute_java_patches(xa_db_host, db_user, db_password, db_name, post_dict)
 				self.update_applied_patches_status(db_name, db_user, db_password, "DB_PATCHES")
 			else:

--- a/security-admin/src/main/java/org/apache/ranger/db/XXSecurityZoneDao.java
+++ b/security-admin/src/main/java/org/apache/ranger/db/XXSecurityZoneDao.java
@@ -158,4 +158,19 @@ public class XXSecurityZoneDao extends BaseDao<XXSecurityZone> {
 
         return securityZoneList;
     }
+
+    public List<XXSecurityZone> getAllZoneIdNames() {
+        @SuppressWarnings("unchecked")
+        List<Object[]> results = getEntityManager().createNamedQuery("XXSecurityZone.getAllZoneIdNames").getResultList();
+
+        List<XXSecurityZone> securityZoneList = new ArrayList<XXSecurityZone>(results.size());
+        for (Object[] result : results) {
+            XXSecurityZone xXSecurityZone = new XXSecurityZone();
+            xXSecurityZone.setId((Long) result[0]);
+            xXSecurityZone.setName((String) result[1]);
+            securityZoneList.add(xXSecurityZone);
+        }
+
+        return securityZoneList;
+    }
 }

--- a/security-admin/src/main/java/org/apache/ranger/patch/PatchPreSql_057_ForUpdateToUniqueGUID_J10052.java
+++ b/security-admin/src/main/java/org/apache/ranger/patch/PatchPreSql_057_ForUpdateToUniqueGUID_J10052.java
@@ -106,7 +106,7 @@ public class PatchPreSql_057_ForUpdateToUniqueGUID_J10052 extends BaseLoader {
     private void updatePolicyGUIDToUniqueValue() {
         logger.info("==> updatePolicyGUIDToUniqueValue() ");
 
-        List<XXSecurityZone> allXXZones   = daoMgr.getXXSecurityZoneDao().getAll();
+        List<XXSecurityZone> allXXZones   = daoMgr.getXXSecurityZoneDao().getAllZoneIdNames();
         List<XXService>      allXXService = daoMgr.getXXService().getAll();
 
         if (CollectionUtils.isNotEmpty(allXXZones) && CollectionUtils.isNotEmpty(allXXService)) {

--- a/security-admin/src/main/resources/META-INF/jpa_named_queries.xml
+++ b/security-admin/src/main/resources/META-INF/jpa_named_queries.xml
@@ -1724,6 +1724,12 @@
 		</query>
 	</named-query>
 
+	<named-query name="XXSecurityZone.getAllZoneIdNames">
+		<query>
+			select obj.id, obj.name from XXSecurityZone obj
+		</query>
+	</named-query>
+
 	<named-query name="XXSecurityZoneRefGroup.findByZoneId">
         <query>
             select obj from XXSecurityZoneRefGroup obj where obj.zoneId = :zoneId


### PR DESCRIPTION
## What changes were proposed in this pull request?

Ranger SQL queries is selecting all columns which are not being used, The upgrade failed as 'gz_jsonData' column is not available during the PatchPreSql057_ForUpdateToUniqueGUID_J10052 execution. 
gz_jsonData column values are not required for the PatchPreSql057_ForUpdateToUniqueGUID_J10052 hence rather selecting all columns only the required columns (id and name) of all records should be fetched.

## How was this patch tested?

Retried the failing environment with this patch and same configuration. Upgrade completed successfully.
