### PR TITLE
RANGER-5174: fix for script engine instantiation failure

### DIFF
--- a/agents-common/src/main/java/org/apache/ranger/plugin/util/GraalScriptEngineCreator.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/util/GraalScriptEngineCreator.java
@@ -72,7 +72,7 @@ public class GraalScriptEngineCreator implements ScriptEngineCreator {
         ScriptEngine ret = null;
 
         if (clsLoader == null) {
-            clsLoader = Thread.currentThread().getContextClassLoader();
+            clsLoader = getDefaultClassLoader();
         }
 
         try {

--- a/agents-common/src/main/java/org/apache/ranger/plugin/util/JavaScriptEngineCreator.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/util/JavaScriptEngineCreator.java
@@ -33,7 +33,7 @@ public class JavaScriptEngineCreator implements ScriptEngineCreator {
         ScriptEngine ret = null;
 
         if (clsLoader == null) {
-            clsLoader = Thread.currentThread().getContextClassLoader();
+            clsLoader = getDefaultClassLoader();
         }
 
         try {

--- a/agents-common/src/main/java/org/apache/ranger/plugin/util/NashornScriptEngineCreator.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/util/NashornScriptEngineCreator.java
@@ -37,7 +37,7 @@ public class NashornScriptEngineCreator implements ScriptEngineCreator {
         ScriptEngine ret = null;
 
         if (clsLoader == null) {
-            clsLoader = Thread.currentThread().getContextClassLoader();
+            clsLoader = getDefaultClassLoader();
         }
 
         try {

--- a/agents-common/src/main/java/org/apache/ranger/plugin/util/ScriptEngineCreator.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/util/ScriptEngineCreator.java
@@ -19,8 +19,22 @@
 
 package org.apache.ranger.plugin.util;
 
+import org.apache.ranger.plugin.classloader.RangerPluginClassLoader;
+
 import javax.script.ScriptEngine;
 
 public interface ScriptEngineCreator {
     ScriptEngine getScriptEngine(ClassLoader clsLoader);
+
+    default ClassLoader getDefaultClassLoader() {
+        ClassLoader ret = Thread.currentThread().getContextClassLoader();
+
+        // Most Ranger plugins use a shim layer and RangerPluginClassLoader for isolation of libraries
+        // loaded by the plugin implementation. The shim ensures that all calls to the plugin would have
+        // RangerPluginClassLoader as current thread classloader.
+        // Some plugins, like Trino, use their own isolation mechanism. In these plugins, current thread's
+        // classloader may not load libraries in the plugin directory, which can result in failure in
+        // creation of the script engine. Using the classloader of current class to resolve this issue.
+        return ret instanceof RangerPluginClassLoader ? ret : this.getClass().getClassLoader();
+    }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Updated script engine creator implementations to use the classloader that loaded the creator instance, while creating script engine instances, instead of current thread's classloader.

## How was this patch tested?

Verified that Trino plugin successfully evaluates expressions in row-filter policies.