### PR TITLE
RANGER-5078: Set ranger.usersync.ldap.referral=follow as default config

### DIFF
--- a/dev-support/ranger-docker/scripts/ranger-usersync-install.properties
+++ b/dev-support/ranger-docker/scripts/ranger-usersync-install.properties
@@ -214,8 +214,8 @@ SYNC_PAGED_RESULTS_ENABLED=
 # search results would be returned page by page with the specified number of entries per page
 # default value: 500
 SYNC_PAGED_RESULTS_SIZE=
-#LDAP context referral could be ignore or follow
-SYNC_LDAP_REFERRAL =ignore
+# valid values: ignore or follow
+SYNC_LDAP_REFERRAL = follow
 
 # if you want to enable or disable jvm metrics for usersync process
 # valid values: true, false

--- a/ugsync/src/main/java/org/apache/ranger/unixusersync/config/UserGroupSyncConfig.java
+++ b/ugsync/src/main/java/org/apache/ranger/unixusersync/config/UserGroupSyncConfig.java
@@ -123,7 +123,7 @@ public class UserGroupSyncConfig {
     private static final String  DEFAULT_GROUP_CLOUDID_ATTRIBUTE_DATATYPE                            = "byte[]";
     private static final String  DEFAULT_OTHER_GROUP_ATTRIBUTES                                      = "displayname,";
     private static final String  DEFAULT_UGSYNC_GROUPNAME_CASE_CONVERSION_VALUE                      = UGSYNC_NONE_CASE_CONVERSION_VALUE;
-    private static final String  DEFAULT_LGSYNC_REFERRAL                                             = "ignore";
+    private static final String  DEFAULT_LGSYNC_REFERRAL                                             = "follow";
     private static final int     DEFAULT_LGSYNC_GROUP_HIERARCHY_LEVELS                               = 0;
     private static final int     DEFAULT_LGSYNC_PAGED_RESULTS_SIZE                                   = 500;
     private static final boolean DEFAULT_LGSYNC_LDAP_DELTASYNC_ENABLED                               = false;

--- a/unixauthservice/scripts/install.properties
+++ b/unixauthservice/scripts/install.properties
@@ -215,8 +215,8 @@ SYNC_PAGED_RESULTS_ENABLED=
 # search results would be returned page by page with the specified number of entries per page
 # default value: 500
 SYNC_PAGED_RESULTS_SIZE=
-#LDAP context referral could be ignore or follow
-SYNC_LDAP_REFERRAL =ignore
+# valid values: ignore or follow
+SYNC_LDAP_REFERRAL = follow
 
 # if you want to enable or disable jvm metrics for usersync process
 # valid values: true, false


### PR DESCRIPTION
## What changes were proposed in this pull request?

Changes the default value of `ranger.usersync.ldap.referral` from `ignore` to `follow`

## How was this patch tested?

Verified that the config parameter is populated correctly in `ranger-ugsync-site.xml` in docker deployment of `ranger-usersync`.
