### PR TITLE
RANGER-5151: fix for error while writing audit logs to HDFS

### DIFF
--- a/agents-audit/src/main/java/org/apache/ranger/audit/utils/AbstractRangerAuditWriter.java
+++ b/agents-audit/src/main/java/org/apache/ranger/audit/utils/AbstractRangerAuditWriter.java
@@ -269,26 +269,10 @@ public abstract class AbstractRangerAuditWriter implements RangerAuditWriter {
 
             closeWriter();
             resetWriter();
+            setNextRollOverTime();
 
             currentFileName  = null;
             reUseLastLogFile = false;
-
-            if (!rollOverByDuration) {
-                try {
-                    if (StringUtils.isEmpty(rolloverPeriod)) {
-                        rolloverPeriod = rollingTimeUtil.convertRolloverSecondsToRolloverPeriod(fileRolloverSec);
-                    }
-
-                    nextRollOverTime = rollingTimeUtil.computeNextRollingTime(rolloverPeriod);
-                } catch (Exception e) {
-                    logger.warn("Rollover by file.rollover.period failed", e);
-                    logger.warn("Using the file.rollover.sec for {} audit file rollover...", fileSystemScheme);
-
-                    nextRollOverTime = rollOverByDuration();
-                }
-            } else {
-                nextRollOverTime = rollOverByDuration();
-            }
         }
 
         logger.debug("<== AbstractRangerAuditWriter.closeFileIfNeeded()");
@@ -307,7 +291,7 @@ public abstract class AbstractRangerAuditWriter implements RangerAuditWriter {
             boolean appendMode = false;
 
             // if append is supported, reuse last log file
-            if (reUseLastLogFile && fileSystem.hasPathCapability(auditPath, CommonPathCapabilities.FS_APPEND)) {
+            if (reUseLastLogFile && isAppendEnabled()) {
                 logger.info("Appending to last log file. auditPath = {}", fullPath);
 
                 try {
@@ -393,5 +377,34 @@ public abstract class AbstractRangerAuditWriter implements RangerAuditWriter {
 
     public void setFileExtension(String fileExtension) {
         this.fileExtension = fileExtension;
+    }
+
+    private void setNextRollOverTime() {
+        if (!rollOverByDuration) {
+            try {
+                if (StringUtils.isEmpty(rolloverPeriod)) {
+                    rolloverPeriod = rollingTimeUtil.convertRolloverSecondsToRolloverPeriod(fileRolloverSec);
+                }
+
+                nextRollOverTime = rollingTimeUtil.computeNextRollingTime(rolloverPeriod);
+            } catch (Exception e) {
+                logger.warn("Rollover by file.rollover.period failed", e);
+                logger.warn("Using the file.rollover.sec for {} audit file rollover...", fileSystemScheme);
+
+                nextRollOverTime = rollOverByDuration();
+            }
+        } else {
+            nextRollOverTime = rollOverByDuration();
+        }
+    }
+
+    private boolean isAppendEnabled() {
+        try {
+            return fileSystem.hasPathCapability(auditPath, CommonPathCapabilities.FS_APPEND);
+        } catch (Throwable t) {
+            logger.warn("Failed to check if audit log file {} can be appended. Will create a new file.", auditPath, t);
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Updated to call `closeFileIfNeeded()` only from `getLogFileStream()`, to avoid one thread closing the file which is being written by another thread.

## How was this patch tested?

Configured plugin to rollover audit log every 3 minutes, generated audits for a long duration and verified that the errors reported in the JIRA are no more seen.

```
  xasecure.audit.destination.hdfs.file.rollover.enable.periodic.rollover=true
  xasecure.audit.destination.hdfs.file.rollover.periodic.rollover.check.sec=180
  xasecure.audit.destination.hdfs.file.rollover.period=3m
```