### PR TITLE
RANGER-5169: Error while migrating Masterkey from older format to exter…

### DIFF
--- a/kms/src/main/java/org/apache/hadoop/crypto/key/RangerMasterKey.java
+++ b/kms/src/main/java/org/apache/hadoop/crypto/key/RangerMasterKey.java
@@ -71,11 +71,12 @@ public class RangerMasterKey implements RangerKMSMKI {
     private final RangerMasterKeyDao masterKeyDao;
 
     public RangerMasterKey() {
-        this.masterKeyDao = null;
+        this(null);
     }
 
     public RangerMasterKey(DaoManager daoManager) {
         this.masterKeyDao = daoManager != null ? daoManager.getRangerMasterKeyDao() : null;
+        init();
     }
 
     public static void getPasswordParam(String paddedEncryptedPwd) {
@@ -194,8 +195,6 @@ public class RangerMasterKey implements RangerKMSMKI {
         logger.debug("==> RangerMasterKey.generateMasterKey()");
         logger.info("Generating Master Key...");
 
-        init();
-
         if (!checkMKExistence(this.masterKeyDao)) {
             logger.info("Master Key doesn't exist in DB, Generating the Master Key");
 
@@ -252,8 +251,6 @@ public class RangerMasterKey implements RangerKMSMKI {
     public void generateMKFromHSMMK(String password, byte[] key) throws Throwable {
         logger.debug("==> RangerMasterKey.generateMKFromHSMMK()");
 
-        init();
-
         if (!checkMKExistence(this.masterKeyDao)) {
             logger.info("Master Key doesn't exist in DB, Generating the Master Key");
 
@@ -273,8 +270,6 @@ public class RangerMasterKey implements RangerKMSMKI {
 
     public void generateMKFromKeySecureMK(String password, byte[] key) throws Throwable {
         logger.debug("==> RangerMasterKey.generateMKFromKeySecureMK()");
-
-        init();
 
         if (!checkMKExistence(this.masterKeyDao)) {
             logger.info("Master Key doesn't exist in DB, Generating the Master Key");


### PR DESCRIPTION
…nal key store

## What changes were proposed in this pull request?

Initialisation of metadata in RangerMasterkey (like message digest, algorithm etc) was happening selectively for generateMasterKey() methods only. But to migrate key from DB to any external keyStore,  generateMasterKey() is not called and hence these metadata remains null.

Fix is to invoke init() method from RangerMasterkey constructor itself so that metadata remains available for all invocations.

## How was this patch tested?

Complete Ranger build, Unit Testing, created new docker image of KMS and performed basic key operations.
