### PR TITLE
RANGER-5212: Search filter in Roles tab does not consider all relevant role columns

### DIFF
--- a/agents-common/src/main/java/org/apache/ranger/plugin/store/RolePredicateUtil.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/store/RolePredicateUtil.java
@@ -37,10 +37,12 @@ public class RolePredicateUtil extends AbstractPredicateUtil {
         addPredicateForRoleId(filter.getParam(SearchFilter.ROLE_ID), predicates);
         addPredicateForGroupName(filter.getParam(SearchFilter.GROUP_NAME), predicates);
         addPredicateForUserName(filter.getParam(SearchFilter.USER_NAME), predicates);
+        addPredicateForRoleName(filter.getParam(SearchFilter.SUB_ROLE_NAME), predicates);
 
         addPredicateForPartialRoleName(filter.getParam(SearchFilter.ROLE_NAME_PARTIAL), predicates);
         addPredicateForPartialGroupName(filter.getParam(SearchFilter.GROUP_NAME_PARTIAL), predicates);
         addPredicateForPartialUserName(filter.getParam(SearchFilter.USER_NAME_PARTIAL), predicates);
+        addPredicateForPartialRoleName(filter.getParam(SearchFilter.SUB_ROLE_NAME_PARTIAL), predicates);
     }
 
     private Predicate addPredicateForRoleName(final String roleName, List<Predicate> predicates) {

--- a/agents-common/src/main/java/org/apache/ranger/plugin/util/SearchFilter.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/util/SearchFilter.java
@@ -70,6 +70,8 @@ public class SearchFilter {
     public static final String ROLE_NAME_PARTIAL        = "roleNamePartial";      // search
     public static final String GROUP_NAME_PARTIAL       = "groupNamePartial";     // search
     public static final String USER_NAME_PARTIAL        = "userNamePartial";      // search
+    public static final String SUB_ROLE_NAME            = "subRoleName";          // search
+    public static final String SUB_ROLE_NAME_PARTIAL    = "subRoleNamePartial";   // search
     public static final String SERVICE_NAME_PREFIX      = "serviceNamePrefix";    // search
     public static final String ZONE_NAME_PREFIX         = "zoneNamePrefix";       // search
     public static final String POLICY_NAME_PREFIX       = "policyNamePrefix";

--- a/security-admin/src/main/java/org/apache/ranger/common/RangerSearchUtil.java
+++ b/security-admin/src/main/java/org/apache/ranger/common/RangerSearchUtil.java
@@ -94,6 +94,8 @@ public class RangerSearchUtil extends SearchUtil {
         ret.setParam(SearchFilter.ROLE_NAME_PARTIAL, request.getParameter(SearchFilter.ROLE_NAME_PARTIAL));
         ret.setParam(SearchFilter.GROUP_NAME_PARTIAL, request.getParameter(SearchFilter.GROUP_NAME_PARTIAL));
         ret.setParam(SearchFilter.USER_NAME_PARTIAL, request.getParameter(SearchFilter.USER_NAME_PARTIAL));
+        ret.setParam(SearchFilter.SUB_ROLE_NAME, request.getParameter(SearchFilter.SUB_ROLE_NAME));
+        ret.setParam(SearchFilter.SUB_ROLE_NAME_PARTIAL, request.getParameter(SearchFilter.SUB_ROLE_NAME_PARTIAL));
         ret.setParam(SearchFilter.CLUSTER_NAME, request.getParameter(SearchFilter.CLUSTER_NAME));
         ret.setParam(SearchFilter.FETCH_ZONE_UNZONE_POLICIES, request.getParameter(SearchFilter.FETCH_ZONE_UNZONE_POLICIES));
         ret.setParam(SearchFilter.FETCH_TAG_POLICIES, request.getParameter(SearchFilter.FETCH_TAG_POLICIES));

--- a/security-admin/src/main/java/org/apache/ranger/service/RangerRoleServiceBase.java
+++ b/security-admin/src/main/java/org/apache/ranger/service/RangerRoleServiceBase.java
@@ -40,6 +40,8 @@ public abstract class RangerRoleServiceBase<T extends XXRole, V extends RangerRo
         searchFields.add(new SearchField(SearchFilter.ROLE_NAME_PARTIAL, "obj.name", SearchField.DATA_TYPE.STRING, SearchField.SEARCH_TYPE.PARTIAL));
         searchFields.add(new SearchField(SearchFilter.GROUP_NAME_PARTIAL, "xXRoleRefGroup.groupName", SearchField.DATA_TYPE.STRING, SearchField.SEARCH_TYPE.PARTIAL, "XXRoleRefGroup xXRoleRefGroup", "xXRoleRefGroup.roleId = obj.id"));
         searchFields.add(new SearchField(SearchFilter.USER_NAME_PARTIAL, "xXRoleRefUser.userName", SearchField.DATA_TYPE.STRING, SearchField.SEARCH_TYPE.PARTIAL, "XXRoleRefUser xXRoleRefUser", "xXRoleRefUser.roleId = obj.id"));
+        searchFields.add(new SearchField(SearchFilter.SUB_ROLE_NAME, "xXRoleRefRole.subRoleName", SearchField.DATA_TYPE.STRING, SearchField.SEARCH_TYPE.FULL, "XXRoleRefRole xXRoleRefRole", "xXRoleRefRole.roleId = obj.id"));
+        searchFields.add(new SearchField(SearchFilter.SUB_ROLE_NAME_PARTIAL, "xXRoleRefRole.subRoleName", SearchField.DATA_TYPE.STRING, SearchField.SEARCH_TYPE.PARTIAL, "XXRoleRefRole xXRoleRefRole", "xXRoleRefRole.roleId = obj.id"));
 
         sortFields.add(new SortField(SearchFilter.CREATE_TIME, "obj.createTime"));
         sortFields.add(new SortField(SearchFilter.UPDATE_TIME, "obj.updateTime"));

--- a/security-admin/src/main/webapp/react-webapp/src/views/UserGroupRoleListing/role_details/RoleListing.jsx
+++ b/security-admin/src/main/webapp/react-webapp/src/views/UserGroupRoleListing/role_details/RoleListing.jsx
@@ -326,6 +326,12 @@ function Roles() {
       label: "User Name",
       urlLabel: "userName",
       type: "text"
+    },
+    {
+      category: "subRoleNamePartial",
+      label: "Associated Role",
+      urlLabel: "associatedRoles",
+      type: "text"
     }
   ];
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

When using the Role Name filter, it only matches values from the Role Name column. It does not match values from the Roles column, even though that column contains the role



## How was this patch tested?

Tested and Validated search for below API.

/roles/lookup/roles?subRoleName=r2
/roles/lookup/roles?subRoleNamePartial=r2