### PR TITLE
RANGER-5122: fixed path for images

### DIFF
--- a/security-admin/scripts/setup.sh
+++ b/security-admin/scripts/setup.sh
@@ -188,6 +188,8 @@ audit_solr_max_shards_per_node=$(get_prop 'audit_solr_max_shards_per_node' $PROP
 audit_solr_acl_user_list_sasl=$(get_prop 'audit_solr_acl_user_list_sasl' $PROPFILE)
 audit_solr_bootstrap_enabled=$(get_prop 'audit_solr_bootstrap_enabled' $PROPFILE)
 
+xa_webapp_contextName=$(get_prop 'xa.webapp.contextName' $PROPFILE)
+
 DB_HOST="${db_host}"
 
 check_ret_status(){
@@ -608,6 +610,13 @@ update_properties() {
                 propertyName=ranger.lookup.kerberos.keytab
                 newPropertyValue="${lookup_keytab}"
                 updatePropertyToFilePy $propertyName $newPropertyValue $to_file_ranger
+	fi
+
+	if [ "${xa_webapp_contextName}" != "" ]
+	then
+                propertyName=ranger.contextName
+                newPropertyValue="${xa_webapp_contextName}"
+                updatePropertyToFilePy $propertyName $newPropertyValue $to_file_default
 	fi
 
 	if [ "${db_ssl_enabled}" != "" ]

--- a/security-admin/src/main/webapp/react-webapp/config/webpack.config.js
+++ b/security-admin/src/main/webapp/react-webapp/config/webpack.config.js
@@ -54,7 +54,7 @@ module.exports = {
             options: {
               name: "[contenthash].[ext]",
               outputPath: "images/",
-              publicPath: "../images/"
+              publicPath: "./images/"
             }
           }
         ]


### PR DESCRIPTION
## What changes were proposed in this pull request?

Load images from the correct path. This bug appears only when context path of the ranger web app is changed to something else than the default root (/).

Also updated setup.sh to allow changing the "ranger.contextName" from install.properties.

Fixes RANGER-5122.

## How was this patch tested?

Tested manually.