### PR TITLE
RANGER-5147: Modernize some Python scripts now that Python 3 is a requirement

### DIFF
--- a/agents-common/scripts/upgrade-plugin.py
+++ b/agents-common/scripts/upgrade-plugin.py
@@ -18,10 +18,7 @@ import xml.etree.ElementTree as ET
 import os,errno,sys
 from os import listdir
 from os.path import isfile, join, dirname
-try:
-	from urllib.parse import urlparse
-except ImportError:
-	from urlparse import urlparse
+from urllib.parse import urlparse
 
 debugLevel = 1
 

--- a/kms/scripts/db_setup.py
+++ b/kms/scripts/db_setup.py
@@ -140,14 +140,14 @@ class MysqlConf(BaseDB):
 		self.JAVA_BIN = self.JAVA_BIN.strip("'")
 		if is_unix:
 			if self.is_db_override_jdbc_connection_string == 'true' and self.db_override_jdbc_connection_string is not None and len(self.db_override_jdbc_connection_string) > 0:
-				jisql_cmd = "%s %s %s -cp %s:%s/jisql/lib/* org.apache.util.sql.Jisql -driver mysqlconj -cstring %s -u '%s' -p '%s' -noheader -trim -c \;" %(self.JAVA_BIN,self.JAVA_OPTS,db_ssl_cert_param,self.SQL_CONNECTOR_JAR,path,self.db_override_jdbc_connection_string,user,password)
+				jisql_cmd = "%s %s %s -cp %s:%s/jisql/lib/* org.apache.util.sql.Jisql -driver mysqlconj -cstring %s -u '%s' -p '%s' -noheader -trim -c \\;" %(self.JAVA_BIN,self.JAVA_OPTS,db_ssl_cert_param,self.SQL_CONNECTOR_JAR,path,self.db_override_jdbc_connection_string,user,password)
 			else:
-				jisql_cmd = "%s %s %s -cp %s:%s/jisql/lib/* org.apache.util.sql.Jisql -driver mysqlconj -cstring jdbc:mysql://%s/%s%s -u '%s' -p '%s' -noheader -trim -c \;" %(self.JAVA_BIN,self.JAVA_OPTS,db_ssl_cert_param,self.SQL_CONNECTOR_JAR,path,self.host,db_name,db_ssl_param,user,password)
+				jisql_cmd = "%s %s %s -cp %s:%s/jisql/lib/* org.apache.util.sql.Jisql -driver mysqlconj -cstring jdbc:mysql://%s/%s%s -u '%s' -p '%s' -noheader -trim -c \\;" %(self.JAVA_BIN,self.JAVA_OPTS,db_ssl_cert_param,self.SQL_CONNECTOR_JAR,path,self.host,db_name,db_ssl_param,user,password)
 		elif os_name == "WINDOWS":
 			if self.is_db_override_jdbc_connection_string == 'true' and self.db_override_jdbc_connection_string is not None and len(self.db_override_jdbc_connection_string) > 0:
-				jisql_cmd = "%s %s %s -cp %s;%s\jisql\\lib\\* org.apache.util.sql.Jisql -driver mysqlconj -cstring %s -u \"%s\" -p \"%s\" -noheader -trim" %(self.JAVA_BIN,self.JAVA_OPTS,db_ssl_cert_param,self.SQL_CONNECTOR_JAR, path, self.db_override_jdbc_connection_string,user, password)
+				jisql_cmd = "%s %s %s -cp %s;%s\\jisql\\lib\\* org.apache.util.sql.Jisql -driver mysqlconj -cstring %s -u \"%s\" -p \"%s\" -noheader -trim" %(self.JAVA_BIN,self.JAVA_OPTS,db_ssl_cert_param,self.SQL_CONNECTOR_JAR, path, self.db_override_jdbc_connection_string,user, password)
 			else:
-				jisql_cmd = "%s %s %s -cp %s;%s\jisql\\lib\\* org.apache.util.sql.Jisql -driver mysqlconj -cstring jdbc:mysql://%s/%s%s -u \"%s\" -p \"%s\" -noheader -trim" %(self.JAVA_BIN,self.JAVA_OPTS,db_ssl_cert_param,self.SQL_CONNECTOR_JAR, path, self.host, db_name,db_ssl_param,user, password)
+				jisql_cmd = "%s %s %s -cp %s;%s\\jisql\\lib\\* org.apache.util.sql.Jisql -driver mysqlconj -cstring jdbc:mysql://%s/%s%s -u \"%s\" -p \"%s\" -noheader -trim" %(self.JAVA_BIN,self.JAVA_OPTS,db_ssl_cert_param,self.SQL_CONNECTOR_JAR, path, self.host, db_name,db_ssl_param,user, password)
 		return jisql_cmd
 
 	def check_connection(self, db_name, db_user, db_password):
@@ -238,16 +238,16 @@ class OracleConf(BaseDB):
 				jisql_cmd = "%s %s -cp %s:%s/jisql/lib/* org.apache.util.sql.Jisql -driver oraclethin -cstring %s -u '%s' -p '%s' -noheader -trim" %(self.JAVA_BIN,self.JAVA_OPTS,self.SQL_CONNECTOR_JAR,path, cstring, user, password)
 		elif os_name == "WINDOWS":
 			if self.is_db_override_jdbc_connection_string == 'true' and self.db_override_jdbc_connection_string is not None and len(self.db_override_jdbc_connection_string) > 0:
-				jisql_cmd = "%s %s -cp %s;%s\jisql\\lib\\* org.apache.util.sql.Jisql -driver oraclethin -cstring %s -u \"%s\" -p \"%s\" -noheader -trim" %(self.JAVA_BIN,self.JAVA_OPTS,self.SQL_CONNECTOR_JAR, path, self.db_override_jdbc_connection_string, user, password)
+				jisql_cmd = "%s %s -cp %s;%s\\jisql\\lib\\* org.apache.util.sql.Jisql -driver oraclethin -cstring %s -u \"%s\" -p \"%s\" -noheader -trim" %(self.JAVA_BIN,self.JAVA_OPTS,self.SQL_CONNECTOR_JAR, path, self.db_override_jdbc_connection_string, user, password)
 			else:
-				jisql_cmd = "%s %s -cp %s;%s\jisql\\lib\\* org.apache.util.sql.Jisql -driver oraclethin -cstring %s -u \"%s\" -p \"%s\" -noheader -trim" %(self.JAVA_BIN,self.JAVA_OPTS,self.SQL_CONNECTOR_JAR, path, cstring, user, password)
+				jisql_cmd = "%s %s -cp %s;%s\\jisql\\lib\\* org.apache.util.sql.Jisql -driver oraclethin -cstring %s -u \"%s\" -p \"%s\" -noheader -trim" %(self.JAVA_BIN,self.JAVA_OPTS,self.SQL_CONNECTOR_JAR, path, cstring, user, password)
 		return jisql_cmd
 
 	def check_connection(self, db_name, db_user, db_password):
 		log("[I] Checking connection", "info")
 		get_cmd = self.get_jisql_cmd(db_user, db_password)
 		if is_unix:
-			query = get_cmd + " -c \; -query \"select * from v$version;\""
+			query = get_cmd + " -c \\; -query \"select * from v$version;\""
 		elif os_name == "WINDOWS":
 			query = get_cmd + " -query \"select * from v$version;\" -c ;"
 		jisql_log(query, db_password)
@@ -266,7 +266,7 @@ class OracleConf(BaseDB):
 			log("[I] Importing script " + db_name + " from file: " + name,"info")
 			get_cmd = self.get_jisql_cmd(db_user, db_password)
 			if is_unix:
-				query = get_cmd + " -input %s -c \;" %file_name
+				query = get_cmd + " -input %s -c \\;" %file_name
 				jisql_log(query, db_password)
 				ret = subprocess.call(shlex.split(query))
 			elif os_name == "WINDOWS":
@@ -286,7 +286,7 @@ class OracleConf(BaseDB):
 	def check_table(self, db_name, db_user, db_password, TABLE_NAME):
 		get_cmd = self.get_jisql_cmd(db_user ,db_password)
 		if is_unix:
-			query = get_cmd + " -c \; -query 'select default_tablespace from user_users;'"
+			query = get_cmd + " -c \\; -query 'select default_tablespace from user_users;'"
 		elif os_name == "WINDOWS":
 			query = get_cmd + " -query \"select default_tablespace from user_users;\" -c ;"
 		jisql_log(query, db_password)
@@ -298,7 +298,7 @@ class OracleConf(BaseDB):
 			log("[I] Verifying table " + TABLE_NAME +" in tablespace " + output, "info")
 			get_cmd = self.get_jisql_cmd(db_user, db_password)
 			if is_unix:
-				query = get_cmd + " -c \; -query \"select UPPER(table_name) from all_tables where UPPER(tablespace_name)=UPPER('%s') and UPPER(table_name)=UPPER('%s');\"" %(output ,TABLE_NAME)
+				query = get_cmd + " -c \\; -query \"select UPPER(table_name) from all_tables where UPPER(tablespace_name)=UPPER('%s') and UPPER(table_name)=UPPER('%s');\"" %(output ,TABLE_NAME)
 			elif os_name == "WINDOWS":
 				query = get_cmd + " -query \"select UPPER(table_name) from all_tables where UPPER(tablespace_name)=UPPER('%s') and UPPER(table_name)=UPPER('%s');\" -c ;" %(output ,TABLE_NAME)
 			jisql_log(query, db_password)
@@ -355,14 +355,14 @@ class PostgresConf(BaseDB):
 				db_ssl_param="?ssl=%s" %(self.db_ssl_enabled)
 		if is_unix:
 			if self.is_db_override_jdbc_connection_string == 'true' and self.db_override_jdbc_connection_string is not None and len(self.db_override_jdbc_connection_string) > 0:
-				jisql_cmd = "%s %s %s -cp %s:%s/jisql/lib/* org.apache.util.sql.Jisql -driver postgresql -cstring %s -u %s -p '%s' -noheader -trim -c \;" %(self.JAVA_BIN,self.JAVA_OPTS,db_ssl_cert_param,self.SQL_CONNECTOR_JAR,path, self.db_override_jdbc_connection_string,user, password)
+				jisql_cmd = "%s %s %s -cp %s:%s/jisql/lib/* org.apache.util.sql.Jisql -driver postgresql -cstring %s -u %s -p '%s' -noheader -trim -c \\;" %(self.JAVA_BIN,self.JAVA_OPTS,db_ssl_cert_param,self.SQL_CONNECTOR_JAR,path, self.db_override_jdbc_connection_string,user, password)
 			else:
-				jisql_cmd = "%s %s %s -cp %s:%s/jisql/lib/* org.apache.util.sql.Jisql -driver postgresql -cstring jdbc:postgresql://%s/%s%s -u %s -p '%s' -noheader -trim -c \;" %(self.JAVA_BIN,self.JAVA_OPTS,db_ssl_cert_param,self.SQL_CONNECTOR_JAR,path, self.host, db_name, db_ssl_param,user, password)
+				jisql_cmd = "%s %s %s -cp %s:%s/jisql/lib/* org.apache.util.sql.Jisql -driver postgresql -cstring jdbc:postgresql://%s/%s%s -u %s -p '%s' -noheader -trim -c \\;" %(self.JAVA_BIN,self.JAVA_OPTS,db_ssl_cert_param,self.SQL_CONNECTOR_JAR,path, self.host, db_name, db_ssl_param,user, password)
 		elif os_name == "WINDOWS":
 			if self.is_db_override_jdbc_connection_string == 'true' and self.db_override_jdbc_connection_string is not None and len(self.db_override_jdbc_connection_string) > 0:
-				jisql_cmd = "%s %s %s -cp %s;%s\jisql\\lib\\* org.apache.util.sql.Jisql -driver postgresql -cstring %s -u %s -p \"%s\" -noheader -trim" %(self.JAVA_BIN,self.JAVA_OPTS,db_ssl_cert_param,self.SQL_CONNECTOR_JAR, path, self.db_override_jdbc_connection_string,user, password)
+				jisql_cmd = "%s %s %s -cp %s;%s\\jisql\\lib\\* org.apache.util.sql.Jisql -driver postgresql -cstring %s -u %s -p \"%s\" -noheader -trim" %(self.JAVA_BIN,self.JAVA_OPTS,db_ssl_cert_param,self.SQL_CONNECTOR_JAR, path, self.db_override_jdbc_connection_string,user, password)
 			else:
