### PR TITLE
RANGER-5125: Missing accessResult column value in ORC File Logging

### DIFF
--- a/agents-audit/src/main/java/org/apache/ranger/audit/utils/ORCFileUtil.java
+++ b/agents-audit/src/main/java/org/apache/ranger/audit/utils/ORCFileUtil.java
@@ -359,6 +359,9 @@ public class ORCFileUtil {
             } else if (object instanceof Date) {
                 ret = (getDateString((Date) object));
             }
+            else if (object instanceof Short) {
+                ret = ((Short) object).toString();
+            }
         } catch (Exception e) {
             logger.error("Error while writing into ORC File:", e);
         }


### PR DESCRIPTION
## What changes were proposed in this pull request?  
- Fixed an issue where `short` values (e.g., `accessResult` field) were **not correctly converted to strings** before being written to ORC.  
- Modified `castStringObject(Object object)` to properly handle `Short` values by converting them to strings.  

## Why is this needed?  
- Previously, `short` values were missing from the ORC output because they were **not handled in `castStringObject()`**, leading to incorrect (empty) values in the ORC file.  
- This fix ensures that `short` values are correctly converted to strings before being stored in ORC.  

## How was this patch tested?  
- **Manual testing** by running the `main()` method from `OrcUtils.java`.  
- Verified that the **accessResult** column in the generated ORC file now contains the correct values instead of being empty.  