### PR TITLE
RANGER-5115: fix for ConcurrentModificationException during policy evaluation

### DIFF
--- a/agents-common/src/main/java/org/apache/ranger/plugin/policyevaluator/RangerDefaultPolicyItemEvaluator.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/policyevaluator/RangerDefaultPolicyItemEvaluator.java
@@ -85,9 +85,7 @@ public class RangerDefaultPolicyItemEvaluator extends RangerAbstractPolicyItemEv
                         ret = true;
                     }
                 } else {
-                    if (withImpliedGrants == null) {
-                        withImpliedGrants = computeWithImpliedGrants();
-                    }
+                    RangerPolicyItem withImpliedGrants = computeWithImpliedGrants();
 
                     if (withImpliedGrants != null && CollectionUtils.isNotEmpty(withImpliedGrants.getAccesses())) {
                         boolean isAccessTypeMatched = false;
@@ -155,9 +153,7 @@ public class RangerDefaultPolicyItemEvaluator extends RangerAbstractPolicyItemEv
             if (isAdminAccess) {
                 ret = policyItem.getDelegateAdmin();
             } else {
-                if (withImpliedGrants == null) {
-                    withImpliedGrants = computeWithImpliedGrants();
-                }
+                RangerPolicyItem withImpliedGrants = computeWithImpliedGrants();
 
                 if (CollectionUtils.isNotEmpty(withImpliedGrants.getAccesses())) {
                     boolean isAnyAccess = StringUtils.equals(accessType, RangerPolicyEngine.ANY_ACCESS);

--- a/agents-common/src/main/java/org/apache/ranger/plugin/policyevaluator/RangerOptimizedPolicyEvaluator.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/policyevaluator/RangerOptimizedPolicyEvaluator.java
@@ -321,7 +321,7 @@ public class RangerOptimizedPolicyEvaluator extends RangerDefaultPolicyEvaluator
 
                 for (RangerPolicy.RangerPolicyItemAccess policyItemAccess : policyItemAccesses) {
                     if (policyItemAccess.getIsAllowed()) {
-                        add(accessPerms, policyItemAccess.getType());
+                        accessPerms = add(accessPerms, policyItemAccess.getType());
                     }
                 }
 

--- a/agents-common/src/test/java/org/apache/ranger/plugin/policyengine/TestPolicyACLs.java
+++ b/agents-common/src/test/java/org/apache/ranger/plugin/policyengine/TestPolicyACLs.java
@@ -43,6 +43,7 @@ import java.io.InputStreamReader;
 import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
@@ -119,10 +120,7 @@ public class TestPolicyACLs {
             RangerPluginContext       pluginContext       = new RangerPluginContext(new RangerPluginConfig(serviceType, null, "test-policy-acls", "cl1", "on-prem", policyEngineOptions));
             RangerPolicyEngine        policyEngine        = new RangerPolicyEngineImpl(testCase.servicePolicies, pluginContext, null);
 
-            for (PolicyACLsTests.TestCase.OneTest oneTest : testCase.tests) {
-                if (oneTest == null) {
-                    continue;
-                }
+            testCase.tests.parallelStream().filter(Objects::nonNull).forEach(oneTest -> {
                 RangerAccessRequestImpl request = new RangerAccessRequestImpl(oneTest.resource, RangerPolicyEngine.ANY_ACCESS, null, null, null);
 
                 request.setResourceMatchingScope(oneTest.resourceMatchingScope);
@@ -287,7 +285,7 @@ public class TestPolicyACLs {
                 assertTrue("getResourceACLs() failed! " + testCase.name + ":" + oneTest.name + " - roleACLsMatched", roleACLsMatched);
                 assertTrue("getResourceACLs() failed! " + testCase.name + ":" + oneTest.name + " - rowFiltersMatched", rowFiltersMatched);
                 assertTrue("getResourceACLs() failed! " + testCase.name + ":" + oneTest.name + " - dataMaskingMatched", dataMaskingMatched);
-            }
+            });
         }
     }
 

--- a/agents-common/src/test/java/org/apache/ranger/plugin/policyengine/TestPolicyEngine.java
+++ b/agents-common/src/test/java/org/apache/ranger/plugin/policyengine/TestPolicyEngine.java
@@ -817,10 +817,8 @@ public class TestPolicyEngine {
     }
 
     private void runTestCaseTests(RangerPolicyEngine policyEngine, RangerServiceDef serviceDef, String testName, List<TestData> tests) {
-        RangerAccessRequest request = null;
-
-        for (TestData test : tests) {
-            request = test.request;
+        tests.parallelStream().forEach(test -> {
+            RangerAccessRequest request = test.request;
 
             if (request.getContext().containsKey(RangerAccessRequestUtil.KEY_CONTEXT_TAGS) ||
                     request.getContext().containsKey(RangerAccessRequestUtil.KEY_CONTEXT_REQUESTED_RESOURCES)) {
@@ -949,7 +947,7 @@ public class TestPolicyEngine {
                 assertEquals("deniedUsers mismatched! - " + test.name, expected.getDeniedUsers(), result.getDeniedUsers());
                 assertEquals("deniedGroups mismatched! - " + test.name, expected.getDeniedGroups(), result.getDeniedGroups());
             }
-        }
+        });
     }
 
     private void setPluginConfig(RangerPluginConfig conf, String suffix, Set<String> value) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

- updated to synchronize initialization of RangerAbstractPolicyItemEvaluator.withImpliedGrants
- updated policy engine tests to evaluate requests in multiple threads

## How was this patch tested?

build with tests complete successfully