-				jisql_cmd = "%s %s %s -cp %s;%s\jisql\\lib\\* org.apache.util.sql.Jisql -driver postgresql -cstring jdbc:postgresql://%s/%s%s -u %s -p \"%s\" -noheader -trim" %(self.JAVA_BIN,self.JAVA_OPTS,db_ssl_cert_param,self.SQL_CONNECTOR_JAR, path, self.host, db_name, db_ssl_param,user, password)
+				jisql_cmd = "%s %s %s -cp %s;%s\\jisql\\lib\\* org.apache.util.sql.Jisql -driver postgresql -cstring jdbc:postgresql://%s/%s%s -u %s -p \"%s\" -noheader -trim" %(self.JAVA_BIN,self.JAVA_OPTS,db_ssl_cert_param,self.SQL_CONNECTOR_JAR, path, self.host, db_name, db_ssl_param,user, password)
 		return jisql_cmd
 
 	def check_connection(self, db_name, db_user, db_password):
@@ -451,7 +451,7 @@ class SqlServerConf(BaseDB):
 		log("[I] Checking connection", "info")
 		get_cmd = self.get_jisql_cmd(db_user, db_password, db_name)
 		if is_unix:
-			query = get_cmd + " -c \; -query \"SELECT 1;\""
+			query = get_cmd + " -c \\; -query \"SELECT 1;\""
 		elif os_name == "WINDOWS":
 			query = get_cmd + " -query \"SELECT 1;\" -c ;"
 		jisql_log(query, db_password)
@@ -488,7 +488,7 @@ class SqlServerConf(BaseDB):
 	def check_table(self, db_name, db_user, db_password, TABLE_NAME):
 		get_cmd = self.get_jisql_cmd(db_user, db_password, db_name)
 		if is_unix:
-			query = get_cmd + " -c \; -query \"SELECT TABLE_NAME FROM information_schema.tables where table_name = '%s';\"" %(TABLE_NAME)
+			query = get_cmd + " -c \\; -query \"SELECT TABLE_NAME FROM information_schema.tables where table_name = '%s';\"" %(TABLE_NAME)
 		elif os_name == "WINDOWS":
 			query = get_cmd + " -query \"SELECT TABLE_NAME FROM information_schema.tables where table_name = '%s';\" -c ;" %(TABLE_NAME)
 		jisql_log(query, db_password)
@@ -529,7 +529,7 @@ class SqlAnywhereConf(BaseDB):
 		log("[I] Checking connection", "info")
 		get_cmd = self.get_jisql_cmd(db_user, db_password, db_name)
 		if is_unix:
-			query = get_cmd + " -c \; -query \"SELECT 1;\""
+			query = get_cmd + " -c \\; -query \"SELECT 1;\""
 		elif os_name == "WINDOWS":
 			query = get_cmd + " -query \"SELECT 1;\" -c ;"
 		jisql_log(query, db_password)
@@ -567,7 +567,7 @@ class SqlAnywhereConf(BaseDB):
 		self.set_options(db_name, db_user, db_password, TABLE_NAME)
 		get_cmd = self.get_jisql_cmd(db_user, db_password, db_name)
 		if is_unix:
-			query = get_cmd + " -c \; -query \"SELECT name FROM sysobjects where name = '%s' and type='U';\"" %(TABLE_NAME)
+			query = get_cmd + " -c \\; -query \"SELECT name FROM sysobjects where name = '%s' and type='U';\"" %(TABLE_NAME)
 		elif os_name == "WINDOWS":
 			query = get_cmd + " -query \"SELECT name FROM sysobjects where name = '%s' and type='U';\" -c ;" %(TABLE_NAME)
 		jisql_log(query, db_password)
@@ -582,19 +582,19 @@ class SqlAnywhereConf(BaseDB):
 	def set_options(self, db_name, db_user, db_password, TABLE_NAME):
 		get_cmd = self.get_jisql_cmd(db_user, db_password, db_name)
 		if is_unix:
-			query = get_cmd + " -c \; -query \"set option public.reserved_keywords='LIMIT';\""
+			query = get_cmd + " -c \\; -query \"set option public.reserved_keywords='LIMIT';\""
 		elif os_name == "WINDOWS":
 			query = get_cmd + " -query \"set option public.reserved_keywords='LIMIT';\" -c ;"
 		jisql_log(query, db_password)
 		ret = subprocess.call(shlex.split(query))
 		if is_unix:
-			query = get_cmd + " -c \; -query \"set option public.max_statement_count=0;\""
+			query = get_cmd + " -c \\; -query \"set option public.max_statement_count=0;\""
 		elif os_name == "WINDOWS":
 			query = get_cmd + " -query \"set option public.max_statement_count=0;\" -c;"
 		jisql_log(query, db_password)
 		ret = subprocess.call(shlex.split(query))
 		if is_unix:
-			query = get_cmd + " -c \; -query \"set option public.max_cursor_count=0;\""
+			query = get_cmd + " -c \\; -query \"set option public.max_cursor_count=0;\""
 		elif os_name == "WINDOWS":
 			query = get_cmd + " -query \"set option public.max_cursor_count=0;\" -c;"
 		jisql_log(query, db_password)

--- a/kms/scripts/dba_script.py
+++ b/kms/scripts/dba_script.py
@@ -104,7 +104,7 @@ def logFile(msg):
 def password_validation(password, userType):
 	if password:
 		if re.search("[\\`'\"]",password):
-			log("[E] "+userType+" user password contains one of the unsupported special characters like \" ' \ `","error")
+			log("[E] "+userType+" user password contains one of the unsupported special characters like \" ' \\ `","error")
 			sys.exit(1)
 		else:
 			log("[I] "+userType+" user password validated","info")
@@ -166,10 +166,10 @@ class MysqlConf(BaseDB):
 			if "useSSL" not in db_name:
 				db_ssl_param="?useSSL=false"
 		if is_unix:
-			jisql_cmd = "%s %s -cp %s:%s/jisql/lib/* org.apache.util.sql.Jisql -driver mysqlconj -cstring jdbc:mysql://%s/%s%s -u %s -p '%s' -noheader -trim -c \;" %(self.JAVA_BIN,db_ssl_cert_param,self.SQL_CONNECTOR_JAR,path,self.host,db_name,db_ssl_param,user,password)
+			jisql_cmd = "%s %s -cp %s:%s/jisql/lib/* org.apache.util.sql.Jisql -driver mysqlconj -cstring jdbc:mysql://%s/%s%s -u %s -p '%s' -noheader -trim -c \\;" %(self.JAVA_BIN,db_ssl_cert_param,self.SQL_CONNECTOR_JAR,path,self.host,db_name,db_ssl_param,user,password)
 		elif os_name == "WINDOWS":
 			self.JAVA_BIN = self.JAVA_BIN.strip("'")
-			jisql_cmd = "%s %s -cp %s;%s\jisql\\lib\\* org.apache.util.sql.Jisql -driver mysqlconj -cstring jdbc:mysql://%s/%s%s -u %s -p \"%s\" -noheader -trim" %(self.JAVA_BIN,db_ssl_cert_param,self.SQL_CONNECTOR_JAR, path, self.host, db_name,db_ssl_param, user, password)
+			jisql_cmd = "%s %s -cp %s;%s\\jisql\\lib\\* org.apache.util.sql.Jisql -driver mysqlconj -cstring jdbc:mysql://%s/%s%s -u %s -p \"%s\" -noheader -trim" %(self.JAVA_BIN,db_ssl_cert_param,self.SQL_CONNECTOR_JAR, path, self.host, db_name,db_ssl_param, user, password)
 		return jisql_cmd
 
 	def verify_user(self, root_user, db_root_password, host, db_user, get_cmd,dryMode):
@@ -374,14 +374,14 @@ class OracleConf(BaseDB):
 		if is_unix:
 			jisql_cmd = "%s -cp %s:%s/jisql/lib/* org.apache.util.sql.Jisql -driver oraclethin -cstring %s -u '%s' -p '%s' -noheader -trim" %(self.JAVA_BIN, self.SQL_CONNECTOR_JAR,path, cstring, user, password)
 		elif os_name == "WINDOWS":
-			jisql_cmd = "%s -cp %s;%s\jisql\\lib\\* org.apache.util.sql.Jisql -driver oraclethin -cstring %s -u \"%s\" -p \"%s\" -noheader -trim" %(self.JAVA_BIN, self.SQL_CONNECTOR_JAR, path, cstring, user, password)
+			jisql_cmd = "%s -cp %s;%s\\jisql\\lib\\* org.apache.util.sql.Jisql -driver oraclethin -cstring %s -u \"%s\" -p \"%s\" -noheader -trim" %(self.JAVA_BIN, self.SQL_CONNECTOR_JAR, path, cstring, user, password)
 		return jisql_cmd
 
 	def check_connection(self, db_name, db_user, db_password):
 		log("[I] Checking connection", "info")
 		get_cmd = self.get_jisql_cmd(db_user, db_password)
 		if is_unix:
-			query = get_cmd + " -c \; -query \"select * from v$version;\""
+			query = get_cmd + " -c \\; -query \"select * from v$version;\""
 		elif os_name == "WINDOWS":
 			query = get_cmd + " -query \"select * from v$version;\" -c ;"
 		jisql_log(query, db_password)
@@ -398,7 +398,7 @@ class OracleConf(BaseDB):
 			log("[I] Verifying user " + db_user ,"info")
 		get_cmd = self.get_jisql_cmd(root_user, db_root_password)		
 		if is_unix:
-			query = get_cmd + " -c \; -query \"select username from all_users where upper(username)=upper('%s');\"" %(db_user)
+			query = get_cmd + " -c \\; -query \"select username from all_users where upper(username)=upper('%s');\"" %(db_user)
 		elif os_name == "WINDOWS":
 			query = get_cmd + " -query \"select username from all_users where upper(username)=upper('%s');\" -c ;" %(db_user)
 		jisql_log(query, db_root_password)
@@ -418,8 +418,8 @@ class OracleConf(BaseDB):
 					log("[I] User does not exists, Creating user : " + db_user, "info")
 					get_cmd = self.get_jisql_cmd(root_user, db_root_password)
 					if is_unix:
-						query = get_cmd + " -c \; -query 'create user %s identified by \"%s\";'" %(db_user, db_password)
-						query_with_masked_pwd = get_cmd + " -c \; -query 'create user %s identified by \"%s\";'" %(db_user, masked_pwd_string)
+						query = get_cmd + " -c \\; -query 'create user %s identified by \"%s\";'" %(db_user, db_password)
+						query_with_masked_pwd = get_cmd + " -c \\; -query 'create user %s identified by \"%s\";'" %(db_user, masked_pwd_string)
 						jisql_log(query_with_masked_pwd, db_root_password)
 						ret = subprocess.call(shlex.split(query))
 					elif os_name == "WINDOWS":
@@ -432,7 +432,7 @@ class OracleConf(BaseDB):
 							log("[I] User " + db_user + " created", "info")
 							log("[I] Granting permission to " + db_user, "info")
 							if is_unix:
-								query = get_cmd + " -c \; -query 'GRANT CREATE SESSION,CREATE PROCEDURE,CREATE TABLE,CREATE VIEW,CREATE SEQUENCE,CREATE TRIGGER,UNLIMITED Tablespace TO %s;'" % (db_user)
+								query = get_cmd + " -c \\; -query 'GRANT CREATE SESSION,CREATE PROCEDURE,CREATE TABLE,CREATE VIEW,CREATE SEQUENCE,CREATE TRIGGER,UNLIMITED Tablespace TO %s;'" % (db_user)
 								jisql_log(query, db_root_password)
 								ret = subprocess.call(shlex.split(query))
 							elif os_name == "WINDOWS":
@@ -458,7 +458,7 @@ class OracleConf(BaseDB):
 			log("[I] Verifying tablespace " + db_name, "info")
 		get_cmd = self.get_jisql_cmd(root_user, db_root_password)		
 		if is_unix:
-			query = get_cmd + " -c \; -query \"SELECT DISTINCT UPPER(TABLESPACE_NAME) FROM USER_TablespaceS where UPPER(Tablespace_Name)=UPPER(\'%s\');\"" %(db_name)
+			query = get_cmd + " -c \\; -query \"SELECT DISTINCT UPPER(TABLESPACE_NAME) FROM USER_TablespaceS where UPPER(Tablespace_Name)=UPPER(\'%s\');\"" %(db_name)
 		elif os_name == "WINDOWS":
 			query = get_cmd + " -query \"SELECT DISTINCT UPPER(TABLESPACE_NAME) FROM USER_TablespaceS where UPPER(Tablespace_Name)=UPPER(\'%s\');\" -c ;" %(db_name)
 		jisql_log(query, db_root_password)
@@ -475,7 +475,7 @@ class OracleConf(BaseDB):
 				if self.verify_user(root_user, db_user, db_root_password,dryMode):
 					get_cmd = self.get_jisql_cmd(db_user ,db_password)
 					if is_unix:
