### PR TITLE
RANGER-5217: revert mandatory distinct clause as getPolicy request may fail for oracle

### DIFF
--- a/agents-common/src/main/java/org/apache/ranger/plugin/util/SearchFilter.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/util/SearchFilter.java
@@ -155,7 +155,7 @@ public class SearchFilter {
     private boolean               getCount   = true;
     private String                sortBy;
     private String                sortType;
-    private boolean               isDistinct = true;
+    private boolean               isDistinct;
 
     public SearchFilter() {
         this((Map<String, String>) null);


### PR DESCRIPTION
## What changes were proposed in this pull request?

getPolicy request may fail as the distinct query clause is not valid for oracle. This PR reverts the changes done by RANGER-4410 commit https://github.com/apache/ranger/commit/7528f5d1385bbbcba44bb22157a7e12df38f0570


## How was this patch tested?

After the build tried the get policy call which was failing earlier.
