### PR TITLE
RANGER-5102: Enable append mode for audits to hdfs with config param

### DIFF
--- a/agents-audit/src/main/java/org/apache/ranger/audit/utils/AbstractRangerAuditWriter.java
+++ b/agents-audit/src/main/java/org/apache/ranger/audit/utils/AbstractRangerAuditWriter.java
@@ -294,7 +294,7 @@ public abstract class AbstractRangerAuditWriter implements RangerAuditWriter {
             boolean appendMode = false;
 
             // if append is supported and enabled via config param, reuse last log file
-            if (reUseLastLogFile && isAppendEnabled()) {
+            if (auditPath != null && reUseLastLogFile && isAppendEnabled()) {
                 try {
                     ostream    = fileSystem.append(auditPath);
                     appendMode = true;

--- a/agents-audit/src/main/java/org/apache/ranger/audit/utils/RangerJSONAuditWriter.java
+++ b/agents-audit/src/main/java/org/apache/ranger/audit/utils/RangerJSONAuditWriter.java
@@ -119,16 +119,12 @@ public class RangerJSONAuditWriter extends AbstractRangerAuditWriter {
                 closeWriter();
                 resetWriter();
 
-                reUseLastLogFile = true;
-
                 return false;
             }
         } catch (Exception e) {
             logger.error("Exception encountered while writing audits to HDFS!", e);
             closeWriter();
             resetWriter();
-
-            reUseLastLogFile = true;
 
             return false;
         } finally {
@@ -137,7 +133,6 @@ public class RangerJSONAuditWriter extends AbstractRangerAuditWriter {
             if (out != null) {
                 out.flush();
             }
-            //closeWriter();
         }
 
         return true;

--- a/agents-audit/src/test/java/org/apache/ranger/audit/utils/RangerJSONAuditWriterTest.java
+++ b/agents-audit/src/test/java/org/apache/ranger/audit/utils/RangerJSONAuditWriterTest.java
@@ -18,21 +18,22 @@
 
 package org.apache.ranger.audit.utils;
 
-import org.apache.hadoop.fs.CommonPathCapabilities;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.io.PrintWriter;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
@@ -47,77 +48,135 @@ public class RangerJSONAuditWriterTest {
         props.setProperty("test.dir", "/tmp");
 
         auditConfigs.put(FileSystem.FS_DEFAULT_NAME_KEY, FileSystem.DEFAULT_FS);
+        auditConfigs.put("fs.file.impl", "org.apache.hadoop.fs.RawLocalFileSystem");
     }
 
     @Test
-    public void checkReUseFlagInStreamErrors() throws Exception {
+    public void verifyAppendToFileWhenEnabledWithConfig() throws Exception {
         RangerJSONAuditWriter jsonAuditWriter = spy(new RangerJSONAuditWriter());
-        PrintWriter           out             = mock(PrintWriter.class);
-
         setup();
-
+        props.setProperty("test.file.append.enabled", "true");
         jsonAuditWriter.init(props, "test", "localfs", auditConfigs);
-        assertFalse(jsonAuditWriter.reUseLastLogFile);
 
-        when(jsonAuditWriter.getLogFileStream()).thenReturn(out);
-        when(out.checkError()).thenReturn(true);
-        assertFalse(jsonAuditWriter.logJSON(Collections.singleton("This event will not be logged!")));
+        assertTrue(jsonAuditWriter.logJSON(Collections.singleton("This event will be logged in write(create) mode!")));
         assertTrue(jsonAuditWriter.reUseLastLogFile);
 
-        // cleanup
+        when(jsonAuditWriter.getLogFileStream()).thenThrow(new IOException("Unable to fetch log file stream!"));
+        assertFalse(jsonAuditWriter.logJSON(Collections.singleton("This event will not be logged due to exception!")));
+
+        assertNull(jsonAuditWriter.ostream);
+        assertNull(jsonAuditWriter.logWriter);
+        assertNotNull(jsonAuditWriter.auditPath);
+        assertNotNull(jsonAuditWriter.fullPath);
+
+        reset(jsonAuditWriter);
+        assertTrue(jsonAuditWriter.logJSON(Collections.singleton("Last log file will be opened in append mode and this event will be written")));
+        assertTrue(jsonAuditWriter.logJSON(Collections.singleton("This event will also be written in append mode")));
+
         jsonAuditWriter.fileSystem.deleteOnExit(jsonAuditWriter.auditPath);
-        jsonAuditWriter.logJSON(Collections.singleton("cleaning up!"));
+    }
+
+    @Test
+    public void verifyFileRolloverWithAppend() throws Exception {
+        RangerJSONAuditWriter jsonAuditWriter = spy(new RangerJSONAuditWriter());
+
+        setup();
+        props.setProperty("test.file.rollover.enable.periodic.rollover", "true");
+        props.setProperty("test.file.rollover.periodic.rollover.check.sec", "2");
+        props.setProperty("test.file.append.enabled", "true");
+        // rollover log file after this interval
+        jsonAuditWriter.fileRolloverSec = 5; // in seconds
+        jsonAuditWriter.init(props, "test", "localfs", auditConfigs);
+
+        assertTrue(jsonAuditWriter.reUseLastLogFile);
+        assertTrue(jsonAuditWriter.logJSON(Collections.singleton("This event will be logged in write(create) mode!")));
+
+        when(jsonAuditWriter.getLogFileStream()).thenThrow(new IOException("Unable to fetch log file stream!"));
+        assertFalse(jsonAuditWriter.logJSON(Collections.singleton("This event will not be logged due to exception!")));
+
+        assertNull(jsonAuditWriter.ostream);
+        assertNull(jsonAuditWriter.logWriter);
+        assertNotNull(jsonAuditWriter.auditPath);
+        assertNotNull(jsonAuditWriter.fullPath);
+
+        reset(jsonAuditWriter);
+
+        assertTrue(jsonAuditWriter.logJSON(Collections.singleton("Last log file will be opened in append mode and this event will be written")));
+        assertTrue(jsonAuditWriter.logJSON(Collections.singleton("This event will also be written in append mode")));
+        Path auditPath1 = jsonAuditWriter.auditPath;
+
+        Thread.sleep(6000);
+
+        // rollover should have happened
+        assertTrue(jsonAuditWriter.reUseLastLogFile);
+        assertNull(jsonAuditWriter.ostream);
+        assertNull(jsonAuditWriter.logWriter);
+        assertNull(jsonAuditWriter.auditPath);
+        assertNull(jsonAuditWriter.fullPath);
+
+        assertTrue(jsonAuditWriter.logJSON(Collections.singleton("Second file created since rollover happened!")));
+
+        // ensure the same rolled over file is not used for append
+        assertNotEquals(auditPath1, jsonAuditWriter.auditPath);
+
+        // cleanup
+        jsonAuditWriter.fileSystem.deleteOnExit(auditPath1);
+        jsonAuditWriter.fileSystem.deleteOnExit(jsonAuditWriter.auditPath);
         jsonAuditWriter.closeWriter();
     }
 
     @Test
-    public void checkAppendtoFileWhenExceptionsOccur() throws Exception {
+    public void verifyNoAppendToFileWhenDisabledWithConfig() throws Exception {
         RangerJSONAuditWriter jsonAuditWriter = spy(new RangerJSONAuditWriter());
 
         setup();
-
+        props.setProperty("test.file.append.enabled", "false");
         jsonAuditWriter.init(props, "test", "localfs", auditConfigs);
         jsonAuditWriter.createFileSystemFolders();
-
         // File creation should fail with an exception which will trigger append next time.
-        when(jsonAuditWriter.fileSystem.create(jsonAuditWriter.auditPath)).thenThrow(new IOException("Creation not allowed!"));
-        jsonAuditWriter.logJSON(Collections.singleton("This event will not be logged!"));
-        jsonAuditWriter.fileSystem.deleteOnExit(jsonAuditWriter.auditPath);
-        assertTrue(jsonAuditWriter.reUseLastLogFile);
+        when(jsonAuditWriter.fileSystem.create(jsonAuditWriter.auditPath)).thenThrow(new IOException("Creation not allowed at this time!"));
+        assertFalse(jsonAuditWriter.logJSON(Collections.singleton("This event will not be logged!")));
+        assertFalse(jsonAuditWriter.reUseLastLogFile);
         assertNull(jsonAuditWriter.ostream);
         assertNull(jsonAuditWriter.logWriter);
+        assertNotNull(jsonAuditWriter.auditPath);
+        assertNotNull(jsonAuditWriter.fullPath);
 
-        jsonAuditWriter.fileSystem = mock(FileSystem.class);
-        when(jsonAuditWriter.fileSystem.hasPathCapability(jsonAuditWriter.auditPath, CommonPathCapabilities.FS_APPEND)).thenReturn(true);
+        Path auditPath1 = jsonAuditWriter.auditPath;
+
+        reset(jsonAuditWriter);
+        assertTrue(jsonAuditWriter.logJSON(Collections.singleton("This event should be written to a newly created file in write mode!")));
+        assertTrue(jsonAuditWriter.logJSON(Collections.singleton("This event should also be written to the previous file")));
+        assertFalse(jsonAuditWriter.reUseLastLogFile);
+
+        // cleanup
+        jsonAuditWriter.fileSystem.deleteOnExit(auditPath1);
         jsonAuditWriter.fileSystem.deleteOnExit(jsonAuditWriter.auditPath);
-        // this will lead to an exception since append is called on mocks
-        jsonAuditWriter.logJSON(Collections.singleton("This event should be appended but won't be as appended we use mocks."));
     }
 
     @Test
-    public void checkFileRolloverAfterThreshold() throws Exception {
+    public void verifyFileRolloverAfterThreshold() throws Exception {
         RangerJSONAuditWriter jsonAuditWriter = spy(new RangerJSONAuditWriter());
 
         setup();
-
         props.setProperty("test.file.rollover.enable.periodic.rollover", "true");
         props.setProperty("test.file.rollover.periodic.rollover.check.sec", "2");
         // rollover log file after this interval
-
         jsonAuditWriter.fileRolloverSec = 5; // in seconds
         jsonAuditWriter.init(props, "test", "localfs", auditConfigs);
 
         assertTrue(jsonAuditWriter.logJSON(Collections.singleton("First file created and added this line!")));
+        Path auditPath1 = jsonAuditWriter.auditPath;
 
-        jsonAuditWriter.fileSystem.deleteOnExit(jsonAuditWriter.auditPath); // cleanup
         Thread.sleep(6000);
-        assertFalse(jsonAuditWriter.reUseLastLogFile);
+
         assertNull(jsonAuditWriter.ostream);
         assertNull(jsonAuditWriter.logWriter);
-
         assertTrue(jsonAuditWriter.logJSON(Collections.singleton("Second file created since rollover happened!")));
 
-        jsonAuditWriter.fileSystem.deleteOnExit(jsonAuditWriter.auditPath); // cleanup
+        // cleanup
+        jsonAuditWriter.fileSystem.deleteOnExit(auditPath1);
+        jsonAuditWriter.fileSystem.deleteOnExit(jsonAuditWriter.auditPath);
         jsonAuditWriter.closeWriter();
     }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Ranger audits to HDFS currently use APPEND mode in case of errors/exceptions encountered in writing audits to HDFS destination (to prevent large number of audit files) and fallbacks to WRITE mode if unable to APPEND.

 

Add a config param to enable APPEND mode (to be used under specific circumstances).


## How was this patch tested?

Verified that the config param `xasecure.audit.destination.hdfs.file.append.enabled` enables/disables append mode in docker with hive, hadoop and ranger containers.