-						query = get_cmd + " -c \; -query 'select default_tablespace from user_users;'"
+						query = get_cmd + " -c \\; -query 'select default_tablespace from user_users;'"
 					elif os_name == "WINDOWS":
 						query = get_cmd + " -query \"select default_tablespace from user_users;\" -c ;"
 					jisql_log(query, db_root_password)
@@ -493,7 +493,7 @@ class OracleConf(BaseDB):
 				log("[I] Tablespace does not exist. Creating tablespace: " + db_name,"info")
 				get_cmd = self.get_jisql_cmd(root_user, db_root_password)
 				if is_unix:
-					query = get_cmd + " -c \; -query \"create tablespace %s datafile '%s.dat' size 10M autoextend on;\"" %(db_name, db_name)
+					query = get_cmd + " -c \\; -query \"create tablespace %s datafile '%s.dat' size 10M autoextend on;\"" %(db_name, db_name)
 					jisql_log(query, db_root_password)
 					ret = subprocess.call(shlex.split(query))
 				elif os_name == "WINDOWS":
@@ -521,7 +521,7 @@ class OracleConf(BaseDB):
 			# Assign default tablespace db_name
 			get_cmd = self.get_jisql_cmd(root_user , db_root_password)
 			if is_unix:
-				query = get_cmd +" -c \; -query 'alter user %s DEFAULT Tablespace %s;'" %(db_user, db_name)
+				query = get_cmd +" -c \\; -query 'alter user %s DEFAULT Tablespace %s;'" %(db_user, db_name)
 				jisql_log(query, db_root_password)
 				ret = subprocess.call(shlex.split(query))
 			elif os_name == "WINDOWS":
@@ -531,7 +531,7 @@ class OracleConf(BaseDB):
 			if ret == 0:
 				log("[I] Granting permission to " + db_user, "info")
 				if is_unix:
-					query = get_cmd + " -c \; -query 'GRANT CREATE SESSION,CREATE PROCEDURE,CREATE TABLE,CREATE VIEW,CREATE SEQUENCE,CREATE TRIGGER,UNLIMITED Tablespace TO %s;'" % (db_user)
+					query = get_cmd + " -c \\; -query 'GRANT CREATE SESSION,CREATE PROCEDURE,CREATE TABLE,CREATE VIEW,CREATE SEQUENCE,CREATE TRIGGER,UNLIMITED Tablespace TO %s;'" % (db_user)
 					jisql_log(query, db_root_password)
 					ret = subprocess.call(shlex.split(query))
 				elif os_name == "WINDOWS":
@@ -556,7 +556,7 @@ class OracleConf(BaseDB):
 		if dryMode == False:
 			get_cmd = self.get_jisql_cmd(root_user ,db_root_password)
 			if is_unix:
-				query = get_cmd + " -c \; -query 'GRANT CREATE SESSION,CREATE PROCEDURE,CREATE TABLE,CREATE VIEW,CREATE SEQUENCE,CREATE TRIGGER,UNLIMITED Tablespace TO %s;'" % (db_user)
+				query = get_cmd + " -c \\; -query 'GRANT CREATE SESSION,CREATE PROCEDURE,CREATE TABLE,CREATE VIEW,CREATE SEQUENCE,CREATE TRIGGER,UNLIMITED Tablespace TO %s;'" % (db_user)
 				jisql_log(query, db_root_password)
 				ret = subprocess.call(shlex.split(query))
 			elif os_name == "WINDOWS":
@@ -611,9 +611,9 @@ class PostgresConf(BaseDB):
 			else:
 				db_ssl_param="?ssl=%s&sslfactory=org.postgresql.ssl.NonValidatingFactory" %(self.db_ssl_enabled)
 		if is_unix:
-			jisql_cmd = "%s %s -cp %s:%s/jisql/lib/* org.apache.util.sql.Jisql -driver postgresql -cstring jdbc:postgresql://%s/%s%s -u %s -p '%s' -noheader -trim -c \;" %(self.JAVA_BIN, db_ssl_cert_param,self.SQL_CONNECTOR_JAR,path, self.host, db_name, db_ssl_param,user, password)
+			jisql_cmd = "%s %s -cp %s:%s/jisql/lib/* org.apache.util.sql.Jisql -driver postgresql -cstring jdbc:postgresql://%s/%s%s -u %s -p '%s' -noheader -trim -c \\;" %(self.JAVA_BIN, db_ssl_cert_param,self.SQL_CONNECTOR_JAR,path, self.host, db_name, db_ssl_param,user, password)
 		elif os_name == "WINDOWS":
-			jisql_cmd = "%s %s -cp %s;%s\jisql\\lib\\* org.apache.util.sql.Jisql -driver postgresql -cstring jdbc:postgresql://%s/%s%s -u %s -p \"%s\" -noheader -trim" %(self.JAVA_BIN, db_ssl_cert_param,self.SQL_CONNECTOR_JAR, path, self.host, db_name, db_ssl_param,user, password)
+			jisql_cmd = "%s %s -cp %s;%s\\jisql\\lib\\* org.apache.util.sql.Jisql -driver postgresql -cstring jdbc:postgresql://%s/%s%s -u %s -p \"%s\" -noheader -trim" %(self.JAVA_BIN, db_ssl_cert_param,self.SQL_CONNECTOR_JAR, path, self.host, db_name, db_ssl_param,user, password)
 		return jisql_cmd
 
 	def verify_user(self, root_user, db_root_password, db_user,dryMode):
@@ -853,7 +853,7 @@ class SqlServerConf(BaseDB):
 			log("[I] Verifying user " + db_user , "info")
 		get_cmd = self.get_jisql_cmd(root_user, db_root_password, 'master')
 		if is_unix:
-			query = get_cmd + " -c \; -query \"select name from sys.sql_logins where name = '%s';\"" %(db_user)
+			query = get_cmd + " -c \\; -query \"select name from sys.sql_logins where name = '%s';\"" %(db_user)
 		elif os_name == "WINDOWS":
 			query = get_cmd + " -query \"select name from sys.sql_logins where name = '%s';\" -c ;" %(db_user)
 		jisql_log(query, db_root_password)
@@ -867,7 +867,7 @@ class SqlServerConf(BaseDB):
 		log("[I] Checking connection", "info")
 		get_cmd = self.get_jisql_cmd(db_user, db_password, db_name)
 		if is_unix:
-			query = get_cmd + " -c \; -query \"SELECT 1;\""
+			query = get_cmd + " -c \\; -query \"SELECT 1;\""
 		elif os_name == "WINDOWS":
 			query = get_cmd + " -query \"SELECT 1;\" -c ;"
 		jisql_log(query, db_password)
@@ -889,8 +889,8 @@ class SqlServerConf(BaseDB):
 					get_cmd = self.get_jisql_cmd(root_user, db_root_password, 'master')
 					log("[I] User does not exists, Creating Login user " + db_user, "info")
 					if is_unix:
-						query = get_cmd + " -c \; -query \"CREATE LOGIN %s WITH PASSWORD = '%s';\"" %(db_user,db_password)
-						query_with_masked_pwd = get_cmd + " -c \; -query \"CREATE LOGIN %s WITH PASSWORD = '%s';\"" %(db_user,masked_pwd_string)
+						query = get_cmd + " -c \\; -query \"CREATE LOGIN %s WITH PASSWORD = '%s';\"" %(db_user,db_password)
+						query_with_masked_pwd = get_cmd + " -c \\; -query \"CREATE LOGIN %s WITH PASSWORD = '%s';\"" %(db_user,masked_pwd_string)
 						jisql_log(query_with_masked_pwd, db_root_password)
 						ret = subprocess.call(shlex.split(query))
 					elif os_name == "WINDOWS":
@@ -915,7 +915,7 @@ class SqlServerConf(BaseDB):
 			log("[I] Verifying database " + db_name, "info")
 		get_cmd = self.get_jisql_cmd(root_user, db_root_password, 'master')
 		if is_unix:
-			query = get_cmd + " -c \; -query \"SELECT name from sys.databases where name='%s';\"" %(db_name)
+			query = get_cmd + " -c \\; -query \"SELECT name from sys.databases where name='%s';\"" %(db_name)
 		elif os_name == "WINDOWS":
 			query = get_cmd + " -query \"SELECT name from sys.databases where name='%s';\" -c ;" %(db_name)
 		jisql_log(query, db_root_password)
@@ -934,7 +934,7 @@ class SqlServerConf(BaseDB):
 				log("[I] Database does not exist. Creating database : " + db_name,"info")
 				get_cmd = self.get_jisql_cmd(root_user, db_root_password, 'master')
 				if is_unix:
-					query = get_cmd + " -c \; -query \"create database %s;\"" %(db_name)
+					query = get_cmd + " -c \\; -query \"create database %s;\"" %(db_name)
 					jisql_log(query, db_root_password)
 					ret = subprocess.call(shlex.split(query))
 				elif os_name == "WINDOWS":
@@ -958,7 +958,7 @@ class SqlServerConf(BaseDB):
 	def create_user(self, root_user, db_name ,db_user, db_password, db_root_password,dryMode):
 		get_cmd = self.get_jisql_cmd(root_user, db_root_password, db_name)
 		if is_unix:
-			query = get_cmd + " -c \; -query \"USE %s SELECT name FROM sys.database_principals WHERE name = N'%s';\"" %(db_name, db_user)
+			query = get_cmd + " -c \\; -query \"USE %s SELECT name FROM sys.database_principals WHERE name = N'%s';\"" %(db_name, db_user)
 		elif os_name == "WINDOWS":
 			query = get_cmd + " -query \"USE %s SELECT name FROM sys.database_principals WHERE name = N'%s';\" -c ;" %(db_name, db_user)
 		jisql_log(query, db_root_password)
@@ -969,7 +969,7 @@ class SqlServerConf(BaseDB):
 		else:
 			if dryMode == False:
 				if is_unix:
-					query = get_cmd + " -c \; -query \"USE %s CREATE USER %s for LOGIN %s;\"" %(db_name ,db_user, db_user)
+					query = get_cmd + " -c \\; -query \"USE %s CREATE USER %s for LOGIN %s;\"" %(db_name ,db_user, db_user)
 					jisql_log(query, db_root_password)
 					ret = subprocess.call(shlex.split(query))
 				elif os_name == "WINDOWS":
@@ -978,7 +978,7 @@ class SqlServerConf(BaseDB):
 					ret = subprocess.call(query)
 				if ret == 0:
 					if is_unix:
-						query = get_cmd + " -c \; -query \"USE %s SELECT name FROM sys.database_principals WHERE name = N'%s';\"" %(db_name ,db_user)
+						query = get_cmd + " -c \\; -query \"USE %s SELECT name FROM sys.database_principals WHERE name = N'%s';\"" %(db_name ,db_user)
 					elif os_name == "WINDOWS":
 						query = get_cmd + " -query \"USE %s SELECT name FROM sys.database_principals WHERE name = N'%s';\" -c ;" %(db_name ,db_user)
 					jisql_log(query, db_root_password)
@@ -999,7 +999,7 @@ class SqlServerConf(BaseDB):
 			log("[I] Granting permission to admin user '" + db_user + "' on db '" + db_name + "'" , "info")
 			get_cmd = self.get_jisql_cmd(root_user, db_root_password, db_name)
 			if is_unix:
-				query = get_cmd + " -c \; -query \" EXEC sp_addrolemember N'db_owner', N'%s';\"" %(db_user)
+				query = get_cmd + " -c \\; -query \" EXEC sp_addrolemember N'db_owner', N'%s';\"" %(db_user)
 				jisql_log(query, db_root_password)
 				ret = subprocess.call(shlex.split(query))
 			elif os_name == "WINDOWS":
@@ -1041,7 +1041,7 @@ class SqlAnywhereConf(BaseDB):
 			log("[I] Verifying user " + db_user , "info")
 		get_cmd = self.get_jisql_cmd(root_user, db_root_password, '')
 		if is_unix:
-			query = get_cmd + " -c \; -query \"select name from syslogins where name = '%s';\"" %(db_user)
+			query = get_cmd + " -c \\; -query \"select name from syslogins where name = '%s';\"" %(db_user)
 		elif os_name == "WINDOWS":
 			query = get_cmd + " -query \"select name from syslogins where name = '%s';\" -c ;" %(db_user)
 		jisql_log(query, db_root_password)
@@ -1055,7 +1055,7 @@ class SqlAnywhereConf(BaseDB):
 		log("[I] Checking connection", "info")
 		get_cmd = self.get_jisql_cmd(db_user, db_password, db_name)
 		if is_unix:
-			query = get_cmd + " -c \; -query \"SELECT 1;\""
+			query = get_cmd + " -c \\; -query \"SELECT 1;\""
 		elif os_name == "WINDOWS":
 			query = get_cmd + " -query \"SELECT 1;\" -c ;"
 		jisql_log(query, db_password)
