### PR TITLE
RANGER-5118: Set default server timezone to logging

### DIFF
--- a/embeddedwebserver/scripts/ranger-admin-services.sh
+++ b/embeddedwebserver/scripts/ranger-admin-services.sh
@@ -55,7 +55,6 @@ then
 fi
 
 JAVA_OPTS=" ${JAVA_OPTS} -XX:MetaspaceSize=100m -XX:MaxMetaspaceSize=200m -Xmx${ranger_admin_max_heap_size} -Xms1g -Xloggc:${RANGER_ADMIN_LOG_DIR}/gc-worker.log -verbose:gc -XX:+PrintGCDetails"
-if [[ ${JAVA_OPTS} != *"-Duser.timezone"* ]] ;then  export JAVA_OPTS=" ${JAVA_OPTS} -Duser.timezone=UTC" ;fi
 
 if [ -z "${RANGER_ADMIN_LOGBACK_CONF_FILE}" ]
 then


### PR DESCRIPTION
## What changes were proposed in this pull request?

These changes will ensure that the server timezone is aligned with the Ranger service components, allowing logging timezones to remain consistent and in sync.

More Details are added at [RANGER-5118](https://issues.apache.org/jira/browse/RANGER-5118)


## How was this patch tested?

This patch was tested locally on a multi-node cluster with latest release version v2.5.0. with this suggested changes, able to dump logs in server local timezone.
