### PR TITLE
RANGER-5264: Update release-build.xml

### DIFF
--- a/release-build.xml
+++ b/release-build.xml
@@ -20,15 +20,12 @@
         Apache Ranger Build Release Tasks
     </description>
 	
-    <property name="release-dir"  value="target" />
-    <property name="incubationstr" value="" />     <!-- value="-incubating" -->
-	<property name="release-name" value="apache-ranger${incubationstr}-${ranger-release-version}" />
-
-	<property name="build-release-tar-file" value="${release-name}.tar.gz" />
+    <property name="release-dir"  value="target"/>
+	<property name="release-name" value="apache-ranger-${ranger-release-version}"/>
+	<property name="build-release-tar-file" value="${release-name}.tar.gz"/>
 
  	<target name="version-check">
-		<fail message="Missing ranger-release-version; -Dranger-release-version=&lt;version-number&gt; should be defined" 
-			  unless="ranger-release-version" />
+		<fail message="Missing ranger-release-version; -Dranger-release-version=&lt;version-number&gt; should be defined" unless="ranger-release-version"/>
     </target>
 	
 	<target name="build-release" depends="version-check">
@@ -41,37 +38,35 @@
 			<tarfileset prefix="${release-name}" dir=".">
 				<exclude name="*/bin/**" />
 				<exclude name="git" />
-				<exclude name="**/.DS_Store" />
-				<exclude name="**/.classpath" />
-				<exclude name="**/.gitignore" />
-				<exclude name="**/.project" />
-				<exclude name="**/.settings/**" />
-				<exclude name="**/target/**" />
-				<exclude name="hdfs-agent/dependency-reduced-pom.xml" />
-				<exclude name="winpkg/*" />
+				<exclude name="**/.DS_Store"/>
+				<exclude name="**/.classpath"/>
+				<exclude name="**/.gitignore"/>
+				<exclude name=".idea/**"/>
+				<exclude name="**/.project"/>
+				<exclude name="**/.settings/**"/>
+				<exclude name="**/target/**"/>
+				<exclude name="dev-support/ranger-docker/dist/**"/>
+				<exclude name="dev-support/ranger-docker/downloads/**"/>
+				<exclude name="hdfs-agent/dependency-reduced-pom.xml"/>
+				<exclude name="winpkg/*"/>
 			</tarfileset>
 		</tar>
-
 		<exec executable="gpg">
-			<arg value="--armor" />
-			<arg value="--output" />
-			<arg value="${release-dir}/${build-release-tar-file}.asc" />
-			<arg value="--detach-sig" />
-			<arg value="${release-dir}/${build-release-tar-file}" />
+			<arg value="--armor"/>
+			<arg value="--output"/>
+			<arg value="${release-dir}/${build-release-tar-file}.asc"/>
+			<arg value="--detach-sig"/>
+			<arg value="${release-dir}/${build-release-tar-file}"/>
 		</exec>
-
-                <exec executable="gpg" output="${release-dir}/${build-release-tar-file}.sha256" dir="${release-dir}">
-                        <arg value="--print-md" />
-                        <arg value="SHA256" />
-                        <arg value="${build-release-tar-file}" />
-                </exec>
-
-                <exec executable="gpg" output="${release-dir}/${build-release-tar-file}.sha512" dir="${release-dir}">
-                        <arg value="--print-md" />
-                        <arg value="SHA512" />
-                        <arg value="${build-release-tar-file}" />
-                </exec>
-
+		<exec executable="gpg" output="${release-dir}/${build-release-tar-file}.sha256" dir="${release-dir}">
+			<arg value="--print-md"/>
+			<arg value="SHA256"/>
+			<arg value="${build-release-tar-file}"/>
+		</exec>
+		<exec executable="gpg" output="${release-dir}/${build-release-tar-file}.sha512" dir="${release-dir}">
+			<arg value="--print-md"/>
+			<arg value="SHA512"/>
+			<arg value="${build-release-tar-file}"/>
+		</exec>
 	</target>
-
 </project>

--- a/release-build.xml
+++ b/release-build.xml
@@ -53,19 +53,17 @@
 		</tar>
 		<exec executable="gpg">
 			<arg value="--armor"/>
+			<arg value="--local-user"/>
+			<arg value="${signing-key}"/>
 			<arg value="--output"/>
 			<arg value="${release-dir}/${build-release-tar-file}.asc"/>
 			<arg value="--detach-sig"/>
 			<arg value="${release-dir}/${build-release-tar-file}"/>
 		</exec>
-		<exec executable="gpg" output="${release-dir}/${build-release-tar-file}.sha256" dir="${release-dir}">
-			<arg value="--print-md"/>
-			<arg value="SHA256"/>
+		<exec executable="sha512sum" output="${release-dir}/${build-release-tar-file}.sha512" dir="${release-dir}">
 			<arg value="${build-release-tar-file}"/>
 		</exec>
-		<exec executable="gpg" output="${release-dir}/${build-release-tar-file}.sha512" dir="${release-dir}">
-			<arg value="--print-md"/>
-			<arg value="SHA512"/>
+		<exec executable="sha256sum" output="${release-dir}/${build-release-tar-file}.sha256" dir="${release-dir}">
 			<arg value="${build-release-tar-file}"/>
 		</exec>
 	</target>


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Refactor `release-build.xml` and add exclusions.
- Update commands for `sha512sum` and `sha256sum` according to https://cwiki.apache.org/confluence/display/RANGER/Ranger+Release+Guideline
- Update `gpg` command to use the input key `${signing-key}` to sign the artifact.
- Interactively ask for passphrase 


## How was this patch tested?

Tested on local machine by running this command:
```
export GPG_TTY=$(tty)
export RANGER_VERSION=2.7.0
export CODESIGNINGKEY=your_gpg_key_id
ant -f release-build.xml -Dranger-release-version=${RANGER_VERSION} -Dsigning-key=${CODESIGNINGKEY}
```

Contents of `target` dir after `ant` command was run:
```
-rw-r--r--@ 1 user.name  staff    93B Jul 23 15:42 apache-ranger-2.7.0.tar.gz.sha256
-rw-r--r--@ 1 user.name  staff   157B Jul 23 15:42 apache-ranger-2.7.0.tar.gz.sha512
-rw-r--r--@ 1 user.name  staff   833B Jul 23 15:42 apache-ranger-2.7.0.tar.gz.asc
-rw-r--r--@ 1 user.name  staff    10M Jul 23 15:42 apache-ranger-2.7.0.tar.gz
```