@@ -1076,13 +1076,13 @@ class SqlAnywhereConf(BaseDB):
 					get_cmd = self.get_jisql_cmd(root_user, db_root_password, '')
 					log("[I] User does not exists, Creating Login user " + db_user, "info")
 					if is_unix:
-						query = get_cmd + " -c \; -query \"CREATE USER %s IDENTIFIED BY '%s';\"" %(db_user,db_password)
-						query_with_masked_pwd = get_cmd + " -c \; -query \"CREATE USER %s IDENTIFIED BY '%s';\"" %(db_user,masked_pwd_string)
+						query = get_cmd + " -c \\; -query \"CREATE USER %s IDENTIFIED BY '%s';\"" %(db_user,db_password)
+						query_with_masked_pwd = get_cmd + " -c \\; -query \"CREATE USER %s IDENTIFIED BY '%s';\"" %(db_user,masked_pwd_string)
 						jisql_log(query_with_masked_pwd, db_root_password)
 						ret = subprocess.call(shlex.split(query))
 					elif os_name == "WINDOWS":
 						query = get_cmd + " -query \"CREATE USER %s IDENTIFIED BY '%s';\" -c ;" %(db_user,db_password)
-						query_with_masked_pwd = get_cmd + " -c \; -query \"CREATE USER %s IDENTIFIED BY '%s';\"" %(db_user,masked_pwd_string)
+						query_with_masked_pwd = get_cmd + " -c \\; -query \"CREATE USER %s IDENTIFIED BY '%s';\"" %(db_user,masked_pwd_string)
 						jisql_log(query_with_masked_pwd, db_root_password)
 						ret = subprocess.call(query)
 					if ret == 0:
@@ -1102,7 +1102,7 @@ class SqlAnywhereConf(BaseDB):
 			log("[I] Verifying database " + db_name, "info")
 		get_cmd = self.get_jisql_cmd(root_user, db_root_password, '')
 		if is_unix:
-			query = get_cmd + " -c \; -query \"select alias from sa_db_info() where alias='%s';\"" %(db_name)
+			query = get_cmd + " -c \\; -query \"select alias from sa_db_info() where alias='%s';\"" %(db_name)
 		elif os_name == "WINDOWS":
 			query = get_cmd + " -query \"select alias from sa_db_info() where alias='%s';\" -c ;" %(db_name)
 		jisql_log(query, db_root_password)
@@ -1120,8 +1120,8 @@ class SqlAnywhereConf(BaseDB):
 				log("[I] Database does not exist. Creating database : " + db_name,"info")
 				get_cmd = self.get_jisql_cmd(root_user, db_root_password, '')
 				if is_unix:
-					query = get_cmd + " -c \; -query \"create database '%s' dba user '%s' dba password '%s' database size 100MB;\"" %(db_name,db_user, db_password)
-					query_with_masked_pwd = get_cmd + " -c \; -query \"create database '%s' dba user '%s' dba password '%s' database size 100MB;\"" %(db_name,db_user, masked_pwd_string)
+					query = get_cmd + " -c \\; -query \"create database '%s' dba user '%s' dba password '%s' database size 100MB;\"" %(db_name,db_user, db_password)
+					query_with_masked_pwd = get_cmd + " -c \\; -query \"create database '%s' dba user '%s' dba password '%s' database size 100MB;\"" %(db_name,db_user, masked_pwd_string)
 					jisql_log(query_with_masked_pwd, db_root_password)
 					ret = subprocess.call(shlex.split(query))
 				elif os_name == "WINDOWS":
@@ -1147,7 +1147,7 @@ class SqlAnywhereConf(BaseDB):
 	def create_user(self, root_user, db_name ,db_user, db_password, db_root_password,dryMode):
 		get_cmd = self.get_jisql_cmd(root_user, db_root_password, '')
 		if is_unix:
-			query = get_cmd + " -c \; -query \"select name from syslogins where name ='%s';\"" %(db_user)
+			query = get_cmd + " -c \\; -query \"select name from syslogins where name ='%s';\"" %(db_user)
 		elif os_name == "WINDOWS":
 			query = get_cmd + " -query \"select name from syslogins where name ='%s';\" -c ;" %(db_user)
 		jisql_log(query, db_root_password)
@@ -1158,8 +1158,8 @@ class SqlAnywhereConf(BaseDB):
 		else:
 			if dryMode == False:
 				if is_unix:
-					query = get_cmd + " -c \; -query \"CREATE USER %s IDENTIFIED BY '%s';\"" %(db_user, db_password)
-					query_with_masked_pwd = get_cmd + " -c \; -query \"CREATE USER %s IDENTIFIED BY '%s';\"" %(db_user, masked_pwd_string)
+					query = get_cmd + " -c \\; -query \"CREATE USER %s IDENTIFIED BY '%s';\"" %(db_user, db_password)
+					query_with_masked_pwd = get_cmd + " -c \\; -query \"CREATE USER %s IDENTIFIED BY '%s';\"" %(db_user, masked_pwd_string)
 					jisql_log(query_with_masked_pwd, db_root_password)
 					ret = subprocess.call(shlex.split(query))
 				elif os_name == "WINDOWS":
@@ -1169,7 +1169,7 @@ class SqlAnywhereConf(BaseDB):
 					ret = subprocess.call(query)
 				if ret == 0:
 					if is_unix:
-						query = get_cmd + " -c \; -query \"select name from syslogins where name ='%s';\"" %(db_user)
+						query = get_cmd + " -c \\; -query \"select name from syslogins where name ='%s';\"" %(db_user)
 					elif os_name == "WINDOWS":
 						query = get_cmd + " -query \"select name from syslogins where name ='%s';\" -c ;" %(db_user)
 					jisql_log(query, db_root_password)
@@ -1190,8 +1190,8 @@ class SqlAnywhereConf(BaseDB):
 			log("[I] Granting permission to user '" + db_user + "' on db '" + db_name + "'" , "info")
 			get_cmd = self.get_jisql_cmd(root_user, db_root_password, '')
 			if is_unix:
-				query = get_cmd + " -c \; -query \"GRANT CONNECT to %s IDENTIFIED BY '%s';\"" %(db_user, db_password)
-				query_with_masked_pwd = get_cmd + " -c \; -query \"GRANT CONNECT to %s IDENTIFIED BY '%s';\"" %(db_user, masked_pwd_string)
+				query = get_cmd + " -c \\; -query \"GRANT CONNECT to %s IDENTIFIED BY '%s';\"" %(db_user, db_password)
+				query_with_masked_pwd = get_cmd + " -c \\; -query \"GRANT CONNECT to %s IDENTIFIED BY '%s';\"" %(db_user, masked_pwd_string)
 				jisql_log(query_with_masked_pwd, db_root_password)
 				ret = subprocess.call(shlex.split(query))
 			elif os_name == "WINDOWS":
@@ -1209,7 +1209,7 @@ class SqlAnywhereConf(BaseDB):
 			log("[I] Starting database " + db_name, "info")
 		get_cmd = self.get_jisql_cmd(root_user, db_root_password, '')
 		if is_unix:
-			query = get_cmd + " -c \; -query \"start database '%s' autostop off;\"" %(db_name)
+			query = get_cmd + " -c \\; -query \"start database '%s' autostop off;\"" %(db_name)
 		elif os_name == "WINDOWS":
 			query = get_cmd + " -query \"start database '%s' autostop off;\" -c ;" %(db_name)
 		jisql_log(query, db_root_password)

--- a/kms/scripts/dba_script.py
+++ b/kms/scripts/dba_script.py
@@ -103,7 +103,7 @@ def logFile(msg):
 
 def password_validation(password, userType):
 	if password:
-		if re.search("[\\\`'\"]",password):
+		if re.search("[\\`'\"]",password):
 			log("[E] "+userType+" user password contains one of the unsupported special characters like \" ' \ `","error")
 			sys.exit(1)
 		else:

--- a/security-admin/scripts/changepasswordutil.py
+++ b/security-admin/scripts/changepasswordutil.py
@@ -53,7 +53,7 @@ def log(msg,type):
 def password_validation(password):
 	if password:
 		if re.search("[\\`'\"]",password):
-			log("[E] password contains one of the unsupported special characters like \" ' \ `","error")
+			log("[E] password contains one of the unsupported special characters like \" ' \\ `","error")
 			sys.exit(1)
 
 

--- a/security-admin/scripts/changepasswordutil.py
+++ b/security-admin/scripts/changepasswordutil.py
@@ -52,7 +52,7 @@ def log(msg,type):
 
 def password_validation(password):
 	if password:
-		if re.search("[\\\`'\"]",password):
+		if re.search("[\\`'\"]",password):
 			log("[E] password contains one of the unsupported special characters like \" ' \ `","error")
 			sys.exit(1)
 

--- a/security-admin/scripts/changeusernameutil.py
+++ b/security-admin/scripts/changeusernameutil.py
@@ -53,7 +53,7 @@ def log(msg,type):
 def username_validation(username):
         if username:
                 if re.search("[\\`'\"]",username):
-                        log("[E] username contains one of the unsupported special characters like \" ' \ `","error")
+                        log("[E] username contains one of the unsupported special characters like \" ' \\ `","error")
                         sys.exit(1)
 
 

--- a/security-admin/scripts/changeusernameutil.py
+++ b/security-admin/scripts/changeusernameutil.py
@@ -52,7 +52,7 @@ def log(msg,type):
 
 def username_validation(username):
         if username:
-                if re.search("[\\\`'\"]",username):
+                if re.search("[\\`'\"]",username):
                         log("[E] username contains one of the unsupported special characters like \" ' \ `","error")
                         sys.exit(1)
 

--- a/security-admin/scripts/db_setup.py
+++ b/security-admin/scripts/db_setup.py
@@ -122,7 +122,7 @@ def jisql_log(query, db_password):
 
 def password_validation(password):
 	if password:
-		if re.search("[\\\`'\"]",password):
+		if re.search("[\\`'\"]",password):
 			log("[E] password contains one of the unsupported special characters like \" ' \ `","error")
 			sys.exit(1)
 

--- a/security-admin/scripts/db_setup.py
+++ b/security-admin/scripts/db_setup.py
@@ -123,7 +123,7 @@ def jisql_log(query, db_password):
 def password_validation(password):
 	if password:
 		if re.search("[\\`'\"]",password):
-			log("[E] password contains one of the unsupported special characters like \" ' \ `","error")
+			log("[E] password contains one of the unsupported special characters like \" ' \\ `","error")
 			sys.exit(1)
 
 def subprocessCallWithRetry(query):
@@ -857,14 +857,14 @@ class MysqlConf(BaseDB):
 		self.JAVA_BIN = self.JAVA_BIN.strip("'")
 		if is_unix:
 			if self.is_db_override_jdbc_connection_string == 'true' and self.db_override_jdbc_connection_string is not None and len(self.db_override_jdbc_connection_string) > 0:
-				jisql_cmd = "%s %s -cp %s:%s/jisql/lib/* org.apache.util.sql.Jisql -driver mysqlconj -cstring %s -u '%s' -p '%s' -noheader -trim -c \;" %(self.JAVA_BIN,db_ssl_cert_param,self.SQL_CONNECTOR_JAR,path,self.db_override_jdbc_connection_string,user,password)
+				jisql_cmd = "%s %s -cp %s:%s/jisql/lib/* org.apache.util.sql.Jisql -driver mysqlconj -cstring %s -u '%s' -p '%s' -noheader -trim -c \\;" %(self.JAVA_BIN,db_ssl_cert_param,self.SQL_CONNECTOR_JAR,path,self.db_override_jdbc_connection_string,user,password)
 			else:
-				jisql_cmd = "%s %s -cp %s:%s/jisql/lib/* org.apache.util.sql.Jisql -driver mysqlconj -cstring jdbc:mysql://%s/%s%s -u '%s' -p '%s' -noheader -trim -c \;" %(self.JAVA_BIN,db_ssl_cert_param,self.SQL_CONNECTOR_JAR,path,self.host,db_name,db_ssl_param,user,password)
+				jisql_cmd = "%s %s -cp %s:%s/jisql/lib/* org.apache.util.sql.Jisql -driver mysqlconj -cstring jdbc:mysql://%s/%s%s -u '%s' -p '%s' -noheader -trim -c \\;" %(self.JAVA_BIN,db_ssl_cert_param,self.SQL_CONNECTOR_JAR,path,self.host,db_name,db_ssl_param,user,password)
 		elif os_name == "WINDOWS":
 			if self.is_db_override_jdbc_connection_string == 'true' and self.db_override_jdbc_connection_string is not None and len(self.db_override_jdbc_connection_string) > 0:
