### PR TITLE
RANGER-5153: fix for intermittent unit test failure in RangerJSONAuditWriterTest

### DIFF
--- a/agents-audit/src/main/java/org/apache/ranger/audit/utils/AbstractRangerAuditWriter.java
+++ b/agents-audit/src/main/java/org/apache/ranger/audit/utils/AbstractRangerAuditWriter.java
@@ -56,7 +56,6 @@ public abstract class AbstractRangerAuditWriter implements RangerAuditWriter {
     public FileSystem          fileSystem;
     public Map<String, String> auditConfigs;
     public Path                auditPath;
-    public PrintWriter         logWriter;
     public RollingTimeUtil     rollingTimeUtil;
     public String              auditProviderName;
     public String              fullPath;
@@ -71,6 +70,7 @@ public abstract class AbstractRangerAuditWriter implements RangerAuditWriter {
     public int                 fileRolloverSec = 24 * 60 * 60; // In seconds
     public boolean             rollOverByDuration;
 
+    public volatile PrintWriter         logWriter;
     public volatile FSDataOutputStream  ostream;   // output stream wrapped in logWriter
 
     protected boolean reUseLastLogFile;

--- a/agents-audit/src/main/java/org/apache/ranger/audit/utils/RangerJSONAuditWriter.java
+++ b/agents-audit/src/main/java/org/apache/ranger/audit/utils/RangerJSONAuditWriter.java
@@ -19,6 +19,7 @@ package org.apache.ranger.audit.utils;
  * under the License.
  */
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.ranger.audit.provider.MiscUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -94,17 +95,23 @@ public class RangerJSONAuditWriter extends AbstractRangerAuditWriter {
             logger.debug("UGI = {}, will write to HDFS file = {}", MiscUtil.getUGILoginUser(), currentFileName);
 
             out = MiscUtil.executePrivilegedAction((PrivilegedExceptionAction<PrintWriter>) () -> {
-                PrintWriter out1 = getLogFileStream();
+                PrintWriter out1 = null;
 
-                for (String event : events) {
-                    out1.println(event);
+                if (CollectionUtils.isEmpty(events)) {
+                    closeFileIfNeeded();
+                } else {
+                    out1 = getLogFileStream();
+
+                    for (String event : events) {
+                        out1.println(event);
+                    }
                 }
 
                 return out1;
             });
 
             // flush and check the stream for errors
-            if (out.checkError()) {
+            if (out != null && out.checkError()) {
                 // In theory, this count may NOT be accurate as part of the messages may have been successfully written.
                 // However, in practice, since client does buffering, either all or none would succeed.
                 logger.error("Stream encountered errors while writing audits to HDFS!");


### PR DESCRIPTION
## What changes were proposed in this pull request?

The test checks for null value for AbstractRangerAuditWriter.logWriter in the main test thread. This member is updated in antoher thread that periodically looks to close the audit file. AbstractRangerAuditWriter.logWriter is now made vollatile so that updated value is visible in the main test thread.

## How was this patch tested?

Build with unit tests completed successfully.