### PR TITLE
RANGER-5211 : KMS Metric collection thread safety check should not pa…

### DIFF
--- a/kms/src/main/java/org/apache/hadoop/crypto/key/kms/server/KMSWebApp.java
+++ b/kms/src/main/java/org/apache/hadoop/crypto/key/kms/server/KMSWebApp.java
@@ -78,6 +78,7 @@ public class KMSWebApp implements ServletContextListener {
     private static KeyProviderCryptoExtension keyProviderCryptoExtension;
     private static KMSMetricsCollector        kmsMetricsCollector;
 
+    private static boolean isMetricsCollectionThreadsafe;
     private JmxReporter jmxReporter;
 
     public static Configuration getConfiguration() {
@@ -133,7 +134,7 @@ public class KMSWebApp implements ServletContextListener {
     }
 
     public static boolean isMetricCollectionThreadSafe() {
-        return Boolean.parseBoolean(KMSWebApp.getConfiguration().get(HADOOP_KMS_METRIC_COLLECTION_THREADSAFE, "false"));
+        return isMetricsCollectionThreadsafe;
     }
 
     public static KMSMetricsCollector getKmsMetricsCollector() {
@@ -181,6 +182,7 @@ public class KMSWebApp implements ServletContextListener {
 
             kmsAudit = new KMSAudit(kmsConf);
 
+            isMetricsCollectionThreadsafe = Boolean.valueOf(kmsConf.get(HADOOP_KMS_METRIC_COLLECTION_THREADSAFE, "false"));
             KMSMetricWrapper kmsMetricWrapper = KMSMetricWrapper.getInstance(isMetricCollectionThreadSafe());
 
             kmsMetricsCollector = kmsMetricWrapper.getKmsMetricsCollector();


### PR DESCRIPTION
…rse config everytime

## What changes were proposed in this pull request?

KMS metrics collector checks before collection whether the collection is thread-safe or not. Default is false. This config was introduced to avoid unnecessary locking for the non-functional metrics. But for businesses where metrics need to be accurate, it can be marked true. To check this flag, existing code was reading the config value from kmsConf every time. And this required to create one Configuration object and this acquires lock on the underlying config. Hence it was blocking many other threads who actually needs to parse and read something.

I have noticed around 30-40 threads always waiting for the kmsConf lock and it was acquired by the thread that was simply checking whether metric collection is thread safe or not.

Since this config doesn't change during execution, It can be simply read and kept during initialisation once , and can be read from there whenever required.
 
## How was this patch tested?

Build got passed, Unit tests got passed.
Further I created ranger-kms docker image and verified the metric collection by hitting metric API.


