### PR TITLE
RANGER-5178: Update callers of executeOnTransactionCommit to check for existence of objects

### DIFF
--- a/security-admin/src/main/java/org/apache/ranger/biz/PolicyRefUpdater.java
+++ b/security-admin/src/main/java/org/apache/ranger/biz/PolicyRefUpdater.java
@@ -516,42 +516,50 @@ public class PolicyRefUpdater {
             return ret;
         }
 
+        private boolean doesPolicyExist(XXPolicy xPolicy) {
+            return daoMgr.getXXPolicy().getById(xPolicy.getId()) != null;
+        }
+
         private void createPolicyAssociation(Long id, String name) {
             LOG.debug("===> PolicyPrincipalAssociator.createPolicyAssociation(policyId={}, type={}, name={}, id={})", xPolicy.getId(), type.name(), name, id);
 
-            switch (type) {
-                case USER: {
-                    XXPolicyRefUser xPolUser = rangerAuditFields.populateAuditFields(new XXPolicyRefUser(), xPolicy);
+            if (doesPolicyExist(xPolicy)) {
+                switch (type) {
+                    case USER: {
+                        XXPolicyRefUser xPolUser = rangerAuditFields.populateAuditFields(new XXPolicyRefUser(), xPolicy);
 
-                    xPolUser.setPolicyId(xPolicy.getId());
-                    xPolUser.setUserId(id);
-                    xPolUser.setUserName(name);
+                        xPolUser.setPolicyId(xPolicy.getId());
+                        xPolUser.setUserId(id);
+                        xPolUser.setUserName(name);
 
-                    daoMgr.getXXPolicyRefUser().create(xPolUser);
-                }
-                break;
-                case GROUP: {
-                    XXPolicyRefGroup xPolGroup = rangerAuditFields.populateAuditFields(new XXPolicyRefGroup(), xPolicy);
-
-                    xPolGroup.setPolicyId(xPolicy.getId());
-                    xPolGroup.setGroupId(id);
-                    xPolGroup.setGroupName(name);
-
-                    daoMgr.getXXPolicyRefGroup().create(xPolGroup);
-                }
-                break;
-                case ROLE: {
-                    XXPolicyRefRole xPolRole = rangerAuditFields.populateAuditFields(new XXPolicyRefRole(), xPolicy);
-
-                    xPolRole.setPolicyId(xPolicy.getId());
-                    xPolRole.setRoleId(id);
-                    xPolRole.setRoleName(name);
-
-                    daoMgr.getXXPolicyRefRole().create(xPolRole);
-                }
-                break;
-                default:
+                        daoMgr.getXXPolicyRefUser().create(xPolUser);
+                    }
                     break;
+                    case GROUP: {
+                        XXPolicyRefGroup xPolGroup = rangerAuditFields.populateAuditFields(new XXPolicyRefGroup(), xPolicy);
+
+                        xPolGroup.setPolicyId(xPolicy.getId());
+                        xPolGroup.setGroupId(id);
+                        xPolGroup.setGroupName(name);
+
+                        daoMgr.getXXPolicyRefGroup().create(xPolGroup);
+                    }
+                    break;
+                    case ROLE: {
+                        XXPolicyRefRole xPolRole = rangerAuditFields.populateAuditFields(new XXPolicyRefRole(), xPolicy);
+
+                        xPolRole.setPolicyId(xPolicy.getId());
+                        xPolRole.setRoleId(id);
+                        xPolRole.setRoleName(name);
+
+                        daoMgr.getXXPolicyRefRole().create(xPolRole);
+                    }
+                    break;
+                    default:
+                        break;
+                }
+            } else {
+                LOG.info("Policy with id = {} does not exist, skipping policy association!", xPolicy.getId());
             }
 
             LOG.debug("<=== PolicyPrincipalAssociator.createPolicyAssociation(policyId={}, type={}, name={}, id={})", xPolicy.getId(), type.name(), name, id);

--- a/security-admin/src/main/java/org/apache/ranger/biz/RoleRefUpdater.java
+++ b/security-admin/src/main/java/org/apache/ranger/biz/RoleRefUpdater.java
@@ -345,45 +345,63 @@ public class RoleRefUpdater {
             return ret;
         }
 
+        private boolean doesPrincipalExist(String name, PolicyRefUpdater.PRINCIPAL_TYPE type) {
+            switch (type) {
+                case USER:
+                    return daoMgr.getXXUser().findByUserName(name) != null;
+                case GROUP:
+                    return daoMgr.getXXGroup().findByGroupName(name) != null;
+                case ROLE:
+                    return daoMgr.getXXRole().findByRoleName(name) != null;
+                default:
+                    break;
+            }
+            return false;
+        }
+
         private void createRoleAssociation(Long id, String name) {
             LOG.debug("===> RolePrincipalAssociator.createRoleAssociation(roleId={}, type={}, name={}, id={})", roleId, type.name(), name, id);
 
-            switch (type) {
-                case USER: {
-                    XXRoleRefUser xRoleRefUser = rangerAuditFields.populateAuditFieldsForCreate(new XXRoleRefUser());
+            if (doesPrincipalExist(name, type)) {
+                switch (type) {
+                    case USER: {
+                            XXRoleRefUser xRoleRefUser = rangerAuditFields.populateAuditFieldsForCreate(new XXRoleRefUser());
 
-                    xRoleRefUser.setRoleId(roleId);
-                    xRoleRefUser.setUserId(id);
-                    xRoleRefUser.setUserName(name);
-                    xRoleRefUser.setUserType(0);
+                            xRoleRefUser.setRoleId(roleId);
+                            xRoleRefUser.setUserId(id);
+                            xRoleRefUser.setUserName(name);
+                            xRoleRefUser.setUserType(0);
 
-                    daoMgr.getXXRoleRefUser().create(xRoleRefUser);
-                }
-                break;
-                case GROUP: {
-                    XXRoleRefGroup xRoleRefGroup = rangerAuditFields.populateAuditFieldsForCreate(new XXRoleRefGroup());
+                            daoMgr.getXXRoleRefUser().create(xRoleRefUser);
+                        }
+                        break;
+                        case GROUP: {
+                            XXRoleRefGroup xRoleRefGroup = rangerAuditFields.populateAuditFieldsForCreate(new XXRoleRefGroup());
 
-                    xRoleRefGroup.setRoleId(roleId);
-                    xRoleRefGroup.setGroupId(id);
-                    xRoleRefGroup.setGroupName(name);
-                    xRoleRefGroup.setGroupType(0);
+                            xRoleRefGroup.setRoleId(roleId);
+                            xRoleRefGroup.setGroupId(id);
+                            xRoleRefGroup.setGroupName(name);
+                            xRoleRefGroup.setGroupType(0);
 
-                    daoMgr.getXXRoleRefGroup().create(xRoleRefGroup);
-                }
-                break;
-                case ROLE: {
-                    XXRoleRefRole xRoleRefRole = rangerAuditFields.populateAuditFieldsForCreate(new XXRoleRefRole());
+                            daoMgr.getXXRoleRefGroup().create(xRoleRefGroup);
+                        }
+                        break;
+                        case ROLE: {
+                            XXRoleRefRole xRoleRefRole = rangerAuditFields.populateAuditFieldsForCreate(new XXRoleRefRole());
 
-                    xRoleRefRole.setRoleId(roleId);
-                    xRoleRefRole.setSubRoleId(id);
-                    xRoleRefRole.setSubRoleName(name);
-                    xRoleRefRole.setSubRoleType(0);
+                            xRoleRefRole.setRoleId(roleId);
+                            xRoleRefRole.setSubRoleId(id);
+                            xRoleRefRole.setSubRoleName(name);
+                            xRoleRefRole.setSubRoleType(0);
 
-                    daoMgr.getXXRoleRefRole().create(xRoleRefRole);
-                }
-                break;
-                default:
-                    break;
+                            daoMgr.getXXRoleRefRole().create(xRoleRefRole);
+                        }
+                        break;
+                        default:
+                            break;
+                    }
+            } else {
+                LOG.info("Principal with type = {}, name = {} does not exist, skipping role association!", type.name(), name);
             }
 
             LOG.debug("<=== RolePrincipalAssociator.createRoleAssociation(roleId={}, type={}, name={}, id={})", roleId, type.name(), name, id);


### PR DESCRIPTION
## What changes were proposed in this pull request?

`executeOnTransactionCommit` in `RangerTransactionSynchronizationAdapter.java` is called multiple places for doing post transaction commit tasks in a subsequent transaction following the parent transaction.
 
The PR adds checks for appropriate objects referenced in classes `PolicyRefUpdater` and `RoleRefUpdater`.


## How was this patch tested?
Pending.
