### PR TITLE
RANGER-5155 : Service Definition with empty configs causes Ranger UI rendering issues

### DIFF
--- a/security-admin/src/main/webapp/react-webapp/src/views/ServiceManager/ServiceDefinition.jsx
+++ b/security-admin/src/main/webapp/react-webapp/src/views/ServiceManager/ServiceDefinition.jsx
@@ -84,7 +84,7 @@ class ServiceDefinition extends Component {
     let configs = {};
     let customConfigs = {};
 
-    let serviceDefConfigs = serviceDef.configs.filter(
+    let serviceDefConfigs = serviceDef?.configs?.filter(
       (config) => config.name !== "ranger.plugin.audit.filters"
     );
 
@@ -94,7 +94,7 @@ class ServiceDefinition extends Component {
     let serviceDefConfigsKey = map(serviceDefConfigs, "name");
     let customConfigsKey = difference(serviceConfigsKey, serviceDefConfigsKey);
 
-    serviceDefConfigs.map(
+    serviceDefConfigs?.map(
       (config) =>
         (configs[config.label !== undefined ? config.label : config.name] =
           serviceConfigs[config.name])


### PR DESCRIPTION
## What changes were proposed in this pull request?
A service definition defined in a .json file with empty "configs" causes Ranger UI to not render correctly when a user performs a login.

Service repo creation undergoes fine with the same service definition.

As soon as an entry is added to the "configs" section, the issue is not seen anymore.

## How was this patch tested?
Manually tested on local machine.