### PR TITLE
RANGER-5131: remove finalize from policy engine

### DIFF
--- a/agents-common/src/main/java/org/apache/ranger/plugin/contextenricher/RangerAbstractContextEnricher.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/contextenricher/RangerAbstractContextEnricher.java
@@ -300,13 +300,4 @@ public abstract class RangerAbstractContextEnricher implements RangerContextEnri
 
         return ret;
     }
-
-    @Override
-    protected void finalize() throws Throwable {
-        try {
-            cleanup();
-        } finally {
-            super.finalize();
-        }
-    }
 }

--- a/agents-common/src/main/java/org/apache/ranger/plugin/policyengine/PolicyEngine.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/policyengine/PolicyEngine.java
@@ -338,15 +338,6 @@ public class PolicyEngine {
         return toString(new StringBuilder()).toString();
     }
 
-    @Override
-    protected void finalize() throws Throwable {
-        try {
-            cleanup();
-        } finally {
-            super.finalize();
-        }
-    }
-
     public StringBuilder toString(StringBuilder sb) {
         if (sb == null) {
             sb = new StringBuilder();

--- a/agents-common/src/main/java/org/apache/ranger/plugin/policyengine/PolicyEngine.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/policyengine/PolicyEngine.java
@@ -597,36 +597,6 @@ public class PolicyEngine {
         LOG.debug("<== reorderEvaluators()");
     }
 
-    private void cleanup() {
-        LOG.debug("==> PolicyEngine.cleanup()");
-
-        RangerPerfTracer perf = null;
-
-        if (RangerPerfTracer.isPerfTraceEnabled(PERF_POLICYENGINE_INIT_LOG)) {
-            perf = RangerPerfTracer.getPerfTracer(PERF_POLICYENGINE_INIT_LOG, "RangerPolicyEngine.cleanUp(hashCode=" + Integer.toHexString(System.identityHashCode(this)) + ")");
-        }
-
-        preCleanup(false);
-
-        if (policyRepository != null) {
-            policyRepository.cleanup();
-        }
-
-        if (tagPolicyRepository != null) {
-            tagPolicyRepository.cleanup();
-        }
-
-        if (MapUtils.isNotEmpty(this.zonePolicyRepositories)) {
-            for (Map.Entry<String, RangerPolicyRepository> entry : this.zonePolicyRepositories.entrySet()) {
-                entry.getValue().cleanup();
-            }
-        }
-
-        RangerPerfTracer.log(perf);
-
-        LOG.debug("<== PolicyEngine.cleanup()");
-    }
-
     private void getDeltasSortedByZones(PolicyEngine current, ServicePolicies servicePolicies, List<RangerPolicyDelta> defaultZoneDeltas, List<RangerPolicyDelta> defaultZoneDeltasForTagPolicies) {
         LOG.debug("==> getDeltasSortedByZones()");
 

--- a/agents-common/src/main/java/org/apache/ranger/plugin/policyengine/RangerPolicyRepository.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/policyengine/RangerPolicyRepository.java
@@ -313,15 +313,6 @@ public class RangerPolicyRepository {
         return sb.toString();
     }
 
-    @Override
-    protected void finalize() throws Throwable {
-        try {
-            cleanup();
-        } finally {
-            super.finalize();
-        }
-    }
-
     public StringBuilder toString(StringBuilder sb) {
         if (sb == null) {
             sb = new StringBuilder();

--- a/agents-common/src/main/java/org/apache/ranger/plugin/policyengine/RangerPolicyRepository.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/policyengine/RangerPolicyRepository.java
@@ -473,20 +473,6 @@ public class RangerPolicyRepository {
         LOG.debug("<== preCleanup(isForced={})", isForced);
     }
 
-    void cleanup() {
-        LOG.debug("==> cleanup()");
-
-        preCleanup(false);
-
-        if (CollectionUtils.isNotEmpty(this.contextEnrichers) && !isContextEnrichersShared) {
-            for (RangerContextEnricher enricher : this.contextEnrichers) {
-                enricher.cleanup();
-            }
-        }
-
-        LOG.debug("<== cleanup()");
-    }
-
     void reorderPolicyEvaluators() {
         LOG.debug("==> reorderEvaluators()");
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Removal of finalize() method from PolicyEngine class

As part of our efforts to ensure compatibility with future JDK versions, this code change removes the deprecated finalize() method from the PolicyEngine class. The finalize() method has been deprecated since JDK 9 and is slated for removal in future JDK versions.

Impact Analysis

A thorough analysis was conducted to assess the impact of removing the finalize() method. The results indicate that there is no adverse impact on the functionality of the PolicyEngine class.

Existing Cleanup Mechanisms

It's worth noting that we already have a cleanup() method in the RangerBasePlugin class, which allows users to release resources held by the PolicyEngine. This method provides a manual way to perform cleanup operations, ensuring that resources are properly released when needed.

## How was this patch tested?

mvn clean install 
