### PR TITLE
RANGER-5191: Fix typo in the log message in RangerRESTClient

### DIFF
--- a/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerRESTClient.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerRESTClient.java
@@ -616,7 +616,7 @@ public class RangerRESTClient {
         } catch (KeyManagementException e) {
             LOG.error("Unable to initials the SSLContext", e);
 
-            throw new IllegalStateException("Unable to initials the SSLContex: " + e.getMessage(), e);
+            throw new IllegalStateException("Unable to initials the SSLContext: " + e.getMessage(), e);
         }
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix a trivial typo in the log message in RangerRESTClient

## How was this patch tested?

No test because this will only fix the error message