-				jisql_cmd = "%s %s -cp %s;%s\jisql\\lib\\* org.apache.util.sql.Jisql -driver mysqlconj -cstring %s -u \"%s\" -p \"%s\" -noheader -trim" %(self.JAVA_BIN,db_ssl_cert_param,self.SQL_CONNECTOR_JAR, path, self.db_override_jdbc_connection_string,user, password)
+				jisql_cmd = "%s %s -cp %s;%s\\jisql\\lib\\* org.apache.util.sql.Jisql -driver mysqlconj -cstring %s -u \"%s\" -p \"%s\" -noheader -trim" %(self.JAVA_BIN,db_ssl_cert_param,self.SQL_CONNECTOR_JAR, path, self.db_override_jdbc_connection_string,user, password)
 			else:
-				jisql_cmd = "%s %s -cp %s;%s\jisql\\lib\\* org.apache.util.sql.Jisql -driver mysqlconj -cstring jdbc:mysql://%s/%s%s -u \"%s\" -p \"%s\" -noheader -trim" %(self.JAVA_BIN,db_ssl_cert_param,self.SQL_CONNECTOR_JAR, path, self.host, db_name, db_ssl_param,user, password)
+				jisql_cmd = "%s %s -cp %s;%s\\jisql\\lib\\* org.apache.util.sql.Jisql -driver mysqlconj -cstring jdbc:mysql://%s/%s%s -u \"%s\" -p \"%s\" -noheader -trim" %(self.JAVA_BIN,db_ssl_cert_param,self.SQL_CONNECTOR_JAR, path, self.host, db_name, db_ssl_param,user, password)
 		return jisql_cmd
 
 	def get_check_table_query(self, TABLE_NAME):
@@ -914,9 +914,9 @@ class OracleConf(BaseDB):
 				jisql_cmd = "%s -cp %s:%s/jisql/lib/* org.apache.util.sql.Jisql -driver oraclethin -cstring %s -u '%s' -p '%s' -noheader -trim" %(self.JAVA_BIN, self.SQL_CONNECTOR_JAR, path, cstring, user, password)
 		elif os_name == "WINDOWS":
 			if self.is_db_override_jdbc_connection_string == 'true' and self.db_override_jdbc_connection_string is not None and len(self.db_override_jdbc_connection_string) > 0:
-				jisql_cmd = "%s -cp %s;%s\jisql\\lib\\* org.apache.util.sql.Jisql -driver oraclethin -cstring %s -u \"%s\" -p \"%s\" -noheader -trim" %(self.JAVA_BIN, self.SQL_CONNECTOR_JAR, path, self.db_override_jdbc_connection_string, user, password)
+				jisql_cmd = "%s -cp %s;%s\\jisql\\lib\\* org.apache.util.sql.Jisql -driver oraclethin -cstring %s -u \"%s\" -p \"%s\" -noheader -trim" %(self.JAVA_BIN, self.SQL_CONNECTOR_JAR, path, self.db_override_jdbc_connection_string, user, password)
 			else:
-				jisql_cmd = "%s -cp %s;%s\jisql\\lib\\* org.apache.util.sql.Jisql -driver oraclethin -cstring %s -u \"%s\" -p \"%s\" -noheader -trim" %(self.JAVA_BIN, self.SQL_CONNECTOR_JAR, path, cstring, user, password)
+				jisql_cmd = "%s -cp %s;%s\\jisql\\lib\\* org.apache.util.sql.Jisql -driver oraclethin -cstring %s -u \"%s\" -p \"%s\" -noheader -trim" %(self.JAVA_BIN, self.SQL_CONNECTOR_JAR, path, cstring, user, password)
 		return jisql_cmd
 
 	def execute_file(self, file_name):
@@ -1000,14 +1000,14 @@ class PostgresConf(BaseDB):
 				db_ssl_param="?ssl=%s" %(self.db_ssl_enabled)
 		if is_unix:
 			if self.is_db_override_jdbc_connection_string == 'true' and self.db_override_jdbc_connection_string is not None and len(self.db_override_jdbc_connection_string) > 0:
-				jisql_cmd = "%s %s -cp %s:%s/jisql/lib/* org.apache.util.sql.Jisql -driver postgresql -cstring %s -u %s -p '%s' -noheader -trim -c \;" %(self.JAVA_BIN, db_ssl_cert_param,self.SQL_CONNECTOR_JAR,path, self.db_override_jdbc_connection_string, user, password)
+				jisql_cmd = "%s %s -cp %s:%s/jisql/lib/* org.apache.util.sql.Jisql -driver postgresql -cstring %s -u %s -p '%s' -noheader -trim -c \\;" %(self.JAVA_BIN, db_ssl_cert_param,self.SQL_CONNECTOR_JAR,path, self.db_override_jdbc_connection_string, user, password)
 			else:
-				jisql_cmd = "%s %s -cp %s:%s/jisql/lib/* org.apache.util.sql.Jisql -driver postgresql -cstring jdbc:postgresql://%s/%s%s -u %s -p '%s' -noheader -trim -c \;" %(self.JAVA_BIN, db_ssl_cert_param,self.SQL_CONNECTOR_JAR,path, self.host, db_name, db_ssl_param,user, password)
+				jisql_cmd = "%s %s -cp %s:%s/jisql/lib/* org.apache.util.sql.Jisql -driver postgresql -cstring jdbc:postgresql://%s/%s%s -u %s -p '%s' -noheader -trim -c \\;" %(self.JAVA_BIN, db_ssl_cert_param,self.SQL_CONNECTOR_JAR,path, self.host, db_name, db_ssl_param,user, password)
 		elif os_name == "WINDOWS":
 			if self.is_db_override_jdbc_connection_string == 'true' and self.db_override_jdbc_connection_string is not None and len(self.db_override_jdbc_connection_string) > 0:
-				jisql_cmd = "%s %s -cp %s;%s\jisql\\lib\\* org.apache.util.sql.Jisql -driver postgresql -cstring %s -u %s -p \"%s\" -noheader -trim" %(self.JAVA_BIN, db_ssl_cert_param,self.SQL_CONNECTOR_JAR, path, self.db_override_jdbc_connection_string,user, password)
+				jisql_cmd = "%s %s -cp %s;%s\\jisql\\lib\\* org.apache.util.sql.Jisql -driver postgresql -cstring %s -u %s -p \"%s\" -noheader -trim" %(self.JAVA_BIN, db_ssl_cert_param,self.SQL_CONNECTOR_JAR, path, self.db_override_jdbc_connection_string,user, password)
 			else:
-				jisql_cmd = "%s %s -cp %s;%s\jisql\\lib\\* org.apache.util.sql.Jisql -driver postgresql -cstring jdbc:postgresql://%s/%s%s -u %s -p \"%s\" -noheader -trim" %(self.JAVA_BIN, db_ssl_cert_param,self.SQL_CONNECTOR_JAR, path, self.host, db_name, db_ssl_param,user, password)
+				jisql_cmd = "%s %s -cp %s;%s\\jisql\\lib\\* org.apache.util.sql.Jisql -driver postgresql -cstring jdbc:postgresql://%s/%s%s -u %s -p \"%s\" -noheader -trim" %(self.JAVA_BIN, db_ssl_cert_param,self.SQL_CONNECTOR_JAR, path, self.host, db_name, db_ssl_param,user, password)
 		return jisql_cmd
 
 	def create_language_plpgsql(self,db_user, db_password, db_name):

--- a/security-admin/scripts/dba_script.py
+++ b/security-admin/scripts/dba_script.py
@@ -114,7 +114,7 @@ def logFile(msg):
 
 def password_validation(password, userType):
 	if password:
-		if re.search("[\\\`'\"]",password):
+		if re.search("[\\`'\"]",password):
 			log("[E] "+userType+" user password contains one of the unsupported special characters like \" ' \ `","error")
 			sys.exit(1)
 		else:

--- a/security-admin/scripts/dba_script.py
+++ b/security-admin/scripts/dba_script.py
@@ -115,7 +115,7 @@ def logFile(msg):
 def password_validation(password, userType):
 	if password:
 		if re.search("[\\`'\"]",password):
-			log("[E] "+userType+" user password contains one of the unsupported special characters like \" ' \ `","error")
+			log("[E] "+userType+" user password contains one of the unsupported special characters like \" ' \\ `","error")
 			sys.exit(1)
 		else:
 			log("[I] "+userType+" user password validated","info")
@@ -193,10 +193,10 @@ class MysqlConf(BaseDB):
 			if "useSSL" not in db_name:
 				db_ssl_param="?useSSL=false"
 		if is_unix:
-			jisql_cmd = "%s %s -cp %s:%s/jisql/lib/* org.apache.util.sql.Jisql -driver mysqlconj -cstring jdbc:mysql://%s/%s%s -u %s -p '%s' -noheader -trim -c \;" %(self.JAVA_BIN,db_ssl_cert_param,self.SQL_CONNECTOR_JAR,path,self.host,db_name,db_ssl_param,user,password)
+			jisql_cmd = "%s %s -cp %s:%s/jisql/lib/* org.apache.util.sql.Jisql -driver mysqlconj -cstring jdbc:mysql://%s/%s%s -u %s -p '%s' -noheader -trim -c \\;" %(self.JAVA_BIN,db_ssl_cert_param,self.SQL_CONNECTOR_JAR,path,self.host,db_name,db_ssl_param,user,password)
 		elif os_name == "WINDOWS":
 			self.JAVA_BIN = self.JAVA_BIN.strip("'")
-			jisql_cmd = "%s %s -cp %s;%s\jisql\\lib\\* org.apache.util.sql.Jisql -driver mysqlconj -cstring jdbc:mysql://%s/%s%s -u %s -p \"%s\" -noheader -trim" %(self.JAVA_BIN, db_ssl_cert_param,self.SQL_CONNECTOR_JAR, path, self.host, db_name,db_ssl_param,user, password)
+			jisql_cmd = "%s %s -cp %s;%s\\jisql\\lib\\* org.apache.util.sql.Jisql -driver mysqlconj -cstring jdbc:mysql://%s/%s%s -u %s -p \"%s\" -noheader -trim" %(self.JAVA_BIN, db_ssl_cert_param,self.SQL_CONNECTOR_JAR, path, self.host, db_name,db_ssl_param,user, password)
 		return jisql_cmd
 
 	def verify_user(self, root_user, db_root_password, host, db_user, get_cmd,dryMode):
@@ -418,14 +418,14 @@ class OracleConf(BaseDB):
 		if is_unix:
 			jisql_cmd = "%s -cp %s:%s/jisql/lib/* org.apache.util.sql.Jisql -driver oraclethin -cstring %s -u '%s' -p '%s' -noheader -trim" %(self.JAVA_BIN, self.SQL_CONNECTOR_JAR,path, cstring, user, password)
 		elif os_name == "WINDOWS":
-			jisql_cmd = "%s -cp %s;%s\jisql\\lib\\* org.apache.util.sql.Jisql -driver oraclethin -cstring %s -u \"%s\" -p \"%s\" -noheader -trim" %(self.JAVA_BIN, self.SQL_CONNECTOR_JAR, path, cstring, user, password)
+			jisql_cmd = "%s -cp %s;%s\\jisql\\lib\\* org.apache.util.sql.Jisql -driver oraclethin -cstring %s -u \"%s\" -p \"%s\" -noheader -trim" %(self.JAVA_BIN, self.SQL_CONNECTOR_JAR, path, cstring, user, password)
 		return jisql_cmd
 
 	def check_connection(self, db_name, db_user, db_password):
 		log("[I] Checking connection", "info")
 		get_cmd = self.get_jisql_cmd(db_user, db_password)
 		if is_unix:
-			query = get_cmd + " -c \; -query \"select * from v$version;\""
+			query = get_cmd + " -c \\; -query \"select * from v$version;\""
 		elif os_name == "WINDOWS":
 			query = get_cmd + " -query \"select * from v$version;\" -c ;"
 		jisql_log(query, db_password)
@@ -442,7 +442,7 @@ class OracleConf(BaseDB):
 			log("[I] Verifying user " + db_user ,"info")
 		get_cmd = self.get_jisql_cmd(root_user, db_root_password)		
 		if is_unix:
-			query = get_cmd + " -c \; -query \"select username from all_users where upper(username)=upper('%s');\"" %(db_user)
+			query = get_cmd + " -c \\; -query \"select username from all_users where upper(username)=upper('%s');\"" %(db_user)
 		elif os_name == "WINDOWS":
 			query = get_cmd + " -query \"select username from all_users where upper(username)=upper('%s');\" -c ;" %(db_user)
 		jisql_log(query, db_root_password)
