### PR TITLE
RANGER-5184 : Enhance Access audit to be filtered by Federated user

### DIFF
--- a/security-admin/src/main/webapp/react-webapp/src/views/AuditEvent/AccessLogs.jsx
+++ b/security-admin/src/main/webapp/react-webapp/src/views/AuditEvent/AccessLogs.jsx
@@ -63,7 +63,8 @@ import {
 import { CustomTooltip, Loader } from "../../components/CommonComponents";
 import {
   ServiceRequestDataRangerAcl,
-  ServiceRequestDataHadoopAcl
+  ServiceRequestDataHadoopAcl,
+  UserTypes
 } from "../../utils/XAEnums";
 import { getServiceDef } from "../../utils/appState";
 
@@ -522,6 +523,23 @@ function Access() {
           } else return "--";
         },
         width: 120,
+        disableResizing: true,
+        getResizerProps: () => {}
+      },
+      {
+        Header: "User Source",
+        accessor: "userSource",
+        Cell: (rawValue) => {
+          if (!isEmpty(rawValue?.value)) {
+            const userSourceVal = find(UserTypes, { value: rawValue.value });
+            return (
+              <h6 className="text-center">
+                <Badge bg={userSourceVal.variant}>{userSourceVal.label}</Badge>
+              </h6>
+            );
+          } else return "--";
+        },
+        width: 100,
         disableResizing: true,
         getResizerProps: () => {}
       },
@@ -1002,6 +1020,19 @@ function Access() {
       urlLabel: "user",
       addMultiple: true,
       type: "text"
+    },
+    {
+      category: "userSource",
+      label: "User Source",
+      urlLabel: "userSource",
+      type: "textoptions",
+      options: () => {
+        return [
+          { value: "0", label: "Internal" },
+          { value: "1", label: "External" },
+          { value: "6", label: "Federated" }
+        ];
+      }
     },
     {
       category: "zoneName",

--- a/security-admin/src/main/webapp/react-webapp/src/views/AuditEvent/AccessLogsTable.jsx
+++ b/security-admin/src/main/webapp/react-webapp/src/views/AuditEvent/AccessLogsTable.jsx
@@ -52,6 +52,7 @@ export const AccessLogsTable = ({ data = {} }) => {
     zoneName,
     requestData,
     tags,
+    userSource,
     datasets,
     projects
   } = data;
@@ -91,6 +92,10 @@ export const AccessLogsTable = ({ data = {} }) => {
         <tr>
           <td>User</td>
           <td>{!isEmpty(requestUser) ? requestUser : "--"}</td>
+        </tr>
+        <tr>
+          <td>User Source</td>
+          <td>{!isEmpty(userSource) ? userSource : "--"}</td>
         </tr>
         <tr>
           <td>Service Name </td>

--- a/security-admin/src/main/webapp/react-webapp/src/views/UserGroupRoleListing/users_details/UserListing.jsx
+++ b/security-admin/src/main/webapp/react-webapp/src/views/UserGroupRoleListing/users_details/UserListing.jsx
@@ -553,7 +553,8 @@ function Users() {
       options: () => {
         return [
           { value: "0", label: "Internal" },
-          { value: "1", label: "External" }
+          { value: "1", label: "External" },
+          { value: "6", label: "Federated" }
         ];
       }
     },


### PR DESCRIPTION
## What changes were proposed in this pull request?
Enhance Access audit to be filtered by Federated user

Have a new search criteria which takes User Type : Federated , Internal , external and this should be used as a filter to the Following API.
https://ranger.apache.org/apidocs/ui/index.html#/AssetREST/getAccessLogs
/assets/accessAudit

## How was this patch tested?
Manually tested on local machine.
