### PR TITLE
RANGER-5199 : Connection to Ranger KMS DB fails with secure MySQL/Maria DB

### DIFF
--- a/kms/src/main/java/org/apache/hadoop/crypto/key/RangerKMSDB.java
+++ b/kms/src/main/java/org/apache/hadoop/crypto/key/RangerKMSDB.java
@@ -162,7 +162,8 @@ public class RangerKMSDB {
     private void updateDBSSLURL() {
         if (conf != null && conf.get(PROPERTY_PREFIX + DB_SSL_ENABLED) != null) {
             final String dbSslEnabled = normalize(conf.get(PROPERTY_PREFIX + DB_SSL_ENABLED));
-
+            String rangerJpaJdbcUrl = conf.get(PROPERTY_PREFIX + DB_URL);
+            int dbFlavor = getDBFlavor(conf);
             if ("true".equalsIgnoreCase(dbSslEnabled)) {
                 final String dbSslRequired                = normalize(conf.get(PROPERTY_PREFIX + DB_SSL_REQUIRED));
                 final String dbSslVerifyServerCertificate = normalize(conf.get(PROPERTY_PREFIX + DB_SSL_VerifyServerCertificate));
@@ -173,12 +174,8 @@ public class RangerKMSDB {
                 conf.set(PROPERTY_PREFIX + DB_SSL_VerifyServerCertificate, dbSslVerifyServerCertificate);
                 conf.set(PROPERTY_PREFIX + DB_SSL_AUTH_TYPE, dbSslAuthType);
 
-                String rangerJpaJdbcUrl = conf.get(PROPERTY_PREFIX + DB_URL);
-
                 if (StringUtils.isNotEmpty(rangerJpaJdbcUrl) && !rangerJpaJdbcUrl.contains("?")) {
                     StringBuilder rangerJpaJdbcUrlSsl = new StringBuilder(rangerJpaJdbcUrl);
-
-                    int dbFlavor = getDBFlavor(conf);
 
                     if (dbFlavor == DB_FLAVOR_MYSQL) {
                         rangerJpaJdbcUrlSsl.append("?useSSL=").append(dbSslEnabled)
@@ -244,6 +241,15 @@ public class RangerKMSDB {
                         logger.debug("truststore property '{}' value not found!", PROPERTY_PREFIX + DB_SSL_TRUSTSTORE);
                     }
                 }
+            } else {
+                if(dbFlavor == DB_FLAVOR_MYSQL){
+                   if(StringUtils.isNotEmpty(rangerJpaJdbcUrl) && !rangerJpaJdbcUrl.contains("?")) {
+                       rangerJpaJdbcUrl = rangerJpaJdbcUrl + "?useSSL=" + dbSslEnabled;
+                       conf.set(PROPERTY_PREFIX + DB_URL, rangerJpaJdbcUrl);
+                        jpaProperties.put(JPA_DB_URL, conf.get(PROPERTY_PREFIX + DB_URL));
+                   }
+                }
+                logger.info(PROPERTY_PREFIX+DB_URL+"="+conf.get(PROPERTY_PREFIX + DB_URL));
             }
         }
     }


### PR DESCRIPTION


## What changes were proposed in this pull request?
RANGER-5199 : Connection to Ranger KMS DB fails with secure MySQL/maria DB

Facing below error while connecting to secure mysql/maria DB.
`ERROR org.apache.hadoop.crypto.key.RangerKeyStoreProvider: [main]: ==> RangerKeyStoreProvider.reloadKeys() error : 
java.lang.RuntimeException: Error while generating Ranger Master key, Error - Exception [EclipseLink-4002] (Eclipse Persistence Services - 2.7.12.v20230209-e5c4074ef3): org.eclipse.persistence.exceptions.DatabaseException
Internal Exception: com.mysql.cj.jdbc.exceptions.CommunicationsException: Communications link failure


The last packet sent successfully to the server was 0 milliseconds ago. The driver has not received any packets from the server.
Error Code: 0
	at org.apache.hadoop.crypto.key.RangerKeyStoreProvider.generateAndGetMasterKey(RangerKeyStoreProvider.java:296) ~[ranger-kms.jar:?]
	at org.apache.hadoop.crypto.key.RangerKeyStoreProvider.<init>(RangerKeyStoreProvider.java:263) ~[ranger-kms.jar:?]
	at org.apache.hadoop.crypto.key.RangerKeyStoreProvider$Factory.createProvider(RangerKeyStoreProvider.java:742) ~[ranger-kms.jar:?]
	at org.apache.hadoop.crypto.key.kms.server.KMSWebApp.createKeyProvider(KMSWebApp.java:111) ~[ranger-kms.jar:?]
	at org.apache.hadoop.crypto.key.kms.server.KMSWebApp.contextInitialized(KMSWebApp.java:175) ~[ranger-kms-2.4.0.7.3.1.200-83.jar:?] `
	
	
We need  ranger-kms backend side fix to append ?useSSL=false when using mysql/mariadb databases.


## How was this patch tested?
1.) Manual testing with secure DB
2.) Successful build.