@@ -462,8 +462,8 @@ class OracleConf(BaseDB):
 					log("[I] User does not exists, Creating user : " + db_user, "info")
 					get_cmd = self.get_jisql_cmd(root_user, db_root_password)
 					if is_unix:
-						query = get_cmd + " -c \; -query 'create user %s identified by \"%s\";'" %(db_user, db_password)
-						query_with_masked_pwd = get_cmd + " -c \; -query 'create user %s identified by \"%s\";'" %(db_user,masked_pwd_string)
+						query = get_cmd + " -c \\; -query 'create user %s identified by \"%s\";'" %(db_user, db_password)
+						query_with_masked_pwd = get_cmd + " -c \\; -query 'create user %s identified by \"%s\";'" %(db_user,masked_pwd_string)
 						jisql_log(query_with_masked_pwd, db_root_password)
 						ret = subprocessCallWithRetry(shlex.split(query))
 					elif os_name == "WINDOWS":
@@ -475,7 +475,7 @@ class OracleConf(BaseDB):
 						log("[I] User " + db_user + " created", "info")
 						log("[I] Granting permission to " + db_user, "info")
 						if is_unix:
-							query = get_cmd + " -c \; -query 'GRANT CREATE SESSION,CREATE PROCEDURE,CREATE TABLE,CREATE VIEW,CREATE SEQUENCE,CREATE SYNONYM,CREATE TRIGGER,UNLIMITED Tablespace TO %s;'" % (db_user)
+							query = get_cmd + " -c \\; -query 'GRANT CREATE SESSION,CREATE PROCEDURE,CREATE TABLE,CREATE VIEW,CREATE SEQUENCE,CREATE SYNONYM,CREATE TRIGGER,UNLIMITED Tablespace TO %s;'" % (db_user)
 							jisql_log(query, db_root_password)
 							ret = subprocessCallWithRetry(shlex.split(query))
 						elif os_name == "WINDOWS":
@@ -499,7 +499,7 @@ class OracleConf(BaseDB):
 			log("[I] Verifying tablespace " + db_name, "info")
 		get_cmd = self.get_jisql_cmd(root_user, db_root_password)		
 		if is_unix:
-			query = get_cmd + " -c \; -query \"SELECT DISTINCT UPPER(TABLESPACE_NAME) FROM USER_TablespaceS where UPPER(Tablespace_Name)=UPPER(\'%s\');\"" %(db_name)
+			query = get_cmd + " -c \\; -query \"SELECT DISTINCT UPPER(TABLESPACE_NAME) FROM USER_TablespaceS where UPPER(Tablespace_Name)=UPPER(\'%s\');\"" %(db_name)
 		elif os_name == "WINDOWS":
 			query = get_cmd + " -query \"SELECT DISTINCT UPPER(TABLESPACE_NAME) FROM USER_TablespaceS where UPPER(Tablespace_Name)=UPPER(\'%s\');\" -c ;" %(db_name)
 		jisql_log(query, db_root_password)
@@ -516,7 +516,7 @@ class OracleConf(BaseDB):
 				if self.verify_user(root_user, db_user, db_root_password,dryMode):
 					get_cmd = self.get_jisql_cmd(db_user ,db_password)
 					if is_unix:
-						query = get_cmd + " -c \; -query 'select default_tablespace from user_users;'"
+						query = get_cmd + " -c \\; -query 'select default_tablespace from user_users;'"
 					elif os_name == "WINDOWS":
 						query = get_cmd + " -query \"select default_tablespace from user_users;\" -c ;"
 					jisql_log(query, db_root_password)
@@ -534,7 +534,7 @@ class OracleConf(BaseDB):
 				log("[I] Tablespace does not exist. Creating tablespace: " + db_name,"info")
 				get_cmd = self.get_jisql_cmd(root_user, db_root_password)
 				if is_unix:
-					query = get_cmd + " -c \; -query \"create tablespace %s datafile '%s.dat' size 10M autoextend on;\"" %(db_name, db_name)
+					query = get_cmd + " -c \\; -query \"create tablespace %s datafile '%s.dat' size 10M autoextend on;\"" %(db_name, db_name)
 					jisql_log(query, db_root_password)
 					ret = subprocessCallWithRetry(shlex.split(query))
 				elif os_name == "WINDOWS":
@@ -558,7 +558,7 @@ class OracleConf(BaseDB):
 			# Assign default tablespace db_name
 			get_cmd = self.get_jisql_cmd(root_user , db_root_password)
 			if is_unix:
-				query = get_cmd +" -c \; -query 'alter user %s DEFAULT Tablespace %s;'" %(db_user, db_name)
+				query = get_cmd +" -c \\; -query 'alter user %s DEFAULT Tablespace %s;'" %(db_user, db_name)
 				jisql_log(query, db_root_password)
 				ret = subprocessCallWithRetry(shlex.split(query))
 			elif os_name == "WINDOWS":
@@ -586,7 +586,7 @@ class OracleConf(BaseDB):
 				log("[I] Tablespace does not exist. Creating tablespace: " + audit_db_name,"info")
 				get_cmd = self.get_jisql_cmd(audit_db_root_user, audit_db_root_password)
 				if is_unix:
-					query = get_cmd + " -c \; -query \"create tablespace %s datafile '%s.dat' size 10M autoextend on;\"" %(audit_db_name, audit_db_name)
+					query = get_cmd + " -c \\; -query \"create tablespace %s datafile '%s.dat' size 10M autoextend on;\"" %(audit_db_name, audit_db_name)
 					jisql_log(query, audit_db_root_password)
 					ret = subprocessCallWithRetry(shlex.split(query))
 				elif os_name == "WINDOWS":
@@ -608,7 +608,7 @@ class OracleConf(BaseDB):
 				# Assign default tablespace audit_db_name
 				get_cmd = self.get_jisql_cmd(audit_db_root_user , audit_db_root_password)
 				if is_unix:
-					query = get_cmd +" -c \; -query 'alter user %s DEFAULT Tablespace %s;'" %(audit_db_user, audit_db_name)
+					query = get_cmd +" -c \\; -query 'alter user %s DEFAULT Tablespace %s;'" %(audit_db_user, audit_db_name)
 					jisql_log(query, audit_db_root_password)
 					ret2 = subprocessCallWithRetry(shlex.split(query))
 				elif os_name == "WINDOWS":
@@ -627,7 +627,7 @@ class OracleConf(BaseDB):
 		if dryMode == False:
 			get_cmd = self.get_jisql_cmd(root_user ,db_root_password)
 			if is_unix:
-				query = get_cmd + " -c \; -query 'GRANT CREATE SESSION,CREATE PROCEDURE,CREATE TABLE,CREATE VIEW,CREATE SEQUENCE,CREATE SYNONYM,CREATE TRIGGER,UNLIMITED Tablespace TO %s;'" % (db_user)
+				query = get_cmd + " -c \\; -query 'GRANT CREATE SESSION,CREATE PROCEDURE,CREATE TABLE,CREATE VIEW,CREATE SEQUENCE,CREATE SYNONYM,CREATE TRIGGER,UNLIMITED Tablespace TO %s;'" % (db_user)
 				jisql_log(query, db_root_password)
 				ret = subprocessCallWithRetry(shlex.split(query))
 			elif os_name == "WINDOWS":
@@ -656,8 +656,8 @@ class OracleConf(BaseDB):
 					log("[I] User does not exists, Creating user " + db_user, "info")
 					get_cmd = self.get_jisql_cmd(audit_db_root_user, audit_db_root_password)
 					if is_unix:
-						query = get_cmd + " -c \; -query 'create user %s identified by \"%s\";'" %(db_user, db_password)
-						query_with_masked_pwd = get_cmd + " -c \; -query 'create user %s identified by \"%s\";'" %(db_user, masked_pwd_string)
+						query = get_cmd + " -c \\; -query 'create user %s identified by \"%s\";'" %(db_user, db_password)
+						query_with_masked_pwd = get_cmd + " -c \\; -query 'create user %s identified by \"%s\";'" %(db_user, masked_pwd_string)
 						jisql_log(query_with_masked_pwd, audit_db_root_password)
 						ret = subprocessCallWithRetry(shlex.split(query))
 					elif os_name == "WINDOWS":
@@ -681,8 +681,8 @@ class OracleConf(BaseDB):
 					log("[I] Audit user does not exists, Creating audit user " + audit_db_user, "info")
 					get_cmd = self.get_jisql_cmd(audit_db_root_user, audit_db_root_password)
 					if is_unix:
-						query = get_cmd + " -c \; -query 'create user %s identified by \"%s\";'" %(audit_db_user, audit_db_password)
-						query_with_masked_pwd = get_cmd + " -c \; -query 'create user %s identified by \"%s\";'" %(audit_db_user, masked_pwd_string)
+						query = get_cmd + " -c \\; -query 'create user %s identified by \"%s\";'" %(audit_db_user, audit_db_password)
+						query_with_masked_pwd = get_cmd + " -c \\; -query 'create user %s identified by \"%s\";'" %(audit_db_user, masked_pwd_string)
 						jisql_log(query_with_masked_pwd, audit_db_root_password)
 						ret = subprocessCallWithRetry(shlex.split(query))
 					elif os_name == "WINDOWS":
@@ -692,7 +692,7 @@ class OracleConf(BaseDB):
 						ret = subprocessCallWithRetry(query)
 					if self.verify_user(audit_db_root_user, audit_db_user, audit_db_root_password,dryMode):
 						if is_unix:
-							query = get_cmd + " -c \; -query \"GRANT CREATE SESSION TO %s;\"" %(audit_db_user)
+							query = get_cmd + " -c \\; -query \"GRANT CREATE SESSION TO %s;\"" %(audit_db_user)
 							jisql_log(query, audit_db_root_password)
 							ret = subprocessCallWithRetry(shlex.split(query))
 						elif os_name == "WINDOWS":
@@ -756,9 +756,9 @@ class PostgresConf(BaseDB):
 			else:
 				db_ssl_param="?ssl=%s&sslfactory=org.postgresql.ssl.NonValidatingFactory" %(self.db_ssl_enabled)
 		if is_unix:
-			jisql_cmd = "%s %s -cp %s:%s/jisql/lib/* org.apache.util.sql.Jisql -driver postgresql -cstring jdbc:postgresql://%s/%s%s -u %s -p '%s' -noheader -trim -c \;" %(self.JAVA_BIN, db_ssl_cert_param,self.SQL_CONNECTOR_JAR,path, self.host, db_name, db_ssl_param,user, password)
+			jisql_cmd = "%s %s -cp %s:%s/jisql/lib/* org.apache.util.sql.Jisql -driver postgresql -cstring jdbc:postgresql://%s/%s%s -u %s -p '%s' -noheader -trim -c \\;" %(self.JAVA_BIN, db_ssl_cert_param,self.SQL_CONNECTOR_JAR,path, self.host, db_name, db_ssl_param,user, password)
 		elif os_name == "WINDOWS":
-			jisql_cmd = "%s %s -cp %s;%s\jisql\\lib\\* org.apache.util.sql.Jisql -driver postgresql -cstring jdbc:postgresql://%s/%s%s -u %s -p \"%s\" -noheader -trim" %(self.JAVA_BIN, db_ssl_cert_param,self.SQL_CONNECTOR_JAR, path, self.host, db_name, db_ssl_param,user, password)
+			jisql_cmd = "%s %s -cp %s;%s\\jisql\\lib\\* org.apache.util.sql.Jisql -driver postgresql -cstring jdbc:postgresql://%s/%s%s -u %s -p \"%s\" -noheader -trim" %(self.JAVA_BIN, db_ssl_cert_param,self.SQL_CONNECTOR_JAR, path, self.host, db_name, db_ssl_param,user, password)
 		return jisql_cmd
 
 	def verify_user(self, root_user, db_root_password, db_user,dryMode):
@@ -1032,7 +1032,7 @@ class SqlServerConf(BaseDB):
 			log("[I] Verifying user " + db_user , "info")
 		get_cmd = self.get_jisql_cmd(root_user, db_root_password, 'master')
 		if is_unix:
-			query = get_cmd + " -c \; -query \"select name from sys.sql_logins where name = '%s';\"" %(db_user)
+			query = get_cmd + " -c \\; -query \"select name from sys.sql_logins where name = '%s';\"" %(db_user)
 		elif os_name == "WINDOWS":
 			query = get_cmd + " -query \"select name from sys.sql_logins where name = '%s';\" -c ;" %(db_user)
 		jisql_log(query, db_root_password)
@@ -1046,7 +1046,7 @@ class SqlServerConf(BaseDB):
 		log("[I] Checking connection", "info")
 		get_cmd = self.get_jisql_cmd(db_user, db_password, db_name)
 		if is_unix:
