### PR TITLE
RANGER-5166: Expose ports for all databases in docker compose

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -128,7 +128,7 @@ jobs:
           docker compose -f docker-compose.ranger-base.yml build
           export DOCKER_BUILDKIT=1
           export COMPOSE_DOCKER_CLI_BUILD=1
-          export RANGER_DB_TYPE=postgres
+          export RANGER_DB_TYPE=sqlserver
           docker compose \
           -f docker-compose.ranger-${RANGER_DB_TYPE}.yml \
           -f docker-compose.ranger.yml \
@@ -146,7 +146,7 @@ jobs:
         run: |
           cd dev-support/ranger-docker
           ./scripts/ozone-plugin-docker-setup.sh
-          export RANGER_DB_TYPE=postgres
+          export RANGER_DB_TYPE=sqlserver
           docker compose \
           -f docker-compose.ranger-${RANGER_DB_TYPE}.yml \
           -f docker-compose.ranger.yml \
@@ -173,6 +173,10 @@ jobs:
                   echo "Container $container is NOT running!";
               fi
           done
+
+          nc -zv 127.0.0.1 1433
+
+          echo $?
           
           if [[ $flag == true ]]; then
               echo "All required containers are up and running";

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -128,7 +128,7 @@ jobs:
           docker compose -f docker-compose.ranger-base.yml build
           export DOCKER_BUILDKIT=1
           export COMPOSE_DOCKER_CLI_BUILD=1
-          export RANGER_DB_TYPE=sqlserver
+          export RANGER_DB_TYPE=postgres
           docker compose \
           -f docker-compose.ranger-${RANGER_DB_TYPE}.yml \
           -f docker-compose.ranger.yml \
@@ -146,7 +146,7 @@ jobs:
         run: |
           cd dev-support/ranger-docker
           ./scripts/ozone-plugin-docker-setup.sh
-          export RANGER_DB_TYPE=sqlserver
+          export RANGER_DB_TYPE=postgres
           docker compose \
           -f docker-compose.ranger-${RANGER_DB_TYPE}.yml \
           -f docker-compose.ranger.yml \
@@ -173,10 +173,6 @@ jobs:
                   echo "Container $container is NOT running!";
               fi
           done
-
-          nc -zv 127.0.0.1 1433
-
-          echo $?
           
           if [[ $flag == true ]]; then
               echo "All required containers are up and running";

--- a/dev-support/ranger-docker/docker-compose.ranger-mysql.yml
+++ b/dev-support/ranger-docker/docker-compose.ranger-mysql.yml
@@ -9,6 +9,8 @@ services:
     command: --default-authentication-plugin=mysql_native_password
     container_name: ranger-mysql
     hostname: ranger-db.example.com
+    ports:
+      - "3306:3306"
     networks:
       - ranger
     healthcheck:

--- a/dev-support/ranger-docker/docker-compose.ranger-oracle.yml
+++ b/dev-support/ranger-docker/docker-compose.ranger-oracle.yml
@@ -8,6 +8,8 @@ services:
     image: ranger-oracle
     container_name: ranger-oracle
     hostname: ranger-db.example.com
+    ports:
+      - "1521:1521"
     networks:
       - ranger
     healthcheck:

--- a/dev-support/ranger-docker/docker-compose.ranger-postgres-mounted.yml
+++ b/dev-support/ranger-docker/docker-compose.ranger-postgres-mounted.yml
@@ -8,6 +8,8 @@ services:
     image: ranger-postgres
     container_name: ranger-postgres
     hostname: ranger-db.example.com
+    ports:
+      - "5432:5432"
     networks:
       - ranger
     volumes:

--- a/dev-support/ranger-docker/docker-compose.ranger-postgres.yml
+++ b/dev-support/ranger-docker/docker-compose.ranger-postgres.yml
@@ -8,6 +8,8 @@ services:
     image: ranger-postgres
     container_name: ranger-postgres
     hostname: ranger-db.example.com
+    ports:
+      - "5432:5432"
     networks:
       - ranger
     healthcheck:

--- a/dev-support/ranger-docker/docker-compose.ranger-sqlserver.yml
+++ b/dev-support/ranger-docker/docker-compose.ranger-sqlserver.yml
@@ -8,6 +8,8 @@ services:
     image: ranger-sqlserver
     container_name: ranger-sqlserver
     hostname: ranger-db.example.com
+    ports:
+      - "1433:1433"
     networks:
       - ranger
     healthcheck:


### PR DESCRIPTION
## What changes were proposed in this pull request?

Expose default ports for all databases in docker compose.

## How was this patch tested?

Tested the changes on local machine for database flavors: `postgres, mysql, oracle` using DBeaver client, test connection is successful. 

Testing for SQL Server: https://github.com/kumaab/ranger/actions/runs/13847861273/job/38753146099
`Connection to 127.0.0.1 1433 port [tcp/ms-sql-s] succeeded!`
