### PR TITLE
RANGER-5130:DatSet policies fail to authorize when condition expression is present

### DIFF
--- a/agents-common/src/main/java/org/apache/ranger/plugin/model/RangerGrant.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/model/RangerGrant.java
@@ -35,15 +35,17 @@ public class RangerGrant implements java.io.Serializable {
     private RangerPrincipal principal;
     private List<String>    accessTypes;
     private List<String>    conditions;
+    private List<String>    validitySchedules;
 
     public RangerGrant() {
-        this(null, null, null);
+        this(null, null, null, null);
     }
 
-    public RangerGrant(RangerPrincipal principal, List<String> accessTypes, List<String> conditions) {
-        this.principal   = principal;
-        this.accessTypes = accessTypes;
-        this.conditions  = conditions;
+    public RangerGrant(RangerPrincipal principal, List<String> accessTypes, List<String> conditions, List<String> validitySchedules) {
+        this.principal         = principal;
+        this.accessTypes       = accessTypes;
+        this.conditions        = conditions;
+        this.validitySchedules = validitySchedules;
     }
 
     public RangerPrincipal getPrincipal() {
@@ -70,9 +72,17 @@ public class RangerGrant implements java.io.Serializable {
         this.conditions = conditions;
     }
 
+    public List<String> getValiditySchedules() {
+        return validitySchedules;
+    }
+
+    public void setValiditySchedules(List<String> validitySchedules) {
+        this.validitySchedules = validitySchedules;
+    }
+
     @Override
     public int hashCode() {
-        return Objects.hash(principal, accessTypes, conditions);
+        return Objects.hash(principal, accessTypes, conditions, validitySchedules);
     }
 
     @Override
@@ -89,7 +99,8 @@ public class RangerGrant implements java.io.Serializable {
 
         return Objects.equals(principal, other.principal) &&
                 Objects.equals(accessTypes, other.accessTypes) &&
-                Objects.equals(conditions, other.conditions);
+                Objects.equals(conditions, other.conditions) &&
+                Objects.equals(validitySchedules, other.validitySchedules);
     }
 
     @Override
@@ -98,6 +109,7 @@ public class RangerGrant implements java.io.Serializable {
                 "principal='" + principal.toString() +
                 ", accessTypes=" + accessTypes +
                 ", conditions=" + conditions +
+                ", validitySchedules=" + validitySchedules +
                 '}';
     }
 }

--- a/agents-common/src/main/java/org/apache/ranger/plugin/model/RangerGrant.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/model/RangerGrant.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -34,18 +35,16 @@ public class RangerGrant implements java.io.Serializable {
 
     private RangerPrincipal principal;
     private List<String>    accessTypes;
-    private List<String>    conditions;
-    private List<String>    validitySchedules;
+    private List<Condition> conditions;
 
     public RangerGrant() {
-        this(null, null, null, null);
+        this(null, null, null);
     }
 
-    public RangerGrant(RangerPrincipal principal, List<String> accessTypes, List<String> conditions, List<String> validitySchedules) {
-        this.principal         = principal;
-        this.accessTypes       = accessTypes;
-        this.conditions        = conditions;
-        this.validitySchedules = validitySchedules;
+    public RangerGrant(RangerPrincipal principal, List<String> accessTypes, List<Condition> conditions) {
+        setPrincipal(principal);
+        setAccessTypes(accessTypes);
+        setConditions(conditions);
     }
 
     public RangerPrincipal getPrincipal() {
@@ -61,28 +60,44 @@ public class RangerGrant implements java.io.Serializable {
     }
 
     public void setAccessTypes(List<String> accessTypes) {
-        this.accessTypes = accessTypes;
+        if (this.accessTypes == null) {
+            this.accessTypes = new ArrayList<>();
+        }
+
+        if (this.accessTypes == accessTypes) {
+            return;
+        }
+
+        this.accessTypes.clear();
+
+        if (accessTypes != null) {
+            this.accessTypes.addAll(accessTypes);
+        }
     }
 
-    public List<String> getConditions() {
+    public List<Condition> getConditions() {
         return conditions;
     }
 
-    public void setConditions(List<String> conditions) {
-        this.conditions = conditions;
-    }
+    public void setConditions(List<Condition> conditions) {
+        if (this.conditions == null) {
+            this.conditions = new ArrayList<>();
+        }
 
-    public List<String> getValiditySchedules() {
-        return validitySchedules;
-    }
+        if (this.conditions == conditions) {
+            return;
+        }
 
-    public void setValiditySchedules(List<String> validitySchedules) {
-        this.validitySchedules = validitySchedules;
+        this.conditions.clear();
+
+        if (conditions != null) {
+            this.conditions.addAll(conditions);
+        }
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(principal, accessTypes, conditions, validitySchedules);
+        return Objects.hash(principal, accessTypes, conditions);
     }
 
     @Override
@@ -99,8 +114,7 @@ public class RangerGrant implements java.io.Serializable {
 
         return Objects.equals(principal, other.principal) &&
                 Objects.equals(accessTypes, other.accessTypes) &&
-                Objects.equals(conditions, other.conditions) &&
-                Objects.equals(validitySchedules, other.validitySchedules);
+                Objects.equals(conditions, other.conditions);
     }
 
     @Override
@@ -109,7 +123,78 @@ public class RangerGrant implements java.io.Serializable {
                 "principal='" + principal.toString() +
                 ", accessTypes=" + accessTypes +
                 ", conditions=" + conditions +
-                ", validitySchedules=" + validitySchedules +
                 '}';
+    }
+
+    @JsonAutoDetect(getterVisibility = JsonAutoDetect.Visibility.NONE, setterVisibility = JsonAutoDetect.Visibility.NONE, fieldVisibility = JsonAutoDetect.Visibility.ANY)
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Condition implements java.io.Serializable {
+        private static final long serialVersionUID = 1L;
+
+        private String       type;
+        private List<String> values;
+
+        public Condition() {
+            this(null, null);
+        }
+
+        public Condition(String type, List<String> values) {
+            setType(type);
+            setValues(values);
+        }
+
+        public String getType() {
+            return type;
+        }
+
+        public void setType(String type) {
+            this.type = type;
+        }
+
+        public List<String> getValues() {
+            return values;
+        }
+
+        public void setValues(List<String> values) {
+            if (this.values == null) {
+                this.values = new ArrayList<>();
+            }
+
+            if (this.values == values) {
+                return;
+            }
+
+            this.values.clear();
+
+            if (values != null) {
+                this.values.addAll(values);
+            }
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            Condition that = (Condition) o;
+            return Objects.equals(type, that.type) && Objects.equals(values, that.values);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(type, values);
+        }
+
+        @Override
+        public String toString() {
+            return "Conditions{" +
+                    "type='" + type + '\'' +
+                    ", values=" + values +
+                    '}';
+        }
     }
 }

--- a/security-admin/src/main/java/org/apache/ranger/rest/GdsREST.java
+++ b/security-admin/src/main/java/org/apache/ranger/rest/GdsREST.java
@@ -108,14 +108,14 @@ public class GdsREST {
     private static final Logger LOG      = LoggerFactory.getLogger(GdsREST.class);
     private static final Logger PERF_LOG = RangerPerfTracer.getPerfLogger("rest.GdsREST");
 
-    public static final String GDS_POLICY_EXPR_CONDITION = "expression";
-
     private static final String            PRINCIPAL_TYPE_USER             = RangerPrincipal.PrincipalType.USER.name().toLowerCase();
     private static final String            PRINCIPAL_TYPE_GROUP            = RangerPrincipal.PrincipalType.GROUP.name().toLowerCase();
     private static final String            PRINCIPAL_TYPE_ROLE             = RangerPrincipal.PrincipalType.ROLE.name().toLowerCase();
     private static final String            DEFAULT_PRINCIPAL_TYPE          = PRINCIPAL_TYPE_USER;
     private static final RangerAdminConfig config                          = RangerAdminConfig.getInstance();
     private static final int               SHARED_RESOURCES_MAX_BATCH_SIZE = config.getInt("ranger.admin.rest.gds.shared.resources.max.batch.size", 100);
+
+    public  static final String  GDS_POLICY_VALIDITY_SCHEDULE_CONDITION    = "validitySchedule";
 
     @Autowired
     GdsDBStore gdsStore;
@@ -2134,7 +2134,7 @@ public class GdsREST {
         }
 
         if (CollectionUtils.isNotEmpty(conditions)) {
-            policyItem.setConditions(conditions.stream().map(condition -> new RangerPolicyItemCondition(GDS_POLICY_EXPR_CONDITION, Collections.singletonList(condition))).collect(Collectors.toList()));
+            policyItem.setConditions(conditions.stream().map(condition -> new RangerPolicyItemCondition(GDS_POLICY_VALIDITY_SCHEDULE_CONDITION, Collections.singletonList(condition))).collect(Collectors.toList()));
         }
 
         switch (grant.getPrincipal().getType()) {

--- a/security-admin/src/test/java/org/apache/ranger/rest/TestGdsREST.java
+++ b/security-admin/src/test/java/org/apache/ranger/rest/TestGdsREST.java
@@ -87,7 +87,7 @@ public class TestGdsREST {
 
         List<RangerPolicy.RangerPolicyItem> hdfsPolicyItems = new ArrayList<>(gdsREST.filterPolicyItemsByRequest(policy, request));
 
-        RangerGrant grant3 = new RangerGrant(new RangerPrincipal(RangerPrincipal.PrincipalType.GROUP, "hdfs"), Collections.singletonList("_READ"), Collections.emptyList());
+        RangerGrant grant3 = new RangerGrant(new RangerPrincipal(RangerPrincipal.PrincipalType.GROUP, "hdfs"), Collections.singletonList("_READ"), Collections.emptyList(), Collections.emptyList());
         policy = gdsREST.updatePolicyWithModifiedGrants(policy, Collections.singletonList(grant3));
 
         List<RangerPolicy.RangerPolicyItem> updatedHdfsPolicyItems = new ArrayList<>(gdsREST.filterPolicyItemsByRequest(policy, request));
@@ -111,7 +111,7 @@ public class TestGdsREST {
 
         List<RangerPolicy.RangerPolicyItem> existingHdfsPolicyItems = new ArrayList<>(gdsREST.filterPolicyItemsByRequest(policy, request));
 
-        RangerGrant grant4 = new RangerGrant(new RangerPrincipal(RangerPrincipal.PrincipalType.GROUP, "hdfs"), Collections.emptyList(), Collections.emptyList());
+        RangerGrant grant4 = new RangerGrant(new RangerPrincipal(RangerPrincipal.PrincipalType.GROUP, "hdfs"), Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
         policy = gdsREST.updatePolicyWithModifiedGrants(policy, Collections.singletonList(grant4));
 
         List<RangerPolicy.RangerPolicyItem> updatedHdfsPolicyItems = gdsREST.filterPolicyItemsByRequest(policy, request);
@@ -238,8 +238,8 @@ public class TestGdsREST {
     }
 
     private List<RangerGrant> createAndGetSampleGrantData() {
-        RangerGrant grant1 = new RangerGrant(new RangerPrincipal(RangerPrincipal.PrincipalType.USER, "hive"), Collections.singletonList("_READ"), Collections.singletonList("IS_ACCESSED_BEFORE('2024/12/12')"));
-        RangerGrant grant2 = new RangerGrant(new RangerPrincipal(RangerPrincipal.PrincipalType.GROUP, "hdfs"), Collections.singletonList("_MANAGE"), Collections.emptyList());
+        RangerGrant grant1 = new RangerGrant(new RangerPrincipal(RangerPrincipal.PrincipalType.USER, "hive"), Collections.singletonList("_READ"), Collections.singletonList("IS_ACCESSED_BEFORE('2024/12/12')"), Collections.singletonList("{\"startTime\":\"1970/01/01 00:00:00\",\"endTime\":\"2025/03/08 00:35:28\",\"timeZone\":\"UTC\"}"));
+        RangerGrant grant2 = new RangerGrant(new RangerPrincipal(RangerPrincipal.PrincipalType.GROUP, "hdfs"), Collections.singletonList("_MANAGE"), Collections.emptyList(), Collections.emptyList());
 
         return Arrays.asList(grant1, grant2);
     }

--- a/security-admin/src/test/java/org/apache/ranger/rest/TestGdsREST.java
+++ b/security-admin/src/test/java/org/apache/ranger/rest/TestGdsREST.java
@@ -87,7 +87,7 @@ public class TestGdsREST {
 
         List<RangerPolicy.RangerPolicyItem> hdfsPolicyItems = new ArrayList<>(gdsREST.filterPolicyItemsByRequest(policy, request));
 
-        RangerGrant grant3 = new RangerGrant(new RangerPrincipal(RangerPrincipal.PrincipalType.GROUP, "hdfs"), Collections.singletonList("_READ"), Collections.emptyList(), Collections.emptyList());
+        RangerGrant grant3 = new RangerGrant(new RangerPrincipal(RangerPrincipal.PrincipalType.GROUP, "hdfs"), Collections.singletonList("_READ"), Collections.emptyList());
         policy = gdsREST.updatePolicyWithModifiedGrants(policy, Collections.singletonList(grant3));
 
         List<RangerPolicy.RangerPolicyItem> updatedHdfsPolicyItems = new ArrayList<>(gdsREST.filterPolicyItemsByRequest(policy, request));
@@ -111,7 +111,7 @@ public class TestGdsREST {
 
         List<RangerPolicy.RangerPolicyItem> existingHdfsPolicyItems = new ArrayList<>(gdsREST.filterPolicyItemsByRequest(policy, request));
 
-        RangerGrant grant4 = new RangerGrant(new RangerPrincipal(RangerPrincipal.PrincipalType.GROUP, "hdfs"), Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+        RangerGrant grant4 = new RangerGrant(new RangerPrincipal(RangerPrincipal.PrincipalType.GROUP, "hdfs"), Collections.emptyList(), Collections.emptyList());
         policy = gdsREST.updatePolicyWithModifiedGrants(policy, Collections.singletonList(grant4));
 
         List<RangerPolicy.RangerPolicyItem> updatedHdfsPolicyItems = gdsREST.filterPolicyItemsByRequest(policy, request);
@@ -238,8 +238,20 @@ public class TestGdsREST {
     }
 
     private List<RangerGrant> createAndGetSampleGrantData() {
-        RangerGrant grant1 = new RangerGrant(new RangerPrincipal(RangerPrincipal.PrincipalType.USER, "hive"), Collections.singletonList("_READ"), Collections.singletonList("IS_ACCESSED_BEFORE('2024/12/12')"), Collections.singletonList("{\"startTime\":\"1970/01/01 00:00:00\",\"endTime\":\"2025/03/08 00:35:28\",\"timeZone\":\"UTC\"}"));
-        RangerGrant grant2 = new RangerGrant(new RangerPrincipal(RangerPrincipal.PrincipalType.GROUP, "hdfs"), Collections.singletonList("_MANAGE"), Collections.emptyList(), Collections.emptyList());
+        List<RangerGrant.Condition> conditions = new ArrayList<>();
+
+        RangerGrant.Condition condition1  = new RangerGrant.Condition(null, null);
+        condition1.setType("expression");
+        condition1.setValues(Arrays.asList("IS_ACCESSED_BEFORE('2024/12/12')", "_STATE == 'CA'"));
+        conditions.add(condition1);
+
+        RangerGrant.Condition condition2  = new RangerGrant.Condition(null, null);
+        condition2.setType("validitySchedule");
+        condition2.setValues(Arrays.asList("{\"startTime\":\"1970/01/01 00:00:00\",\"endTime\":\"2025/03/08 00:35:28\",\"timeZone\":\"UTC\"}"));
+        conditions.add(condition2);
+
+        RangerGrant grant1 = new RangerGrant(new RangerPrincipal(RangerPrincipal.PrincipalType.USER, "hive"), Collections.singletonList("_READ"), conditions);
+        RangerGrant grant2 = new RangerGrant(new RangerPrincipal(RangerPrincipal.PrincipalType.GROUP, "hdfs"), Collections.singletonList("_MANAGE"), Collections.emptyList());
 
         return Arrays.asList(grant1, grant2);
     }


### PR DESCRIPTION
DatSet policies fail to authorize when condition expression is present. This happens if the  DataSet / Shares is getting created via Grant API 

## What changes were proposed in this pull request?

Update the condition created via Grant API of GdsREST call to "validitySchedule" type. In this way the create condition will be evaluated by RangerValidityScheduleConditionEvaluator.


## How was this patch tested?
Tested in local VM via invoking Grant API with policy condition of "conditions":[{"type":"validitySchedule","values":["{\"startTime\":\"1970/01/01 00:00:00\",\"endTime\":\"2025/03/08 00:35:28\",\"timeZone\":\"UTC\"}"]}]