-			query = get_cmd + " -c \; -query \"SELECT 1;\""
+			query = get_cmd + " -c \\; -query \"SELECT 1;\""
 		elif os_name == "WINDOWS":
 			query = get_cmd + " -query \"SELECT 1;\" -c ;"
 		jisql_log(query, db_password)
@@ -1068,8 +1068,8 @@ class SqlServerConf(BaseDB):
 					get_cmd = self.get_jisql_cmd(root_user, db_root_password, 'master')
 					log("[I] User does not exists, Creating Login user " + db_user, "info")
 					if is_unix:
-						query = get_cmd + " -c \; -query \"CREATE LOGIN %s WITH PASSWORD = '%s';\"" %(db_user,db_password)
-						query_with_masked_pwd = get_cmd + " -c \; -query \"CREATE LOGIN %s WITH PASSWORD = '%s';\"" %(db_user,masked_pwd_string)
+						query = get_cmd + " -c \\; -query \"CREATE LOGIN %s WITH PASSWORD = '%s';\"" %(db_user,db_password)
+						query_with_masked_pwd = get_cmd + " -c \\; -query \"CREATE LOGIN %s WITH PASSWORD = '%s';\"" %(db_user,masked_pwd_string)
 						jisql_log(query_with_masked_pwd, db_root_password)
 						ret = subprocessCallWithRetry(shlex.split(query))
 					elif os_name == "WINDOWS":
@@ -1090,7 +1090,7 @@ class SqlServerConf(BaseDB):
 			log("[I] Verifying database " + db_name, "info")
 		get_cmd = self.get_jisql_cmd(root_user, db_root_password, 'master')
 		if is_unix:
-			query = get_cmd + " -c \; -query \"SELECT name from sys.databases where name='%s';\"" %(db_name)
+			query = get_cmd + " -c \\; -query \"SELECT name from sys.databases where name='%s';\"" %(db_name)
 		elif os_name == "WINDOWS":
 			query = get_cmd + " -query \"SELECT name from sys.databases where name='%s';\" -c ;" %(db_name)
 		jisql_log(query, db_root_password)
@@ -1109,7 +1109,7 @@ class SqlServerConf(BaseDB):
 				log("[I] Database does not exist. Creating database : " + db_name,"info")
 				get_cmd = self.get_jisql_cmd(root_user, db_root_password, 'master')
 				if is_unix:
-					query = get_cmd + " -c \; -query \"create database %s;\"" %(db_name)
+					query = get_cmd + " -c \\; -query \"create database %s;\"" %(db_name)
 					jisql_log(query, db_root_password)
 					ret = subprocessCallWithRetry(shlex.split(query))
 				elif os_name == "WINDOWS":
@@ -1129,7 +1129,7 @@ class SqlServerConf(BaseDB):
 	def create_user(self, root_user, db_name ,db_user, db_password, db_root_password,dryMode):
 		get_cmd = self.get_jisql_cmd(root_user, db_root_password, db_name)
 		if is_unix:
-			query = get_cmd + " -c \; -query \"SELECT name FROM sys.database_principals WHERE name = N'%s';\"" %(db_user)
+			query = get_cmd + " -c \\; -query \"SELECT name FROM sys.database_principals WHERE name = N'%s';\"" %(db_user)
 		elif os_name == "WINDOWS":
 			query = get_cmd + " -query \"SELECT name FROM sys.database_principals WHERE name = N'%s';\" -c ;" %(db_user)
 		jisql_log(query, db_root_password)
@@ -1140,7 +1140,7 @@ class SqlServerConf(BaseDB):
 		else:
 			if dryMode == False:
 				if is_unix:
-					query = get_cmd + " -c \; -query \"CREATE USER %s for LOGIN %s;\"" %(db_user, db_user)
+					query = get_cmd + " -c \\; -query \"CREATE USER %s for LOGIN %s;\"" %(db_user, db_user)
 					jisql_log(query, db_root_password)
 					ret = subprocessCallWithRetry(shlex.split(query))
 				elif os_name == "WINDOWS":
@@ -1148,7 +1148,7 @@ class SqlServerConf(BaseDB):
 					jisql_log(query, db_root_password)
 					ret = subprocessCallWithRetry(query)
 				if is_unix:
-					query = get_cmd + " -c \; -query \"SELECT name FROM sys.database_principals WHERE name = N'%s';\"" %(db_user)
+					query = get_cmd + " -c \\; -query \"SELECT name FROM sys.database_principals WHERE name = N'%s';\"" %(db_user)
 				elif os_name == "WINDOWS":
 					query = get_cmd + " -query \"SELECT name FROM sys.database_principals WHERE name = N'%s';\" -c ;" %(db_user)
 				jisql_log(query, db_root_password)
@@ -1166,7 +1166,7 @@ class SqlServerConf(BaseDB):
 			log("[I] Granting permission to admin user '" + db_user + "' on db '" + db_name + "'" , "info")
 			get_cmd = self.get_jisql_cmd(root_user, db_root_password, db_name)
 			if is_unix:
-				query = get_cmd + " -c \; -query \" EXEC sp_addrolemember N'db_owner', N'%s';\"" %(db_user)
+				query = get_cmd + " -c \\; -query \" EXEC sp_addrolemember N'db_owner', N'%s';\"" %(db_user)
 				jisql_log(query, db_root_password)
 				ret = subprocessCallWithRetry(shlex.split(query))
 			elif os_name == "WINDOWS":
@@ -1240,7 +1240,7 @@ class SqlAnywhereConf(BaseDB):
 			log("[I] Verifying user " + db_user , "info")
 		get_cmd = self.get_jisql_cmd(root_user, db_root_password, '')
 		if is_unix:
-			query = get_cmd + " -c \; -query \"select name from syslogins where name = '%s';\"" %(db_user)
+			query = get_cmd + " -c \\; -query \"select name from syslogins where name = '%s';\"" %(db_user)
 		elif os_name == "WINDOWS":
 			query = get_cmd + " -query \"select name from syslogins where name = '%s';\" -c ;" %(db_user)
 		jisql_log(query, db_root_password)
@@ -1254,7 +1254,7 @@ class SqlAnywhereConf(BaseDB):
 		log("[I] Checking connection", "info")
 		get_cmd = self.get_jisql_cmd(db_user, db_password, db_name)
 		if is_unix:
-			query = get_cmd + " -c \; -query \"SELECT 1;\""
+			query = get_cmd + " -c \\; -query \"SELECT 1;\""
 		elif os_name == "WINDOWS":
 			query = get_cmd + " -query \"SELECT 1;\" -c ;"
 		jisql_log(query, db_password)
@@ -1276,8 +1276,8 @@ class SqlAnywhereConf(BaseDB):
 					get_cmd = self.get_jisql_cmd(root_user, db_root_password, '')
 					log("[I] User does not exists, Creating Login user " + db_user, "info")
 					if is_unix:
-						query = get_cmd + " -c \; -query \"CREATE USER %s IDENTIFIED BY '%s';\"" %(db_user,db_password)
-						query_with_masked_pwd = get_cmd + " -c \; -query \"CREATE USER %s IDENTIFIED BY '%s';\"" %(db_user,masked_pwd_string)
+						query = get_cmd + " -c \\; -query \"CREATE USER %s IDENTIFIED BY '%s';\"" %(db_user,db_password)
+						query_with_masked_pwd = get_cmd + " -c \\; -query \"CREATE USER %s IDENTIFIED BY '%s';\"" %(db_user,masked_pwd_string)
 						jisql_log(query_with_masked_pwd, db_root_password)
 						ret = subprocessCallWithRetry(shlex.split(query))
 					elif os_name == "WINDOWS":
@@ -1298,7 +1298,7 @@ class SqlAnywhereConf(BaseDB):
 			log("[I] Starting database " + db_name, "info")
 		get_cmd = self.get_jisql_cmd(root_user, db_root_password, '')
 		if is_unix:
-			query = get_cmd + " -c \; -query \"start database '%s' autostop off;\"" %(db_name)
+			query = get_cmd + " -c \\; -query \"start database '%s' autostop off;\"" %(db_name)
 		elif os_name == "WINDOWS":
 			query = get_cmd + " -query \"start database '%s' autostop off;\" -c ;" %(db_name)
 		jisql_log(query, db_root_password)
@@ -1309,7 +1309,7 @@ class SqlAnywhereConf(BaseDB):
 			log("[I] Verifying database " + db_name, "info")
 		get_cmd = self.get_jisql_cmd(root_user, db_root_password, '')
 		if is_unix:
-			query = get_cmd + " -c \; -query \"select alias from sa_db_info() where alias='%s';\"" %(db_name)
+			query = get_cmd + " -c \\; -query \"select alias from sa_db_info() where alias='%s';\"" %(db_name)
 		elif os_name == "WINDOWS":
 			query = get_cmd + " -query \"select alias from sa_db_info() where alias='%s';\" -c ;" %(db_name)
 		jisql_log(query, db_root_password)
@@ -1328,8 +1328,8 @@ class SqlAnywhereConf(BaseDB):
 				log("[I] Database does not exist. Creating database : " + db_name,"info")
 				get_cmd = self.get_jisql_cmd(root_user, db_root_password, '')
 				if is_unix:
-					query = get_cmd + " -c \; -query \"create database '%s' dba user '%s' dba password '%s' database size 100MB;\"" %(db_name,db_user, db_password)
-					query_with_masked_pwd = get_cmd + " -c \; -query \"create database '%s' dba user '%s' dba password '%s' database size 100MB;\"" %(db_name,db_user, masked_pwd_string)
+					query = get_cmd + " -c \\; -query \"create database '%s' dba user '%s' dba password '%s' database size 100MB;\"" %(db_name,db_user, db_password)
+					query_with_masked_pwd = get_cmd + " -c \\; -query \"create database '%s' dba user '%s' dba password '%s' database size 100MB;\"" %(db_name,db_user, masked_pwd_string)
 					jisql_log(query_with_masked_pwd, db_root_password)
 					ret = subprocessCallWithRetry(shlex.split(query))
 				elif os_name == "WINDOWS":
@@ -1351,7 +1351,7 @@ class SqlAnywhereConf(BaseDB):
 	def create_user(self, root_user, db_name ,db_user, db_password, db_root_password,dryMode):
 		get_cmd = self.get_jisql_cmd(root_user, db_root_password, '')
 		if is_unix:
-			query = get_cmd + " -c \; -query \"select name from syslogins where name ='%s';\"" %(db_user)
+			query = get_cmd + " -c \\; -query \"select name from syslogins where name ='%s';\"" %(db_user)
 		elif os_name == "WINDOWS":
 			query = get_cmd + " -query \"select name from syslogins where name ='%s';\" -c ;" %(db_user)
 		jisql_log(query, db_root_password)
@@ -1362,8 +1362,8 @@ class SqlAnywhereConf(BaseDB):
 		else:
 			if dryMode == False:
 				if is_unix:
-					query = get_cmd + " -c \; -query \"CREATE USER %s IDENTIFIED BY '%s';\"" %(db_user, db_password)
-					query_with_masked_pwd = get_cmd + " -c \; -query \"CREATE USER %s IDENTIFIED BY '%s';\"" %(db_user, masked_pwd_string)
+					query = get_cmd + " -c \\; -query \"CREATE USER %s IDENTIFIED BY '%s';\"" %(db_user, db_password)
+					query_with_masked_pwd = get_cmd + " -c \\; -query \"CREATE USER %s IDENTIFIED BY '%s';\"" %(db_user, masked_pwd_string)
 					jisql_log(query_with_masked_pwd, db_root_password)
 					ret = subprocessCallWithRetry(shlex.split(query))
 				elif os_name == "WINDOWS":
@@ -1372,7 +1372,7 @@ class SqlAnywhereConf(BaseDB):
 					jisql_log(query_with_masked_pwd, db_root_password)
 					ret = subprocessCallWithRetry(query)
 				if is_unix:
-					query = get_cmd + " -c \; -query \"select name from syslogins where name ='%s';\"" %(db_user)
+					query = get_cmd + " -c \\; -query \"select name from syslogins where name ='%s';\"" %(db_user)
 				elif os_name == "WINDOWS":
 					query = get_cmd + " -query \"select name from syslogins where name ='%s';\" -c ;" %(db_user)
 				jisql_log(query, db_root_password)
@@ -1390,8 +1390,8 @@ class SqlAnywhereConf(BaseDB):
 			log("[I] Granting permission to user '" + db_user + "' on db '" + db_name + "'" , "info")
 			get_cmd = self.get_jisql_cmd(root_user, db_root_password, db_name)
 			if is_unix:
