### PR TITLE
RANGER-5214 : Fix for KMS throwing IOException instead of AccessContr…

### DIFF
--- a/kms/src/main/java/org/apache/hadoop/crypto/key/kms/server/KMS.java
+++ b/kms/src/main/java/org/apache/hadoop/crypto/key/kms/server/KMS.java
@@ -507,7 +507,7 @@ public class KMS {
         } catch (Exception e) {
             LOG.error("Exception in generateDataKey:", e);
 
-            throw new IOException(e);
+            throw e;
         } finally {
             LOG.debug("<== generateDataKey(name={}", name);
         }
@@ -533,8 +533,8 @@ public class KMS {
             if (edekOp.equals(KMSRESTConstants.EEK_GENERATE)) {
                 final List<EncryptedKeyVersion> retEdeks = new LinkedList<>();
 
+                assertAccess(Type.GENERATE_EEK, user, KMSOp.GENERATE_EEK, name, request.getRemoteAddr());
                 try {
-                    assertAccess(Type.GENERATE_EEK, user, KMSOp.GENERATE_EEK, name, request.getRemoteAddr());
                     user.doAs((PrivilegedExceptionAction<Void>) () -> {
                         for (int i = 0; i < numKeys; i++) {
                             retEdeks.add(provider.generateEncryptedKey(name));


### PR DESCRIPTION
…olException

## What changes were proposed in this pull request?

It's a regression fix , due to this issue  KMS generateEEK API was throwing IOException instead of relevant exception like IllegalArgumentException if keyName is empty or missing in the URL.
 
Fix contains the proper exception handling and now it is consistent with original behaviour.


## How was this patch tested?

mvn build is successful
UT got passed.
Created a new ranger-kms docker image and verified the two related endpoints.

**Without zoneKey name in the URL:**
```
root@ranger-kms:/# curl -ivk  -H "Content-Type: application/json" -H  -X GET 'http://host.docker.internal:9292/kms/v1/key//_eek?eek_op=generate&user.name=keyadmin'
.................
> GET /kms/v1/key//_eek?eek_op=generate&user.name=keyadmin HTTP/1.1

< Server: Apache Ranger
Server: Apache Ranger

< 
{
  "RemoteException" : {
    "message" : "Parameter 'name' cannot be empty",
    "exception" : "IllegalArgumentException",
    "javaClassName" : "java.lang.IllegalArgumentException"
  }
* Closing connection 1
}root@ranger-kms:/# 
```
**With zonekey name, a valid request**
```
root@ranger-kms:/# curl -ivk  -H "Content-Type: application/json" -H  -X GET 'http://host.docker.internal:9292/kms/v1/key/testkey/_eek?eek_op=generate&user.name=keyadmin'

> GET /kms/v1/key/testkey/_eek?eek_op=generate&user.name=keyadmin HTTP/1.1
> Host: host.docker.internal:9292
..........................................

< 
[ {
  "encryptedKeyVersion" : {
    "material" : "P_DjnLoXbuRk6VEw21thMg",
    "name" : "testkey",
    "versionName" : "EEK"
  },
  "versionName" : "testkey@0",
  "iv" : "r66Mf-saz8DjkPjZxux9ZA"
* Connection #1 to host host.docker.internal left intact
} ]root@ranger-kms:/#
```