-				query = get_cmd + " -c \; -query \" GRANT CONNECT to %s IDENTIFIED BY '%s';\"" %(db_user,db_password)
-				query_with_masked_pwd = get_cmd + " -c \; -query \" GRANT CONNECT to %s IDENTIFIED BY '%s';\"" %(db_user,masked_pwd_string)
+				query = get_cmd + " -c \\; -query \" GRANT CONNECT to %s IDENTIFIED BY '%s';\"" %(db_user,db_password)
+				query_with_masked_pwd = get_cmd + " -c \\; -query \" GRANT CONNECT to %s IDENTIFIED BY '%s';\"" %(db_user,masked_pwd_string)
 				jisql_log(query_with_masked_pwd, db_root_password)
 				ret = subprocessCallWithRetry(shlex.split(query))
 			elif os_name == "WINDOWS":

--- a/security-admin/scripts/restrict_permissions.py
+++ b/security-admin/scripts/restrict_permissions.py
@@ -111,10 +111,10 @@ class MysqlConf(BaseDB):
 	def get_jisql_cmd(self, user, password ,db_name):
 		path = os.getcwd()
 		if os_name == "LINUX":
-			jisql_cmd = "%s -cp %s:jisql/lib/* org.apache.util.sql.Jisql -driver mysqlconj -cstring jdbc:mysql://%s/%s -u %s -p %s -noheader -trim -c \;" %(self.JAVA_BIN, self.SQL_CONNECTOR_JAR, self.host, db_name, user, password)
+			jisql_cmd = "%s -cp %s:jisql/lib/* org.apache.util.sql.Jisql -driver mysqlconj -cstring jdbc:mysql://%s/%s -u %s -p %s -noheader -trim -c \\;" %(self.JAVA_BIN, self.SQL_CONNECTOR_JAR, self.host, db_name, user, password)
 		elif os_name == "WINDOWS":
 			self.JAVA_BIN = self.JAVA_BIN.strip("'")
-			jisql_cmd = "%s -cp %s;%s\jisql\\lib\\* org.apache.util.sql.Jisql -driver mysqlconj -cstring jdbc:mysql://%s/%s -u %s -p %s -noheader -trim" %(self.JAVA_BIN, self.SQL_CONNECTOR_JAR, path, self.host, db_name, user, password)
+			jisql_cmd = "%s -cp %s;%s\\jisql\\lib\\* org.apache.util.sql.Jisql -driver mysqlconj -cstring jdbc:mysql://%s/%s -u %s -p %s -noheader -trim" %(self.JAVA_BIN, self.SQL_CONNECTOR_JAR, path, self.host, db_name, user, password)
 		return jisql_cmd
 		
 	def verify_user(self, root_user, db_root_password, host, db_user, get_cmd,dryMode):

--- a/security-admin/scripts/updateUserAndGroupNamesInJson.py
+++ b/security-admin/scripts/updateUserAndGroupNamesInJson.py
@@ -52,7 +52,7 @@ def log(msg,type):
 
 def username_validation(username):
 	if username:
-		if re.search("[\\\`'\"]",username):
+		if re.search("[\\`'\"]",username):
 			log("[E] username contains one of the unsupported special characters like \" ' \ `","error")
 			sys.exit(1)
 

--- a/security-admin/scripts/updateUserAndGroupNamesInJson.py
+++ b/security-admin/scripts/updateUserAndGroupNamesInJson.py
@@ -53,7 +53,7 @@ def log(msg,type):
 def username_validation(username):
 	if username:
 		if re.search("[\\`'\"]",username):
-			log("[E] username contains one of the unsupported special characters like \" ' \ `","error")
+			log("[E] username contains one of the unsupported special characters like \" ' \\ `","error")
 			sys.exit(1)
 
 def main(argv):

--- a/security-admin/scripts/upgrade_admin.py
+++ b/security-admin/scripts/upgrade_admin.py
@@ -15,10 +15,7 @@
 # limitations under the License.
 from __future__ import print_function
 from io import StringIO
-try:
-	from ConfigParser import ConfigParser
-except ImportError:
-	from configparser import ConfigParser
+from configparser import ConfigParser
 import xml.etree.ElementTree as ET
 import os,sys,getopt
 from os import listdir

--- a/security-admin/scripts/upgrade_admin.py
+++ b/security-admin/scripts/upgrade_admin.py
@@ -145,7 +145,7 @@ def getPropertiesConfigMap(configFileName):
 	config.seek(0,os.SEEK_SET)
 	fcp = ConfigParser()
 	fcp.optionxform = str
-	fcp.readfp(config)
+	fcp.read_file(config)
 	for k,v in fcp.items('dummysection'):
 		ret[k] = v
 	return ret
@@ -158,7 +158,7 @@ def getPropertiesKeyList(configFileName):
 	config.seek(0,os.SEEK_SET)
 	fcp = ConfigParser()
 	fcp.optionxform = str
-	fcp.readfp(config)
+	fcp.read_file(config)
 	for k,v in fcp.items('dummysection'):
 		ret.append(k)
 	return ret

--- a/security-admin/scripts/upgrade_admin.py
+++ b/security-admin/scripts/upgrade_admin.py
@@ -14,10 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from __future__ import print_function
-try:
-	from StringIO import StringIO
-except ImportError:
-	from io import StringIO
+from io import StringIO
 try:
 	from ConfigParser import ConfigParser
 except ImportError:

--- a/security-admin/src/bin/ranger_install.py
+++ b/security-admin/src/bin/ranger_install.py
@@ -53,7 +53,7 @@ def log(msg,type):
 def password_validation(password, userType):
 	if password:
 		if re.search("[\\`'\"]",password):
-			log("[E] "+userType+" user password contains one of the unsupported special characters like \" ' \ `","error")
+			log("[E] "+userType+" user password contains one of the unsupported special characters like \" ' \\ `","error")
 			sys.exit(1)
 		else:
 			log("[I] "+userType+" user password validated","info")

--- a/security-admin/src/bin/ranger_install.py
+++ b/security-admin/src/bin/ranger_install.py
@@ -16,10 +16,7 @@ import sys
 import errno
 import logging
 import zipfile
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
+from io import StringIO
 try:
     from ConfigParser import ConfigParser
 except ImportError:

--- a/security-admin/src/bin/ranger_install.py
+++ b/security-admin/src/bin/ranger_install.py
@@ -52,7 +52,7 @@ def log(msg,type):
 
 def password_validation(password, userType):
 	if password:
-		if re.search("[\\\`'\"]",password):
+		if re.search("[\\`'\"]",password):
 			log("[E] "+userType+" user password contains one of the unsupported special characters like \" ' \ `","error")
 			sys.exit(1)
 		else:

--- a/security-admin/src/bin/ranger_install.py
+++ b/security-admin/src/bin/ranger_install.py
@@ -17,10 +17,7 @@ import errno
 import logging
 import zipfile
 from io import StringIO
-try:
-    from ConfigParser import ConfigParser
-except ImportError:
-    from configparser import ConfigParser
+from configparser import ConfigParser
 import subprocess
 import fileinput
 import zipfile

--- a/tagsync/scripts/setup.py
+++ b/tagsync/scripts/setup.py
@@ -155,7 +155,7 @@ def getPropertiesConfigMap(configFileName):
     config.seek(0,os.SEEK_SET)
     fcp = ConfigParser()
     fcp.optionxform = str
-    fcp.readfp(config)
+    fcp.read_file(config)
     for k,v in fcp.items('dummysection'):
         ret[k] = v
     return ret
@@ -168,7 +168,7 @@ def getPropertiesKeyList(configFileName):
     config.seek(0,os.SEEK_SET)
     fcp = ConfigParser()
     fcp.optionxform = str
-    fcp.readfp(config)
+    fcp.read_file(config)
     for k,v in fcp.items('dummysection'):
         ret.append(k)
     return ret

--- a/tagsync/scripts/setup.py
+++ b/tagsync/scripts/setup.py
@@ -15,10 +15,7 @@
 # limitations under the License.
 
 from io import StringIO
-try:
-	from ConfigParser import ConfigParser
-except ImportError:
-	from configparser import ConfigParser
+from configparser import ConfigParser
 try:
 	from urlparse import urlparse
 except ImportError:

--- a/tagsync/scripts/setup.py
+++ b/tagsync/scripts/setup.py
@@ -16,10 +16,7 @@
 
 from io import StringIO
 from configparser import ConfigParser
-try:
-	from urlparse import urlparse
-except ImportError:
-	from urllib.parse import urlparse
+from urllib.parse import urlparse
 import re
 import xml.etree.ElementTree as ET
 import os,errno,sys,getopt

--- a/tagsync/scripts/setup.py
+++ b/tagsync/scripts/setup.py
@@ -14,10 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-try:
-	from StringIO import StringIO
-except ImportError:
-	from io import StringIO
+from io import StringIO
 try:
 	from ConfigParser import ConfigParser
 except ImportError:

--- a/unixauthservice/scripts/setup.py
+++ b/unixauthservice/scripts/setup.py
@@ -224,7 +224,7 @@ def updatePropertyInJCKSFile(jcksFileName, propName, value):
 def password_validation(password, userType):
     if password:
         if re.search("[\\`'\"]", password):
-            print("[E] " + userType + " property contains one of the unsupported special characters like \" ' \ `")
+            print("[E] " + userType + " property contains one of the unsupported special characters like \" ' \\ `")
             sys.exit(1)
         else:
             print("[I] " + userType + " property is verified.")

--- a/unixauthservice/scripts/setup.py
+++ b/unixauthservice/scripts/setup.py
@@ -223,7 +223,7 @@ def updatePropertyInJCKSFile(jcksFileName, propName, value):
 
 def password_validation(password, userType):
     if password:
-        if re.search("[\\\`'\"]", password):
+        if re.search("[\\`'\"]", password):
             print("[E] " + userType + " property contains one of the unsupported special characters like \" ' \ `")
             sys.exit(1)
         else:

--- a/unixauthservice/scripts/setup.py
+++ b/unixauthservice/scripts/setup.py
@@ -172,7 +172,7 @@ def getPropertiesConfigMap(configFileName):
     config.seek(0, os.SEEK_SET)
     fcp = ConfigParser()
     fcp.optionxform = str
-    fcp.readfp(config)
+    fcp.read_file(config)
     for k, v in fcp.items('dummysection'):
         ret[k] = v
     return ret
@@ -186,7 +186,7 @@ def getPropertiesKeyList(configFileName):
     config.seek(0, os.SEEK_SET)
     fcp = ConfigParser()
     fcp.optionxform = str
-    fcp.readfp(config)
+    fcp.read_file(config)
     for k, v in fcp.items('dummysection'):
         ret.append(k)
     return ret

--- a/unixauthservice/scripts/setup.py
+++ b/unixauthservice/scripts/setup.py
@@ -15,10 +15,7 @@
 # limitations under the License.
 
 
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
+from io import StringIO
 try:
     from ConfigParser import ConfigParser
 except ImportError:

--- a/unixauthservice/scripts/setup.py
+++ b/unixauthservice/scripts/setup.py
@@ -16,10 +16,7 @@
 
 
 from io import StringIO
-try:
-    from ConfigParser import ConfigParser
-except ImportError:
-    from configparser import ConfigParser
+from configparser import ConfigParser
 try:
     import commands as commands
 except ImportError:

--- a/unixauthservice/scripts/setup.py
+++ b/unixauthservice/scripts/setup.py
@@ -17,10 +17,7 @@
 
 from io import StringIO
 from configparser import ConfigParser
-try:
-    import commands as commands
-except ImportError:
-    import subprocess as commands
+import subprocess
 
 import re
 import xml.etree.ElementTree as ET
@@ -283,7 +280,7 @@ def convertInstallPropsToXML(props):
 
 def createUser(username, groupname):
     checkuser = "grep ^" + username + ": /etc/passwd | awk -F: '{print $1}'|head -1 "
-    (status, output) = commands.getstatusoutput(checkuser)
+    (status, output) = subprocess.getstatusoutput(checkuser)
     if len(output) < 1:
         cmd = "useradd -g %s %s -m" % (groupname, username)
         ret = os.system(cmd)
@@ -300,7 +297,7 @@ def createUser(username, groupname):
 
 def createGroup(groupname):
     checkgroup = "egrep ^" + groupname + ": /etc/group | awk -F: '{print $1}'|head -1 "
-    (status, output) = commands.getstatusoutput(checkgroup)
+    (status, output) = subprocess.getstatusoutput(checkgroup)
     if len(output) < 1:
         cmd = "groupadd %s" % (groupname)
         ret = os.system(cmd)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Now that Python 3 is a requirement, we can remove some compatibility with Python 2, replace obsolete function calls and fix escape sequences that Python 3 treats as invalid.

This is not a comprehensive review of all Python scripts! Just the things that we noticed while having to adjust to a version of Python that's even newer than the 3.8 given as the minimum required version.

## How was this patch tested?

Some of those changes are running in production on our deployments.