### PR TITLE
RANGER-5215 : Policy authroisation fails for Ranger Plugins in case of users/groups converted by Ranger userysnc as per given Regex

### DIFF
--- a/agents-common/pom.xml
+++ b/agents-common/pom.xml
@@ -173,6 +173,25 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.ranger</groupId>
+            <artifactId>ugsync-util</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
         </dependency>

--- a/agents-common/src/main/java/org/apache/ranger/plugin/model/UgsyncNameTransformRules.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/model/UgsyncNameTransformRules.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *=-0987654321`o6 bftware distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.plugin.model;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.apache.ranger.plugin.util.RangerUserStoreUtil;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import java.util.Map;
+
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+@JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.FIELD)
+public class UgsyncNameTransformRules extends RangerBaseModelObject implements java.io.Serializable {
+
+    private static final long   serialVersionUID = 1L;
+    Map<String, String> nameTransformRules;
+    private final String name;
+
+    public UgsyncNameTransformRules() {this(null, null, null);}
+
+    public UgsyncNameTransformRules(String guid, String name, Map<String, String> nameTransformRules) {
+        super();
+        setGuid(guid);
+        setId(Long.valueOf(1));
+        setVersion(Long.valueOf(1));
+        this.name               = name;
+        this.nameTransformRules = nameTransformRules;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Map<String, String> getNameTransformRules() {
+        return nameTransformRules;
+    }
+
+    @Override
+    public String toString() {
+        return "{nameTransformRules=" + RangerUserStoreUtil.getPrintableOptions(nameTransformRules)
+                + "}";
+    }
+}

--- a/agents-common/src/main/java/org/apache/ranger/plugin/policyengine/RangerPluginContext.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/policyengine/RangerPluginContext.java
@@ -27,6 +27,7 @@ import org.apache.ranger.plugin.model.RangerPolicy;
 import org.apache.ranger.plugin.resourcematcher.RangerResourceMatcher;
 import org.apache.ranger.plugin.service.RangerAuthContext;
 import org.apache.ranger.plugin.service.RangerAuthContextListener;
+import org.apache.ranger.ugsyncutil.transform.Mapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,13 +40,49 @@ public class RangerPluginContext {
 
     private final RangerPluginConfig                                                         config;
     private final Map<String, Map<RangerPolicy.RangerPolicyResource, RangerResourceMatcher>> resourceMatchers = new HashMap<>();
-    private final ReentrantReadWriteLock                                                     lock             = new ReentrantReadWriteLock(true); // fair lock
+    private final ReentrantReadWriteLock                                                     lock             = new ReentrantReadWriteLock(true);// fair lock
+    private       Mapper                                                                     userNameTransformInst;
+    private       Mapper                                                                     groupNameTransformInst;
+    private       String                                                                     userNameCaseConversion;
+    private       String                                                                     groupNameCaseConversion;
     private       RangerAuthContext                                                          authContext;
     private       RangerAuthContextListener                                                  authContextListener;
     private       RangerAdminClient                                                          adminClient;
 
     public RangerPluginContext(RangerPluginConfig config) {
         this.config = config;
+    }
+
+    public Mapper getUserNameTransformInst() {
+        return userNameTransformInst;
+    }
+
+    public void setUserNameTransformInst(Mapper userNameTransformInst) {
+        this.userNameTransformInst = userNameTransformInst;
+    }
+
+    public Mapper getGroupNameTransformInst() {
+        return groupNameTransformInst;
+    }
+
+    public void setGroupNameTransformInst(Mapper groupNameTransformInst) {
+        this.groupNameTransformInst = groupNameTransformInst;
+    }
+
+    public String getUserNameCaseConversion() {
+        return userNameCaseConversion;
+    }
+
+    public void setUserNameCaseConversion(String userNameCaseConversion) {
+        this.userNameCaseConversion = userNameCaseConversion;
+    }
+
+    public String getGroupNameCaseConversion() {
+        return groupNameCaseConversion;
+    }
+
+    public void setGroupNameCaseConversion(String groupNameCaseConversion) {
+        this.groupNameCaseConversion = groupNameCaseConversion;
     }
 
     public RangerPluginConfig getConfig() {

--- a/agents-common/src/main/java/org/apache/ranger/plugin/policyengine/RangerPolicyEngineImpl.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/policyengine/RangerPolicyEngineImpl.java
@@ -40,6 +40,7 @@ import org.apache.ranger.plugin.util.RangerPerfTracer;
 import org.apache.ranger.plugin.util.RangerReadWriteLock;
 import org.apache.ranger.plugin.util.RangerRoles;
 import org.apache.ranger.plugin.util.ServicePolicies;
+import org.apache.ranger.ugsyncutil.transform.Mapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -83,6 +84,53 @@ public class RangerPolicyEngineImpl implements RangerPolicyEngine {
         policyEngine     = new PolicyEngine(servicePolicies, pluginContext, roles, isUseReadWriteLock);
         serviceConfig    = new ServiceConfig(servicePolicies.getServiceConfig());
         requestProcessor = new RangerDefaultRequestProcessor(policyEngine);
+
+        Map<String, String> serviceConfigMap = servicePolicies.getServiceConfig();
+        if (MapUtils.isNotEmpty(serviceConfigMap)) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("==> RangerBasePlugin(" + serviceConfigMap.keySet() + ")");
+            }
+            pluginContext.setUserNameCaseConversion(serviceConfigMap.get(RangerCommonConstants.PLUGINS_USERNAME_CASE_CONVERSION_PARAM));
+            pluginContext.setGroupNameCaseConversion(serviceConfigMap.get(RangerCommonConstants.PLUGINS_GROUPNAME_CASE_CONVERSION_PARAM));
+            String mappingUserNameHandler = serviceConfigMap.get(RangerCommonConstants.PLUGINS_MAPPING_USERNAME_HANDLER);
+            try {
+                if (mappingUserNameHandler != null) {
+                    Class<Mapper> regExClass        = (Class<Mapper>) Class.forName(mappingUserNameHandler);
+                    Mapper        userNameRegExInst = regExClass.newInstance();
+                    if (userNameRegExInst != null) {
+                        String baseProperty = RangerCommonConstants.PLUGINS_MAPPING_USERNAME;
+                        userNameRegExInst.init(baseProperty, getAllRegexPatterns(baseProperty, serviceConfigMap),
+                                serviceConfigMap.get(RangerCommonConstants.PLUGINS_MAPPING_SEPARATOR));
+                        pluginContext.setUserNameTransformInst(userNameRegExInst);
+                    } else {
+                        LOG.error("RegEx handler instance for username is null!");
+                    }
+                }
+            } catch (ClassNotFoundException cne) {
+                LOG.error("Failed to load " + mappingUserNameHandler + " " + cne);
+            } catch (Throwable te) {
+                LOG.error("Failed to instantiate " + mappingUserNameHandler + " " + te);
+            }
+            String mappingGroupNameHandler = serviceConfigMap.get(RangerCommonConstants.PLUGINS_MAPPING_GROUPNAME_HANDLER);
+            try {
+                if (mappingGroupNameHandler != null) {
+                    Class<Mapper> regExClass         = (Class<Mapper>) Class.forName(mappingGroupNameHandler);
+                    Mapper        groupNameRegExInst = regExClass.newInstance();
+                    if (groupNameRegExInst != null) {
+                        String baseProperty = RangerCommonConstants.PLUGINS_MAPPING_GROUPNAME;
+                        groupNameRegExInst.init(baseProperty, getAllRegexPatterns(baseProperty, serviceConfigMap),
+                                serviceConfigMap.get(RangerCommonConstants.PLUGINS_MAPPING_SEPARATOR));
+                        pluginContext.setGroupNameTransformInst(groupNameRegExInst);
+                    } else {
+                        LOG.error("RegEx handler instance for groupname is null!");
+                    }
+                }
+            } catch (ClassNotFoundException cne) {
+                LOG.error("Failed to load " + mappingGroupNameHandler + " " + cne);
+            } catch (Throwable te) {
+                LOG.error("Failed to instantiate " + mappingGroupNameHandler + " " + te);
+            }
+        }
     }
 
     private RangerPolicyEngineImpl(final PolicyEngine policyEngine, RangerPolicyEngineImpl other) {
@@ -552,6 +600,31 @@ public class RangerPolicyEngineImpl implements RangerPolicyEngine {
 
     public RangerAccessRequestProcessor getRequestProcessor() {
         return requestProcessor;
+    }
+
+    private List<String> getAllRegexPatterns(String baseProperty, Map<String, String> serviceConfig) throws Throwable {
+        List<String> regexPatterns = new ArrayList<String>();
+        String       baseRegex     = serviceConfig.get(baseProperty);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("==> getAllRegexPatterns(" + baseProperty + ")");
+            LOG.debug("baseRegex = " + baseRegex);
+            LOG.debug("pluginConfig = " + serviceConfig.keySet());
+        }
+        if (baseRegex == null) {
+            return regexPatterns;
+        }
+        regexPatterns.add(baseRegex);
+        int    i         = 1;
+        String nextRegex = serviceConfig.get(baseProperty + "." + i);
+        while (nextRegex != null) {
+            regexPatterns.add(nextRegex);
+            i++;
+            nextRegex = serviceConfig.get(baseProperty + "." + i);
+        }
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("<== getAllRegexPatterns(" + regexPatterns + ")");
+        }
+        return regexPatterns;
     }
 
     private RangerAccessResult zoneAwareAccessEvaluationWithNoAudit(RangerAccessRequest request, int policyType) {

--- a/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerCommonConstants.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerCommonConstants.java
@@ -20,16 +20,25 @@
 package org.apache.ranger.plugin.util;
 
 public class RangerCommonConstants {
-    public static final String  PROP_COOKIE_NAME                                     = "ranger.admin.cookie.name";
-    public static final String  DEFAULT_COOKIE_NAME                                  = "RANGERADMINSESSIONID";
-    public static final String  RANGER_ADMIN_SUFFIX_POLICY_DELTA                     = ".supports.policy.deltas";
-    public static final String  PLUGIN_CONFIG_SUFFIX_POLICY_DELTA                    = ".supports.policy.deltas";
-    public static final String  RANGER_ADMIN_SUFFIX_TAG_DELTA                        = ".supports.tag.deltas";
-    public static final String  PLUGIN_CONFIG_SUFFIX_TAG_DELTA                       = ".supports.tag.deltas";
-    public static final String  RANGER_ADMIN_SUFFIX_IN_PLACE_POLICY_UPDATES          = ".supports.in.place.policy.updates";
-    public static final String  PLUGIN_CONFIG_SUFFIX_IN_PLACE_POLICY_UPDATES         = ".supports.in.place.policy.updates";
-    public static final String  RANGER_ADMIN_SUFFIX_IN_PLACE_TAG_UPDATES             = ".supports.in.place.tag.updates";
-    public static final String  PLUGIN_CONFIG_SUFFIX_IN_PLACE_TAG_UPDATES            = ".supports.in.place.tag.updates";
+    public static final String PROP_COOKIE_NAME                             = "ranger.admin.cookie.name";
+    public static final String DEFAULT_COOKIE_NAME                          = "RANGERADMINSESSIONID";
+    public static final String RANGER_ADMIN_SUFFIX_POLICY_DELTA             = ".supports.policy.deltas";
+    public static final String PLUGIN_CONFIG_SUFFIX_POLICY_DELTA            = ".supports.policy.deltas";
+    public static final String RANGER_ADMIN_SUFFIX_TAG_DELTA                = ".supports.tag.deltas";
+    public static final String PLUGIN_CONFIG_SUFFIX_TAG_DELTA               = ".supports.tag.deltas";
+    public static final String RANGER_ADMIN_SUFFIX_IN_PLACE_POLICY_UPDATES  = ".supports.in.place.policy.updates";
+    public static final String PLUGIN_CONFIG_SUFFIX_IN_PLACE_POLICY_UPDATES = ".supports.in.place.policy.updates";
+    public static final String RANGER_ADMIN_SUFFIX_IN_PLACE_TAG_UPDATES     = ".supports.in.place.tag.updates";
+    public static final String PLUGIN_CONFIG_SUFFIX_IN_PLACE_TAG_UPDATES    = ".supports.in.place.tag.updates";
+    public static final String PLUGIN_CONFIG_SUFFIX_NAME_TRANSFORMATION     = ".supports.name.transformation";
+
+    public static final String  PLUGINS_USERNAME_CASE_CONVERSION_PARAM               = "ranger.plugins.ldap.username.caseconversion";
+    public static final String  PLUGINS_GROUPNAME_CASE_CONVERSION_PARAM              = "ranger.plugins.ldap.groupname.caseconversion";
+    public static final String  PLUGINS_MAPPING_USERNAME                             = "ranger.plugins.mapping.username.regex";
+    public static final String  PLUGINS_MAPPING_GROUPNAME                            = "ranger.plugins.mapping.groupname.regex";
+    public static final String  PLUGINS_MAPPING_USERNAME_HANDLER                     = "ranger.plugins.mapping.username.handler";
+    public static final String  PLUGINS_MAPPING_GROUPNAME_HANDLER                    = "ranger.plugins.mapping.groupname.handler";
+    public static final String  PLUGINS_MAPPING_SEPARATOR                            = "ranger.plugins.mapping.regex.separator";
     public static final String  RANGER_SUPPORTS_TAGS_DEDUP                           = ".supports.tags.dedup";
     public static final boolean RANGER_ADMIN_SUFFIX_POLICY_DELTA_DEFAULT             = false;
     public static final boolean PLUGIN_CONFIG_SUFFIX_POLICY_DELTA_DEFAULT            = false;

--- a/agents-common/src/main/java/org/apache/ranger/plugin/util/ServicePolicies.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/util/ServicePolicies.java
@@ -70,6 +70,7 @@ public class ServicePolicies implements java.io.Serializable {
         ret.setPolicyVersion(source.getPolicyVersion());
         ret.setAuditMode(source.getAuditMode());
         ret.setServiceDef(source.getServiceDef());
+        ret.setServiceConfig(source.getServiceConfig());
         ret.setPolicyUpdateTime(source.getPolicyUpdateTime());
         ret.setSecurityZones(source.getSecurityZones());
         ret.setPolicies(Collections.emptyList());

--- a/distro/src/main/assembly/admin-web.xml
+++ b/distro/src/main/assembly/admin-web.xml
@@ -237,6 +237,7 @@
           <include>org.eclipse.jdt.core.compiler:ecj:jar:P20140317-1600</include>
           <include>org.apache.hadoop:hadoop-auth:jar:${hadoop.version}</include>
           <include>org.apache.ranger:ranger-plugins-common</include>
+          <include>org.apache.ranger:ugsync-util</include>
           <include>org.slf4j:slf4j-api:jar:${slf4j.version}</include>
           <include>org.apache.hadoop:hadoop-common</include>
           <include>commons-logging:commons-logging</include>

--- a/distro/src/main/assembly/hbase-agent.xml
+++ b/distro/src/main/assembly/hbase-agent.xml
@@ -44,6 +44,7 @@
         <include>org.apache.ranger:ranger-plugins-audit</include>
         <include>org.apache.ranger:ranger-plugins-cred</include>
         <include>org.apache.ranger:ranger-plugins-common</include>
+        <include>org.apache.ranger:ugsync-util</include>
         <include>org.apache.ranger:ranger-hbase-plugin</include>
       </includes>
       <binaries>

--- a/distro/src/main/assembly/hdfs-agent.xml
+++ b/distro/src/main/assembly/hdfs-agent.xml
@@ -73,6 +73,7 @@
         <include>org.apache.ranger:ranger-plugins-audit</include>
         <include>org.apache.ranger:ranger-plugins-cred</include>
         <include>org.apache.ranger:ranger-plugins-common</include>
+        <include>org.apache.ranger:ugsync-util</include>
         <include>org.apache.ranger:ranger-hdfs-plugin</include>
       </includes>
       <binaries>

--- a/distro/src/main/assembly/hive-agent.xml
+++ b/distro/src/main/assembly/hive-agent.xml
@@ -44,6 +44,7 @@
         <include>org.apache.ranger:ranger-plugins-audit</include>
         <include>org.apache.ranger:ranger-plugins-cred</include>
         <include>org.apache.ranger:ranger-plugins-common</include>
+        <include>org.apache.ranger:ugsync-util</include>
         <include>org.apache.ranger:ranger-hive-plugin</include>
       </includes>
       <binaries>

--- a/distro/src/main/assembly/kms.xml
+++ b/distro/src/main/assembly/kms.xml
@@ -214,6 +214,7 @@
                     <include>org.apache.hadoop:hadoop-auth:jar:${hadoop.version}</include>
                     <include>org.apache.solr:solr-solrj:jar:${solr.version}</include>
                     <include>org.apache.ranger:ranger-plugins-common</include>
+                    <include>org.apache.ranger:ugsync-util</include>
                     <include>com.kstruct:gethostname4j:jar:${kstruct.gethostname4j.version}</include>
                     <include>net.java.dev.jna:jna:jar:${jna.version}</include>
                     <include>net.java.dev.jna:jna-platform:jar:${jna-platform.version}</include>
@@ -282,6 +283,7 @@
                 <include>org.apache.ranger:ranger-plugins-audit</include>
                 <include>org.apache.ranger:ranger-plugins-cred</include>
                 <include>org.apache.ranger:ranger-plugins-common</include>
+                <include>org.apache.ranger:ugsync-util</include>
                 <include>org.apache.ranger:ranger-kms-plugin</include>
             </includes>
             <binaries>

--- a/distro/src/main/assembly/knox-agent.xml
+++ b/distro/src/main/assembly/knox-agent.xml
@@ -45,6 +45,7 @@
         <include>org.apache.ranger:ranger-plugins-audit</include>
         <include>org.apache.ranger:ranger-plugins-cred</include>
         <include>org.apache.ranger:ranger-plugins-common</include>
+        <include>org.apache.ranger:ugsync-util</include>
         <include>org.apache.ranger:ranger-knox-plugin</include>
       </includes>
       <binaries>

--- a/distro/src/main/assembly/plugin-atlas.xml
+++ b/distro/src/main/assembly/plugin-atlas.xml
@@ -45,6 +45,7 @@
         <include>org.apache.ranger:ranger-plugins-audit</include>
         <include>org.apache.ranger:ranger-plugins-cred</include>
         <include>org.apache.ranger:ranger-plugins-common</include>
+        <include>org.apache.ranger:ugsync-util</include>
         <include>org.apache.ranger:ranger-atlas-plugin</include>
       </includes>
       <binaries>

--- a/distro/src/main/assembly/plugin-kafka.xml
+++ b/distro/src/main/assembly/plugin-kafka.xml
@@ -41,6 +41,7 @@
 				<include>org.apache.ranger:ranger-plugins-audit</include>
 				<include>org.apache.ranger:ranger-plugins-cred</include>
 				<include>org.apache.ranger:ranger-plugins-common</include>
+				<include>org.apache.ranger:ugsync-util</include>
 			</includes>
 			<binaries>
 				<outputDirectory>lib/ranger-kafka-plugin-impl</outputDirectory>

--- a/distro/src/main/assembly/plugin-kms.xml
+++ b/distro/src/main/assembly/plugin-kms.xml
@@ -44,6 +44,7 @@
         <include>org.apache.ranger:ranger-plugins-audit</include>
         <include>org.apache.ranger:ranger-plugins-cred</include>
         <include>org.apache.ranger:ranger-plugins-common</include>
+        <include>org.apache.ranger:ugsync-util</include>
         <include>org.apache.ranger:ranger-kms-plugin</include>
       </includes>
       <binaries>
@@ -82,6 +83,7 @@
       <includes>
         <include>org.apache.ranger:ranger-plugins-installer</include>
         <include>org.apache.ranger:credentialbuilder</include>
+        <include>org.apache.ranger:ugsync-util</include>
       </includes>
       <binaries>
         <outputDirectory>install/lib</outputDirectory>

--- a/distro/src/main/assembly/plugin-kylin.xml
+++ b/distro/src/main/assembly/plugin-kylin.xml
@@ -44,6 +44,7 @@
         <include>org.apache.ranger:ranger-plugins-audit</include>
         <include>org.apache.ranger:ranger-plugins-cred</include>
         <include>org.apache.ranger:ranger-plugins-common</include>
+        <include>org.apache.ranger:ugsync-util</include>
         <include>org.apache.ranger:ranger-kylin-plugin</include>
       </includes>
       <binaries>

--- a/distro/src/main/assembly/plugin-ozone.xml
+++ b/distro/src/main/assembly/plugin-ozone.xml
@@ -80,6 +80,7 @@
                 <include>org.apache.ranger:ranger-plugins-audit</include>
                 <include>org.apache.ranger:ranger-plugins-cred</include>
                 <include>org.apache.ranger:ranger-plugins-common</include>
+                <include>org.apache.ranger:ugsync-util</include>
                 <include>org.apache.ranger:ranger-ozone-plugin</include>
             </includes>
             <binaries>

--- a/distro/src/main/assembly/plugin-solr.xml
+++ b/distro/src/main/assembly/plugin-solr.xml
@@ -39,6 +39,7 @@
         <include>org.apache.ranger:ranger-plugins-audit</include>
         <include>org.apache.ranger:ranger-plugins-cred</include>
         <include>org.apache.ranger:ranger-plugins-common</include>
+        <include>org.apache.ranger:ugsync-util</include>
         <include>org.apache.ranger:ranger-solr-plugin</include>
       </includes>
       <binaries>

--- a/distro/src/main/assembly/plugin-sqoop.xml
+++ b/distro/src/main/assembly/plugin-sqoop.xml
@@ -44,6 +44,7 @@
         <include>org.apache.ranger:ranger-plugins-audit</include>
         <include>org.apache.ranger:ranger-plugins-cred</include>
         <include>org.apache.ranger:ranger-plugins-common</include>
+        <include>org.apache.ranger:ugsync-util</include>
         <include>org.apache.ranger:ranger-sqoop-plugin</include>
       </includes>
       <binaries>

--- a/distro/src/main/assembly/plugin-trino.xml
+++ b/distro/src/main/assembly/plugin-trino.xml
@@ -29,6 +29,7 @@
                 <include>org.apache.ranger:ranger-plugins-audit</include>
                 <include>org.apache.ranger:ranger-plugins-cred</include>
                 <include>org.apache.ranger:ranger-plugins-common</include>
+                <include>org.apache.ranger:ugsync-util</include>
                 <include>org.apache.ranger:ranger-trino-plugin</include>
             </includes>
             <binaries>

--- a/distro/src/main/assembly/ranger-tools.xml
+++ b/distro/src/main/assembly/ranger-tools.xml
@@ -66,6 +66,7 @@
               <include>org.codehaus.woodstox:stax2-api:jar:${codehaus.woodstox.stax2api.version}</include>
               <include>com.fasterxml.woodstox:woodstox-core:jar:${fasterxml.woodstox.version}</include>
               <include>org.apache.ranger:ranger-plugins-common</include>
+              <include>org.apache.ranger:ugsync-util</include>
               <include>org.apache.ranger:ranger-plugins-audit</include>
               <include>com.kstruct:gethostname4j:jar:${kstruct.gethostname4j.version}</include>
               <include>net.java.dev.jna:jna:jar:${jna.version}</include>

--- a/distro/src/main/assembly/sample-client.xml
+++ b/distro/src/main/assembly/sample-client.xml
@@ -29,6 +29,7 @@
                 <include>org.apache.ranger:sample-client</include>
                 <include>org.apache.ranger:ranger-intg</include>
                 <include>org.apache.ranger:ranger-plugins-common</include>
+                <include>org.apache.ranger:ugsync-util</include>
                 <include>org.apache.ranger:ranger-plugins-cred</include>
             </includes>
             <binaries>

--- a/distro/src/main/assembly/storm-agent.xml
+++ b/distro/src/main/assembly/storm-agent.xml
@@ -44,6 +44,7 @@
         <include>org.apache.ranger:ranger-plugins-audit</include>
         <include>org.apache.ranger:ranger-plugins-cred</include>
         <include>org.apache.ranger:ranger-plugins-common</include>
+        <include>org.apache.ranger:ugsync-util</include>
         <include>org.apache.ranger:ranger-storm-plugin</include>
       </includes>
       <binaries>

--- a/distro/src/main/assembly/tagsync.xml
+++ b/distro/src/main/assembly/tagsync.xml
@@ -57,6 +57,7 @@
 							<include>org.apache.ranger:credentialbuilder</include>
 							<include>org.apache.ranger:ranger-plugins-cred</include>
 							<include>org.apache.ranger:ranger-plugins-common</include>
+							<include>org.apache.ranger:ugsync-util</include>
 							<include>org.apache.ranger:ranger-util</include>
 							<include>org.apache.zookeeper:zookeeper:jar:${zookeeper.version}</include>
 							<include>com.fasterxml.jackson.core:jackson-annotations:jar:${atlas.jackson.version}</include>

--- a/distro/src/main/assembly/usersync.xml
+++ b/distro/src/main/assembly/usersync.xml
@@ -56,6 +56,7 @@
 							<include>org.apache.httpcomponents:httpclient:jar:${httpcomponents.httpclient.version}</include>
 							<include>commons-codec:commons-codec</include>
 							<include>org.apache.ranger:ranger-plugins-common</include>
+							<include>org.apache.ranger:ugsync-util</include>
 							<include>org.apache.ranger:ranger-common-ha:jar:${project.version}</include>
 							<include>org.apache.curator:curator-framework:jar:${curator.version}</include>
 							<include>org.apache.curator:curator-recipes:jar:${curator.version}</include>

--- a/security-admin/src/main/java/org/apache/ranger/biz/XUserMgr.java
+++ b/security-admin/src/main/java/org/apache/ranger/biz/XUserMgr.java
@@ -177,9 +177,6 @@ public class XUserMgr extends XUserMgrBase {
     ServiceDBStore svcStore;
 
     @Autowired
-    GUIDUtil guidUtil;
-
-    @Autowired
     XUgsyncAuditInfoService xUgsyncAuditInfoService;
 
     @Autowired

--- a/security-admin/src/main/java/org/apache/ranger/common/RangerServicePoliciesCache.java
+++ b/security-admin/src/main/java/org/apache/ranger/common/RangerServicePoliciesCache.java
@@ -285,8 +285,8 @@ public class RangerServicePoliciesCache {
     }
 
     private class ServicePoliciesWrapper {
-        final Long               serviceId;
-        final ReentrantLock      lock                  = new ReentrantLock();
+        final Long          serviceId;
+        final ReentrantLock lock = new ReentrantLock();
         ServicePolicies          servicePolicies;
         Date                     updateTime;
         long                     longestDbLoadTimeInMs = -1;
@@ -362,8 +362,14 @@ public class RangerServicePoliciesCache {
                                 if (isDeltaCacheReinitialized) {
                                     this.deltaCache = new ServicePolicyDeltasCache(lastKnownVersion, servicePoliciesForDeltas);
                                 }
+                                if (LOG.isDebugEnabled()) {
+                                    LOG.debug("servicePoliciesForDeltas = " + servicePoliciesForDeltas.getServiceConfig());
+                                }
 
                                 ret = servicePoliciesForDeltas;
+                                if (LOG.isDebugEnabled()) {
+                                    LOG.debug("ret = " + ret.getServiceConfig());
+                                }
                             } else {
                                 LOG.warn("Deltas were requested for service:[{}], but could not get them!! lastKnownVersion:[{}]; Returning cached ServicePolicies:[{}]", serviceName, lastKnownVersion, servicePolicies != null ? servicePolicies.getPolicyVersion() : -1L);
 

--- a/security-admin/src/main/java/org/apache/ranger/rest/ServiceREST.java
+++ b/security-admin/src/main/java/org/apache/ranger/rest/ServiceREST.java
@@ -2672,6 +2672,12 @@ public class ServiceREST {
             throw restErrorUtil.createRESTException(httpCode, logMsg, logError);
         }
 
+        if (LOG.isDebugEnabled()) {
+            if (ret != null) {
+                LOG.debug("<== ServiceREST.getSecureServicePoliciesIfUpdated(): configs =" + ret.getServiceConfig());
+            }
+        }
+
         LOG.debug("<== ServiceREST.getSecureServicePoliciesIfUpdated({}, {}, {}, {}, {}, {}) : count={}", serviceName, lastKnownVersion, lastActivationTime, pluginId, clusterName, supportsPolicyDeltas, ((ret == null || ret.getPolicies() == null) ? 0 : ret.getPolicies().size()));
 
         return ret;

--- a/ugsync-util/pom.xml
+++ b/ugsync-util/pom.xml
@@ -47,6 +47,28 @@
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>${log4j2.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>log4j-over-slf4j</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <profiles>
@@ -71,6 +93,7 @@
                     <artifactId>jaxb-api</artifactId>
                     <version>2.3.1</version>
                 </dependency>
+
             </dependencies>
         </profile>
     </profiles>

--- a/ugsync-util/src/main/java/org/apache/ranger/ugsyncutil/transform/AbstractMapper.java
+++ b/ugsync-util/src/main/java/org/apache/ranger/ugsyncutil/transform/AbstractMapper.java
@@ -17,10 +17,24 @@
  * under the License.
  */
 
-package org.apache.ranger.usergroupsync;
+package org.apache.ranger.ugsyncutil.transform;
 
-public interface Mapper {
-    void init(String baseProperty);
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-    String transform(String attrValue);
+import java.util.List;
+
+public abstract class AbstractMapper implements Mapper {
+    protected static final Logger logger = LoggerFactory.getLogger(AbstractMapper.class);
+
+    @Override
+    public void init(String baseProperty, List<String> regexPatterns, String regexSeparator) {
+        // TODO Auto-generated method stub
+    }
+
+    @Override
+    public String transform(String attrValue) {
+        // TODO Auto-generated method stub
+        return null;
+    }
 }

--- a/ugsync-util/src/main/java/org/apache/ranger/ugsyncutil/transform/Mapper.java
+++ b/ugsync-util/src/main/java/org/apache/ranger/ugsyncutil/transform/Mapper.java
@@ -17,22 +17,12 @@
  * under the License.
  */
 
-package org.apache.ranger.usergroupsync;
+package org.apache.ranger.ugsyncutil.transform;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.List;
 
-public abstract class AbstractMapper implements Mapper {
-    protected static final Logger logger = LoggerFactory.getLogger(AbstractMapper.class);
+public interface Mapper {
+    void init(String baseProperty, List<String> regexPatterns, String regexSeparator);
 
-    @Override
-    public void init(String baseProperty) {
-        // TODO Auto-generated method stub
-    }
-
-    @Override
-    public String transform(String attrValue) {
-        // TODO Auto-generated method stub
-        return null;
-    }
+    String transform(String attrValue);
 }

--- a/ugsync-util/src/main/java/org/apache/ranger/ugsyncutil/transform/RegEx.java
+++ b/ugsync-util/src/main/java/org/apache/ranger/ugsyncutil/transform/RegEx.java
@@ -17,9 +17,7 @@
  * under the License.
  */
 
-package org.apache.ranger.usergroupsync;
-
-import org.apache.ranger.unixusersync.config.UserGroupSyncConfig;
+package org.apache.ranger.ugsyncutil.transform;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -27,24 +25,19 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class RegEx extends AbstractMapper {
-    private final UserGroupSyncConfig           config = UserGroupSyncConfig.getInstance();
-    private       LinkedHashMap<String, String> replacementPattern;
+    private LinkedHashMap<String, String> replacementPattern;
 
     public LinkedHashMap<String, String> getReplacementPattern() {
         return replacementPattern;
     }
 
     @Override
-    public void init(String baseProperty) {
-        logger.info("Initializing for {}", baseProperty);
-
+    public void init(String baseProperty, List<String> regexPatterns, String regexSeparator) {
+        AbstractMapper.logger.info("Initializing for " + baseProperty);
         try {
-            List<String> regexPatterns  = config.getAllRegexPatterns(baseProperty);
-            String       regexSeparator = config.getRegexSeparator();
-
             populateReplacementPatterns(baseProperty, regexPatterns, regexSeparator);
         } catch (Throwable t) {
-            logger.error("Failed to initialize {}", baseProperty, t.fillInStackTrace());
+            AbstractMapper.logger.error("Failed to initialize " + baseProperty, t.fillInStackTrace());
         }
     }
 
@@ -63,13 +56,13 @@ public class RegEx extends AbstractMapper {
                 }
             }
         } catch (Throwable t) {
-            logger.error("Failed to transform {}", attrValue, t.fillInStackTrace());
+            AbstractMapper.logger.error("Failed to transform " + attrValue, t.fillInStackTrace());
         }
 
         return result;
     }
 
-    protected void populateReplacementPatterns(String baseProperty, List<String> regexPatterns, String regexSeparator) {
+    public void populateReplacementPatterns(String baseProperty, List<String> regexPatterns, String regexSeparator) {
         replacementPattern = new LinkedHashMap<>();
 
         String  regex = String.format("s%s([^%s]*)%s([^%s]*)%s(g)?", regexSeparator, regexSeparator, regexSeparator, regexSeparator, regexSeparator);
@@ -79,7 +72,7 @@ public class RegEx extends AbstractMapper {
             Matcher m = p.matcher(regexPattern);
 
             if (!m.matches()) {
-                logger.warn("Invalid RegEx {} and hence skipping this regex property", regexPattern);
+                AbstractMapper.logger.warn("Invalid RegEx " + regexPattern + " and hence skipping this regex property");
             }
 
             m = m.reset();

--- a/ugsync-util/src/main/java/org/apache/ranger/ugsyncutil/util/UgsyncCommonConstants.java
+++ b/ugsync-util/src/main/java/org/apache/ranger/ugsyncutil/util/UgsyncCommonConstants.java
@@ -25,6 +25,30 @@ public class UgsyncCommonConstants {
     public static final String SYNC_SOURCE   = "sync_source";
     public static final String LDAP_URL      = "ldap_url";
 
+    public static final String UGSYNC_NONE_CASE_CONVERSION_VALUE = "none";
+    public static final String UGSYNC_LOWER_CASE_CONVERSION_VALUE = "lower";
+    public static final String UGSYNC_UPPER_CASE_CONVERSION_VALUE = "upper";
+
+    public static final String UGSYNC_USERNAME_CASE_CONVERSION_PARAM = "ranger.usersync.ldap.username.caseconversion";
+    public static final String DEFAULT_UGSYNC_USERNAME_CASE_CONVERSION_VALUE = UGSYNC_NONE_CASE_CONVERSION_VALUE;
+
+    public static final String UGSYNC_GROUPNAME_CASE_CONVERSION_PARAM = "ranger.usersync.ldap.groupname.caseconversion";
+    public static final String DEFAULT_UGSYNC_GROUPNAME_CASE_CONVERSION_VALUE = UGSYNC_NONE_CASE_CONVERSION_VALUE;
+
+    public static final String SYNC_MAPPING_USERNAME = "ranger.usersync.mapping.username.regex";
+
+    public static final String SYNC_MAPPING_GROUPNAME = "ranger.usersync.mapping.groupname.regex";
+
+    public static final String SYNC_MAPPING_USERNAME_HANDLER = "ranger.usersync.mapping.username.handler";
+    public static final String DEFAULT_SYNC_MAPPING_USERNAME_HANDLER = "org.apache.ranger.ugsyncutil.transform.RegEx";
+
+    public static final String SYNC_MAPPING_GROUPNAME_HANDLER = "ranger.usersync.mapping.groupname.handler";
+    public static final String DEFAULT_SYNC_MAPPING_GROUPNAME_HANDLER = "org.apache.ranger.ugsyncutil.transform.RegEx";
+
+    public static final String SYNC_MAPPING_SEPARATOR = "ranger.usersync.mapping.regex.separator";
+
+    public static final String DEFAULT_MAPPING_SEPARATOR = "/";
+
     private UgsyncCommonConstants() {
         // to block instantiation
     }

--- a/ugsync-util/src/test/java/org/apache/ranger/ugsynutil/transform/TestRegEx.java
+++ b/ugsync-util/src/test/java/org/apache/ranger/ugsynutil/transform/TestRegEx.java
@@ -17,16 +17,16 @@
  * under the License.
  */
 
-package org.apache.ranger.usergroupsync;
+package org.apache.ranger.ugsynutil.transform;
 
+import org.apache.ranger.ugsyncutil.transform.RegEx;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-
-import static org.junit.Assert.assertEquals;
 
 public class TestRegEx {
     protected String userNameBaseProperty  = "ranger.usersync.mapping.username.regex";
@@ -49,7 +49,7 @@ public class TestRegEx {
     public void testUserNameTransform() {
         userRegexPatterns.add("s/\\s/_/");
         userNameRegEx.populateReplacementPatterns(userNameBaseProperty, userRegexPatterns, mappingSeparator);
-        assertEquals("test_user", userNameRegEx.transform("test user"));
+        Assert.assertEquals("test_user", userNameRegEx.transform("test user"));
     }
 
     @Test
@@ -57,13 +57,13 @@ public class TestRegEx {
         groupRegexPatterns.add("s/\\s/_/g");
         groupRegexPatterns.add("s/_/\\$/g");
         groupNameRegEx.populateReplacementPatterns(groupNameBaseProperty, groupRegexPatterns, mappingSeparator);
-        assertEquals("ldap$grp", groupNameRegEx.transform("ldap grp"));
+        Assert.assertEquals("ldap$grp", groupNameRegEx.transform("ldap grp"));
     }
 
     @Test
     public void testEmptyTransform() {
-        assertEquals("test user", userNameRegEx.transform("test user"));
-        assertEquals("ldap grp", groupNameRegEx.transform("ldap grp"));
+        Assert.assertEquals("test user", userNameRegEx.transform("test user"));
+        Assert.assertEquals("ldap grp", groupNameRegEx.transform("ldap grp"));
     }
 
     @Test
@@ -72,8 +72,8 @@ public class TestRegEx {
         groupRegexPatterns.add("s/\\s/_/g");
         userNameRegEx.populateReplacementPatterns(userNameBaseProperty, userRegexPatterns, mappingSeparator);
         groupNameRegEx.populateReplacementPatterns(groupNameBaseProperty, groupRegexPatterns, mappingSeparator);
-        assertEquals("test_user", userNameRegEx.transform("test user"));
-        assertEquals("ldap_grp", groupNameRegEx.transform("ldap grp"));
+        Assert.assertEquals("test_user", userNameRegEx.transform("test user"));
+        Assert.assertEquals("ldap_grp", groupNameRegEx.transform("ldap grp"));
     }
 
     @Test
@@ -85,8 +85,8 @@ public class TestRegEx {
         groupRegexPatterns.add("s/\\s");
         groupRegexPatterns.add("s/\\$//g");
         groupNameRegEx.populateReplacementPatterns(groupNameBaseProperty, groupRegexPatterns, mappingSeparator);
-        assertEquals("test user", userNameRegEx.transform("test\\user"));
-        assertEquals("ldapgrp", groupNameRegEx.transform("ldap grp"));
+        Assert.assertEquals("test user", userNameRegEx.transform("test\\user"));
+        Assert.assertEquals("ldapgrp", groupNameRegEx.transform("ldap grp"));
     }
 
     @Test
@@ -96,7 +96,7 @@ public class TestRegEx {
             userRegexPatterns = new ArrayList<>();
             userRegexPatterns.add(String.format("s%sdark%sDE/dark%sg", separator, separator, separator));
             userNameRegEx.populateReplacementPatterns(userNameBaseProperty, userRegexPatterns, separator);
-            assertEquals("DE/dark_knight_admin", userNameRegEx.transform("dark_knight_admin"));
+            Assert.assertEquals("DE/dark_knight_admin", userNameRegEx.transform("dark_knight_admin"));
         }
     }
 
@@ -106,10 +106,10 @@ public class TestRegEx {
         String separator = "#";
         userRegexPatterns = Collections.singletonList("s#^(.*)#PR/$1#g");
         userNameRegEx.populateReplacementPatterns(userNameBaseProperty, userRegexPatterns, separator);
-        assertEquals("PR/mew_two", userNameRegEx.transform("mew_two"));
-        assertEquals("PR/dragoon", userNameRegEx.transform("dragoon"));
-        assertEquals("PR/pikachu", userNameRegEx.transform("pikachu"));
-        assertEquals("PR/dialga", userNameRegEx.transform("dialga"));
+        Assert.assertEquals("PR/mew_two", userNameRegEx.transform("mew_two"));
+        Assert.assertEquals("PR/dragoon", userNameRegEx.transform("dragoon"));
+        Assert.assertEquals("PR/pikachu", userNameRegEx.transform("pikachu"));
+        Assert.assertEquals("PR/dialga", userNameRegEx.transform("dialga"));
     }
 
     @Test
@@ -118,7 +118,7 @@ public class TestRegEx {
         String separator = "#";
         userRegexPatterns = Collections.singletonList("s#^(.*)#$1_ty#g");
         userNameRegEx.populateReplacementPatterns(userNameBaseProperty, userRegexPatterns, separator);
-        assertEquals("mew_ty", userNameRegEx.transform("mew"));
-        assertEquals("onix_ty", userNameRegEx.transform("onix"));
+        Assert.assertEquals("mew_ty", userNameRegEx.transform("mew"));
+        Assert.assertEquals("onix_ty", userNameRegEx.transform("onix"));
     }
 }

--- a/ugsync/src/main/java/org/apache/ranger/unixusersync/config/UserGroupSyncConfig.java
+++ b/ugsync/src/main/java/org/apache/ranger/unixusersync/config/UserGroupSyncConfig.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.ranger.credentialapi.CredentialReader;
 import org.apache.ranger.plugin.util.RangerCommonConstants;
 import org.apache.ranger.plugin.util.XMLUtils;
+import org.apache.ranger.ugsyncutil.util.UgsyncCommonConstants;
 import org.apache.ranger.unixusersync.ha.UserSyncHAInitializerImpl;
 import org.apache.ranger.usergroupsync.UserGroupSink;
 import org.apache.ranger.usergroupsync.UserGroupSource;
@@ -36,212 +37,173 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.security.KeyStore;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.StringTokenizer;
 
 public class UserGroupSyncConfig {
-    private static final Logger LOG                                                                  = LoggerFactory.getLogger(UserGroupSyncConfig.class);
-
-    private static final String CORE_SITE_CONFIG_FILE                                                = "core-site.xml";
-
-    public static final String CONFIG_FILE                                                           = "ranger-ugsync-site.xml";
-    public static final String DEFAULT_CONFIG_FILE                                                   = "ranger-ugsync-default.xml";
-    public static final String UGSYNC_ENABLED_PROP                                                   = "ranger.usersync.enabled";
-
-    private static final String UGSYNC_SOURCE_CLASS_PARAM                                            = "ranger.usersync.source.impl.class";
-    private static final String UGSYNC_SINK_CLASS_PARAM                                              = "ranger.usersync.sink.impl.class";
-    private static final String UGSYNC_SOURCE_CLASS                                                  = "org.apache.ranger.unixusersync.process.UnixUserGroupBuilder";
-    private static final String UGSYNC_SINK_CLASS                                                    = "org.apache.ranger.unixusersync.process.PolicyMgrUserGroupBuilder";
-    private static final String LGSYNC_SOURCE_CLASS                                                  = "org.apache.ranger.ldapusersync.process.LdapUserGroupBuilder";
-
+    public static final String CONFIG_FILE         = "ranger-ugsync-site.xml";
+    public static final String DEFAULT_CONFIG_FILE = "ranger-ugsync-default.xml";
+    public static final String UGSYNC_ENABLED_PROP = "ranger.usersync.enabled";
+    /* Unix Configs */
+    public static final String UGSYNC_MIN_USERID_PROP    = "ranger.usersync.unix.minUserId";
+    public static final String UGSYNC_MIN_GROUPID_PROP   = "ranger.usersync.unix.minGroupId";
+    public static final String UGSYNC_UNIX_PASSWORD_FILE = "ranger.usersync.unix.password.file";
+    public static final String UGSYNC_UNIX_GROUP_FILE    = "ranger.usersync.unix.group.file";
+    /* Unix Defaults */
+    public static final String DEFAULT_UGSYNC_UNIX_GROUP_FILE    = "/etc/group";
+    public static final String DEFAULT_UGSYNC_UNIX_PASSWORD_FILE = "/etc/passwd";
+    public static final String DEFAULT_UGSYNC_MIN_GROUPID        = "0";
+    /* File Sync Configs */
+    public static final String UGSYNC_SOURCE_FILE_PROC        = "ranger.usersync.filesource.file";
+    public static final String UGSYNC_SOURCE_FILE_DELIMITER   = "ranger.usersync.filesource.text.delimiter";
+    public static final String UGSYNC_SOURCE_FILE_DELIMITERER = "ranger.usersync.filesource.text.delimiterer";
+    /* Metrics */
+    public static final String UGSYNC_METRICS_ENABLED_PROP = "ranger.usersync.metrics.enabled";
+    /* Policy Manager Configs */
+    public static final String UGSYNC_PM_URL_PROP                   = "ranger.usersync.policymanager.baseURL";
+    public static final String UGSYNC_MAX_RECORDS_PER_API_CALL_PROP = "ranger.usersync.policymanager.maxrecordsperapicall";
+    public static final String UGSYNC_MOCK_RUN_PROP                 = "ranger.usersync.policymanager.mockrun";
+    public static final String UGSYNC_TEST_RUN_PROP                 = "ranger.usersync.policymanager.testrun";
+    /* Other Configs */
+    public static final  String UGSYNC_SERVER_HA_ENABLED_PARAM                  = "ranger-ugsync.server.ha.enabled";
+    public static final  String UGSYNC_NAME_VALIDATION_ENABLED                  = "ranger.usersync.name.validation.enabled";
+    public static final  String UGSYNC_SYNC_SOURCE_VALIDATION_ENABLED           = "ranger.usersync.syncsource.validation.enabled";
+    private static final Logger LOG = LoggerFactory.getLogger(UserGroupSyncConfig.class);
+    private static final String CORE_SITE_CONFIG_FILE = "core-site.xml";
+    private static final String UGSYNC_SOURCE_CLASS_PARAM = "ranger.usersync.source.impl.class";
+    private static final String UGSYNC_SINK_CLASS_PARAM   = "ranger.usersync.sink.impl.class";
+    private static final String UGSYNC_SOURCE_CLASS       = "org.apache.ranger.unixusersync.process.UnixUserGroupBuilder";
+    private static final String UGSYNC_SINK_CLASS         = "org.apache.ranger.unixusersync.process.PolicyMgrUserGroupBuilder";
+    private static final String LGSYNC_SOURCE_CLASS       = "org.apache.ranger.ldapusersync.process.LdapUserGroupBuilder";
     /* LDAP Configs */
-    private static final String LGSYNC_LDAP_URL                                                      = "ranger.usersync.ldap.url";
-    private static final String LGSYNC_LDAP_AUTHENTICATION_MECHANISM                                 = "ranger.usersync.ldap.authentication.mechanism";
-    private static final String LGSYNC_REFERRAL                                                      = "ranger.usersync.ldap.referral";
-    private static final String LGSYNC_LDAP_BIND_DN                                                  = "ranger.usersync.ldap.binddn";
-    private static final String LGSYNC_LDAP_BIND_ALIAS                                               = "ranger.usersync.ldap.bindalias";
-    private static final String LGSYNC_LDAP_BIND_PASSWORD                                            = "ranger.usersync.ldap.ldapbindpassword";
-    private static final String LGSYNC_SEARCH_BASE                                                   = "ranger.usersync.ldap.searchBase";
-    private static final String LGSYNC_USER_SEARCH_BASE                                              = "ranger.usersync.ldap.user.searchbase";
-    private static final String LGSYNC_USER_SEARCH_SCOPE                                             = "ranger.usersync.ldap.user.searchscope";
-    private static final String LGSYNC_USER_OBJECT_CLASS                                             = "ranger.usersync.ldap.user.objectclass";
-    private static final String LGSYNC_USER_SEARCH_FILTER                                            = "ranger.usersync.ldap.user.searchfilter";
-    private static final String LGSYNC_USER_NAME_ATTRIBUTE                                           = "ranger.usersync.ldap.user.nameattribute";
-    private static final String LGSYNC_USER_GROUP_NAME_ATTRIBUTE                                     = "ranger.usersync.ldap.user.groupnameattribute";
-    private static final String LGSYNC_OTHER_USER_ATTRIBUTES                                         = "ranger.usersync.ldap.user.otherattributes";
-    private static final String LGSYNC_USER_CLOUDID_ATTRIBUTE                                        = "ranger.usersync.ldap.user.cloudid.attribute";
-    private static final String LGSYNC_USER_CLOUDID_ATTRIBUTE_DATATYPE                               = "ranger.usersync.ldap.user.cloudid.attribute.datatype";
-    private static final String UGSYNC_USERNAME_CASE_CONVERSION_PARAM                                = "ranger.usersync.ldap.username.caseconversion";
+    private static final String LGSYNC_LDAP_URL                        = "ranger.usersync.ldap.url";
+    private static final String LGSYNC_LDAP_AUTHENTICATION_MECHANISM   = "ranger.usersync.ldap.authentication.mechanism";
+    private static final String LGSYNC_REFERRAL                        = "ranger.usersync.ldap.referral";
+    private static final String LGSYNC_LDAP_BIND_DN                    = "ranger.usersync.ldap.binddn";
+    private static final String LGSYNC_LDAP_BIND_ALIAS                 = "ranger.usersync.ldap.bindalias";
+    private static final String LGSYNC_LDAP_BIND_PASSWORD              = "ranger.usersync.ldap.ldapbindpassword";
+    private static final String LGSYNC_SEARCH_BASE                     = "ranger.usersync.ldap.searchBase";
+    private static final String LGSYNC_USER_SEARCH_BASE                = "ranger.usersync.ldap.user.searchbase";
+    private static final String LGSYNC_USER_SEARCH_SCOPE               = "ranger.usersync.ldap.user.searchscope";
+    private static final String LGSYNC_USER_OBJECT_CLASS               = "ranger.usersync.ldap.user.objectclass";
+    private static final String LGSYNC_USER_SEARCH_FILTER              = "ranger.usersync.ldap.user.searchfilter";
+    private static final String LGSYNC_USER_NAME_ATTRIBUTE             = "ranger.usersync.ldap.user.nameattribute";
+    private static final String LGSYNC_USER_GROUP_NAME_ATTRIBUTE       = "ranger.usersync.ldap.user.groupnameattribute";
+    private static final String LGSYNC_OTHER_USER_ATTRIBUTES           = "ranger.usersync.ldap.user.otherattributes";
+    private static final String LGSYNC_USER_CLOUDID_ATTRIBUTE          = "ranger.usersync.ldap.user.cloudid.attribute";
+    private static final String LGSYNC_USER_CLOUDID_ATTRIBUTE_DATATYPE = "ranger.usersync.ldap.user.cloudid.attribute.datatype";
+
+    /* LDAP Defaults */
     /**
      * ranger.usersync.user.searchenabled is used only when group search first is enabled to get username from -
      * 1. the group member attribute of the group or
      * 2. the additional user search based on the user attribute configuration
      */
-    private static final String LGSYNC_USER_SEARCH_ENABLED                                           = "ranger.usersync.user.searchenabled";
-
-    private static final String LGSYNC_GROUP_SEARCH_BASE                                             = "ranger.usersync.group.searchbase";
-    private static final String LGSYNC_GROUP_SEARCH_SCOPE                                            = "ranger.usersync.group.searchscope";
-    private static final String LGSYNC_GROUP_OBJECT_CLASS                                            = "ranger.usersync.group.objectclass";
-    private static final String LGSYNC_GROUP_SEARCH_FILTER                                           = "ranger.usersync.group.searchfilter";
-    private static final String LGSYNC_GROUP_NAME_ATTRIBUTE                                          = "ranger.usersync.group.nameattribute";
-    private static final String LGSYNC_GROUP_MEMBER_ATTRIBUTE_NAME                                   = "ranger.usersync.group.memberattributename";
-    private static final String LGSYNC_GROUP_SEARCH_ENABLED                                          = "ranger.usersync.group.searchenabled";
-    private static final String LGSYNC_GROUP_SEARCH_FIRST_ENABLED                                    = "ranger.usersync.group.search.first.enabled";
-    private static final String LGSYNC_GROUPNAMES                                                    = "ranger.usersync.ldap.groupnames";
-    private static final String LGSYNC_OTHER_GROUP_ATTRIBUTES                                        = "ranger.usersync.ldap.group.otherattributes";
-    private static final String LGSYNC_GROUP_CLOUDID_ATTRIBUTE                                       = "ranger.usersync.ldap.group.cloudid.attribute";
-    private static final String LGSYNC_GROUP_CLOUDID_ATTRIBUTE_DATATYPE                              = "ranger.usersync.ldap.group.cloudid.attribute.datatype";
-    private static final String UGSYNC_GROUPNAME_CASE_CONVERSION_PARAM                               = "ranger.usersync.ldap.groupname.caseconversion";
-    private static final String LGSYNC_GROUP_HIERARCHY_LEVELS                                        = "ranger.usersync.ldap.grouphierarchylevels";
-
-    private static final String LGSYNC_LDAP_BIND_KEYSTORE                                            = "ranger.usersync.credstore.filename";
-    private static final String LGSYNC_LDAP_DELTASYNC_ENABLED                                        = "ranger.usersync.ldap.deltasync";
-    private static final String LGSYNC_LDAP_STARTTLS_ENABLED                                         = "ranger.usersync.ldap.starttls";
-    private static final String UGSYNC_SLEEP_LDAP_FORCE_TIME_IN_MILLIS_BETWEEN_CYCLE_PARAM_ENABLED   = "ranger.usersync.ldap.force.sleeptimeinmillisbetweensynccycle.enabled";
-
-    /* LDAP Defaults */
-    public static final String UGSYNC_NONE_CASE_CONVERSION_VALUE                                     = "none";
-    public static final String UGSYNC_LOWER_CASE_CONVERSION_VALUE                                    = "lower";
-    public static final String UGSYNC_UPPER_CASE_CONVERSION_VALUE                                    = "upper";
-
-    private static final String DEFAULT_AUTHENTICATION_MECHANISM                                     = "simple";
-    private static final String DEFAULT_USER_OBJECT_CLASS                                            = "person";
-    private static final String DEFAULT_USER_NAME_ATTRIBUTE                                          = "cn";
-    private static final String DEFAULT_USER_GROUP_NAME_ATTRIBUTE                                    = "memberof,ismemberof";
-    private static final String DEFAULT_USER_CLOUDID_ATTRIBUTE                                       = "objectid";
-    private static final String DEFAULT_USER_CLOUDID_ATTRIBUTE_DATATYPE                              = "byte[]";
-    private static final String DEFAULT_OTHER_USER_ATTRIBUTES                                        = "userurincipaluame,";
-    private static final String DEFAULT_UGSYNC_USERNAME_CASE_CONVERSION_VALUE                        = UGSYNC_NONE_CASE_CONVERSION_VALUE;
-
-    private static final String  DEFAULT_LGSYNC_GROUP_OBJECT_CLASS                                   = "groupofnames";
-    private static final String  DEFAULT_LGSYNC_GROUP_NAME_ATTRIBUTE                                 = "cn";
-    private static final String  DEFAULT_LGSYNC_GROUP_MEMBER_ATTRIBUTE_NAME                          = "member";
-    private static final String  DEFAULT_GROUP_CLOUDID_ATTRIBUTE                                     = "objectid";
-    private static final String  DEFAULT_GROUP_CLOUDID_ATTRIBUTE_DATATYPE                            = "byte[]";
-    private static final String  DEFAULT_OTHER_GROUP_ATTRIBUTES                                      = "displayname,";
-    private static final String  DEFAULT_UGSYNC_GROUPNAME_CASE_CONVERSION_VALUE                      = UGSYNC_NONE_CASE_CONVERSION_VALUE;
-    private static final String  DEFAULT_LGSYNC_REFERRAL                                             = "ignore";
-    private static final int     DEFAULT_LGSYNC_GROUP_HIERARCHY_LEVELS                               = 0;
-    private static final int     DEFAULT_LGSYNC_PAGED_RESULTS_SIZE                                   = 500;
-    private static final boolean DEFAULT_LGSYNC_LDAP_DELTASYNC_ENABLED                               = false;
-    private static final boolean DEFAULT_LGSYNC_LDAP_STARTTLS_ENABLED                                = false;
-    private static final boolean DEFAULT_LGSYNC_PAGED_RESULTS_ENABLED                                = true;
-    private static final boolean DEFAULT_LGSYNC_GROUP_SEARCH_ENABLED                                 = true;
-    private static final boolean DEFAULT_LGSYNC_USER_SEARCH_ENABLED                                  = true;
-    private static final boolean DEFAULT_LGSYNC_GROUP_SEARCH_FIRST_ENABLED                           = true;
-
-    /* Unix Configs */
-    public static final String UGSYNC_MIN_USERID_PROP                                                = "ranger.usersync.unix.minUserId";
-    public static final String UGSYNC_MIN_GROUPID_PROP                                               = "ranger.usersync.unix.minGroupId";
-    public static final String UGSYNC_UNIX_PASSWORD_FILE                                             = "ranger.usersync.unix.password.file";
-    public static final String UGSYNC_UNIX_GROUP_FILE                                                = "ranger.usersync.unix.group.file";
-
-    private static final String UGSYNC_GROUP_ENUMERATE_ENABLED                                       = "ranger.usersync.group.enumerate";
-    private static final String UGSYNC_GROUP_ENUMERATE_GROUPS                                        = "ranger.usersync.group.enumerategroup";
-    private static final String UGSYNC_UNIX_BACKEND                                                  = "ranger.usersync.unix.backend";
-
-    /* Unix Defaults */
-    public static final String DEFAULT_UGSYNC_UNIX_GROUP_FILE                                        = "/etc/group";
-    public static final String DEFAULT_UGSYNC_UNIX_PASSWORD_FILE                                     = "/etc/passwd";
-    public static final String DEFAULT_UGSYNC_MIN_GROUPID                                            = "0";
-
-    private static final String DEFAULT_UGSYNC_UNIX_BACKEND                                          = "passwd";
-    private static final String UGSYNC_UPDATE_MILLIS_MIN                                             = "ranger.usersync.unix.updatemillismin";
-
-    /* File Sync Configs */
-    public static final String UGSYNC_SOURCE_FILE_PROC                                               = "ranger.usersync.filesource.file";
-    public static final String UGSYNC_SOURCE_FILE_DELIMITER                                          = "ranger.usersync.filesource.text.delimiter";
-    public static final String UGSYNC_SOURCE_FILE_DELIMITERER                                        = "ranger.usersync.filesource.text.delimiterer";
-
-    private static final String DEFAULT_USER_GROUP_TEXTFILE_DELIMITER                                = ",";
-
-    /* RegEx */
-    public static final String SYNC_MAPPING_USERNAME                                                 = "ranger.usersync.mapping.username.regex";
-    public static final String SYNC_MAPPING_GROUPNAME                                                = "ranger.usersync.mapping.groupname.regex";
-
-    private static final String SYNC_MAPPING_USERNAME_HANDLER                                        = "ranger.usersync.mapping.username.handler";
-    private static final String SYNC_MAPPING_GROUPNAME_HANDLER                                       = "ranger.usersync.mapping.groupname.handler";
-    private static final String SYNC_MAPPING_SEPARATOR                                               = "ranger.usersync.mapping.regex.separator";
-
-    private static final String DEFAULT_SYNC_MAPPING_USERNAME_HANDLER                                = "org.apache.ranger.usergroupsync.RegEx";
-    private static final String DEFAULT_SYNC_MAPPING_GROUPNAME_HANDLER                               = "org.apache.ranger.usergroupsync.RegEx";
-
-    private static final String DEFAULT_MAPPING_SEPARATOR                                            = "/";
-
+    private static final String LGSYNC_USER_SEARCH_ENABLED             = "ranger.usersync.user.searchenabled";
+    private static final String LGSYNC_GROUP_SEARCH_BASE                = "ranger.usersync.group.searchbase";
+    private static final String LGSYNC_GROUP_SEARCH_SCOPE               = "ranger.usersync.group.searchscope";
+    private static final String LGSYNC_GROUP_OBJECT_CLASS               = "ranger.usersync.group.objectclass";
+    private static final String LGSYNC_GROUP_SEARCH_FILTER              = "ranger.usersync.group.searchfilter";
+    private static final String LGSYNC_GROUP_NAME_ATTRIBUTE             = "ranger.usersync.group.nameattribute";
+    private static final String LGSYNC_GROUP_MEMBER_ATTRIBUTE_NAME      = "ranger.usersync.group.memberattributename";
+    private static final String LGSYNC_GROUP_SEARCH_ENABLED             = "ranger.usersync.group.searchenabled";
+    private static final String LGSYNC_GROUP_SEARCH_FIRST_ENABLED       = "ranger.usersync.group.search.first.enabled";
+    private static final String LGSYNC_GROUPNAMES                       = "ranger.usersync.ldap.groupnames";
+    private static final String LGSYNC_OTHER_GROUP_ATTRIBUTES           = "ranger.usersync.ldap.group.otherattributes";
+    private static final String LGSYNC_GROUP_CLOUDID_ATTRIBUTE          = "ranger.usersync.ldap.group.cloudid.attribute";
+    private static final String LGSYNC_GROUP_CLOUDID_ATTRIBUTE_DATATYPE = "ranger.usersync.ldap.group.cloudid.attribute.datatype";
+    private static final String LGSYNC_GROUP_HIERARCHY_LEVELS           = "ranger.usersync.ldap.grouphierarchylevels";
+    private static final String LGSYNC_LDAP_BIND_KEYSTORE                                          = "ranger.usersync.credstore.filename";
+    private static final String LGSYNC_LDAP_DELTASYNC_ENABLED                                      = "ranger.usersync.ldap.deltasync";
+    private static final String LGSYNC_LDAP_STARTTLS_ENABLED                                       = "ranger.usersync.ldap.starttls";
+    private static final String UGSYNC_SLEEP_LDAP_FORCE_TIME_IN_MILLIS_BETWEEN_CYCLE_PARAM_ENABLED = "ranger.usersync.ldap.force.sleeptimeinmillisbetweensynccycle.enabled";
+    private static final String DEFAULT_AUTHENTICATION_MECHANISM        = "simple";
+    private static final String DEFAULT_USER_OBJECT_CLASS               = "person";
+    private static final String DEFAULT_USER_NAME_ATTRIBUTE             = "cn";
+    private static final String DEFAULT_USER_GROUP_NAME_ATTRIBUTE       = "memberof,ismemberof";
+    private static final String DEFAULT_USER_CLOUDID_ATTRIBUTE          = "objectid";
+    private static final String DEFAULT_USER_CLOUDID_ATTRIBUTE_DATATYPE = "byte[]";
+    private static final String DEFAULT_OTHER_USER_ATTRIBUTES           = "userurincipaluame,";
+    private static final String  DEFAULT_LGSYNC_GROUP_OBJECT_CLASS          = "groupofnames";
+    private static final String  DEFAULT_LGSYNC_GROUP_NAME_ATTRIBUTE        = "cn";
+    private static final String  DEFAULT_LGSYNC_GROUP_MEMBER_ATTRIBUTE_NAME = "member";
+    private static final String  DEFAULT_GROUP_CLOUDID_ATTRIBUTE            = "objectid";
+    private static final String  DEFAULT_GROUP_CLOUDID_ATTRIBUTE_DATATYPE   = "byte[]";
+    private static final String  DEFAULT_OTHER_GROUP_ATTRIBUTES             = "displayname,";
+    private static final String  DEFAULT_LGSYNC_REFERRAL                    = "ignore";
+    private static final int     DEFAULT_LGSYNC_GROUP_HIERARCHY_LEVELS      = 0;
+    private static final int     DEFAULT_LGSYNC_PAGED_RESULTS_SIZE          = 500;
+    private static final boolean DEFAULT_LGSYNC_LDAP_DELTASYNC_ENABLED      = false;
+    private static final boolean DEFAULT_LGSYNC_LDAP_STARTTLS_ENABLED       = false;
+    private static final boolean DEFAULT_LGSYNC_PAGED_RESULTS_ENABLED       = true;
+    private static final boolean DEFAULT_LGSYNC_GROUP_SEARCH_ENABLED        = true;
+    private static final boolean DEFAULT_LGSYNC_USER_SEARCH_ENABLED         = true;
+    private static final boolean DEFAULT_LGSYNC_GROUP_SEARCH_FIRST_ENABLED  = true;
+    private static final String UGSYNC_GROUP_ENUMERATE_ENABLED = "ranger.usersync.group.enumerate";
+    private static final String UGSYNC_GROUP_ENUMERATE_GROUPS  = "ranger.usersync.group.enumerategroup";
+    private static final String UGSYNC_UNIX_BACKEND            = "ranger.usersync.unix.backend";
+    private static final String DEFAULT_UGSYNC_UNIX_BACKEND = "passwd";
+    private static final String UGSYNC_UPDATE_MILLIS_MIN    = "ranger.usersync.unix.updatemillismin";
+    private static final String DEFAULT_USER_GROUP_TEXTFILE_DELIMITER = ",";
     /* Role Assignments */
-    private static final String ROLE_ASSIGNMENT_LIST_DELIMITER                                       = "ranger.usersync.role.assignment.list.delimiter";
-    private static final String USERS_GROUPS_ASSIGNMENT_LIST_DELIMITER                               = "ranger.usersync.users.groups.assignment.list.delimiter";
-    private static final String USERNAME_GROUPNAME_ASSIGNMENT_LIST_DELIMITER                         = "ranger.usersync.username.groupname.assignment.list.delimiter";
-    private static final String GROUP_BASED_ROLE_ASSIGNMENT_RULES                                    = "ranger.usersync.group.based.role.assignment.rules";
-    private static final String WHITELIST_USER_ROLE_ASSIGNMENT_RULES                                 = "ranger.usersync.whitelist.users.role.assignment.rules";
-    private static final String DEFAULT_WHITELIST_USER_ROLE_ASSIGNMENT_RULES                         = "&ROLE_SYS_ADMIN:u:admin,rangerusersync,rangertagsync&ROLE_KEY_ADMIN:u:keyadmin";
+    private static final String ROLE_ASSIGNMENT_LIST_DELIMITER               = "ranger.usersync.role.assignment.list.delimiter";
+    private static final String USERS_GROUPS_ASSIGNMENT_LIST_DELIMITER       = "ranger.usersync.users.groups.assignment.list.delimiter";
+    private static final String USERNAME_GROUPNAME_ASSIGNMENT_LIST_DELIMITER = "ranger.usersync.username.groupname.assignment.list.delimiter";
+    private static final String GROUP_BASED_ROLE_ASSIGNMENT_RULES            = "ranger.usersync.group.based.role.assignment.rules";
+    private static final String WHITELIST_USER_ROLE_ASSIGNMENT_RULES         = "ranger.usersync.whitelist.users.role.assignment.rules";
+    private static final String DEFAULT_WHITELIST_USER_ROLE_ASSIGNMENT_RULES = "&ROLE_SYS_ADMIN:u:admin,rangerusersync,rangertagsync&ROLE_KEY_ADMIN:u:keyadmin";
+    private static final String UGSYNC_METRICS_FILENAME                       = "ranger.usersync.metrics.filename";
+    private static final String DEFAULT_UGSYNC_METRICS_FILENAME               = "ranger_usersync_metric.json";
+    private static final String UGSYNC_METRICS_FILEPATH                       = "ranger.usersync.metrics.filepath";
+    private static final String UGSYNC_METRICS_FREQUENCY_TIME_IN_MILLIS_PARAM = "ranger.usersync.metrics.frequencytimeinmillis";
+    private static final String DEFAULT_UGSYNC_METRICS_FILEPATH                 = "/tmp/";
+    private static final long   DEFAULT_UGSYNC_METRICS_FREQUENCY_TIME_IN_MILLIS = 10_000L;
+    private static final String SYNC_POLICY_MGR_KEYSTORE           = "ranger.usersync.policymgr.keystore";
+    private static final String SYNC_POLICY_MGR_ALIAS              = "ranger.usersync.policymgr.alias";
+    private static final String SYNC_POLICY_MGR_PASSWORD           = "ranger.usersync.policymgr.password";
+    private static final String SYNC_POLICY_MGR_USERNAME           = "ranger.usersync.policymgr.username";
+    private static final String SYNC_POLICY_MGR_MAX_RETRY_ATTEMPTS = "ranger.usersync.policymgr.max.retry.attempts";
+    private static final String SYNC_POLICY_MGR_RETRY_INTERVAL_MS  = "ranger.usersync.policymgr.retry.interval.ms";
+    private static final String DEFAULT_POLICYMGR_USERNAME         = "rangerusersync";
+    private static final String UGSYNC_SLEEP_TIME_IN_MILLIS_BETWEEN_CYCLE_PARAM = "ranger.usersync.sleeptimeinmillisbetweensynccycle";
 
-    /* Metrics */
-    public static final String UGSYNC_METRICS_ENABLED_PROP                                           = "ranger.usersync.metrics.enabled";
+    private static final long    UGSYNC_SLEEP_TIME_IN_MILLIS_BETWEEN_CYCLE_MIN_VALUE             = 60_000L;
+    private static final long    UGSYNC_SLEEP_TIME_IN_MILLIS_BETWEEN_CYCLE_UNIX_DEFAULT_VALUE    = 60_000L;
+    private static final long    UGSYNC_SLEEP_TIME_IN_MILLIS_BETWEEN_CYCLE_LDAP_DEFAULT_VALUE    = 3_600_000L;
+    private static final long    DEFAULT_UGSYNC_UPDATE_MILLIS_MIN                                = 60_000;
+    private static final long    UGSYNC_INIT_SLEEP_TIME_IN_MILLIS_BETWEEN_CYCLE_MIN_VALUE_FOR_HA = 5_000L;
+    private static final boolean DEFAULT_UGSYNC_NAME_VALIDATION_ENABLED                          = false;
+    private static final boolean DEFAULT_UGSYNC_SYNC_SOURCE_VALIDATION_ENABLED                   = true;
 
-    private static final String UGSYNC_METRICS_FILENAME                                              = "ranger.usersync.metrics.filename";
-    private static final String DEFAULT_UGSYNC_METRICS_FILENAME                                      = "ranger_usersync_metric.json";
-    private static final String UGSYNC_METRICS_FILEPATH                                              = "ranger.usersync.metrics.filepath";
-    private static final String UGSYNC_METRICS_FREQUENCY_TIME_IN_MILLIS_PARAM                        = "ranger.usersync.metrics.frequencytimeinmillis";
+    private static final String SYNC_SOURCE                         = "ranger.usersync.sync.source";
+    private static final String LGSYNC_PAGED_RESULTS_ENABLED        = "ranger.usersync.pagedresultsenabled";
+    private static final String LGSYNC_PAGED_RESULTS_SIZE           = "ranger.usersync.pagedresultssize";
+    private static final String UGSYNC_DELETES_ENABLED              = "ranger.usersync.deletes.enabled";
+    private static final String UGSYNC_DELETES_FREQUENCY            = "ranger.usersync.deletes.frequency";
+    private static final String USERSYNC_RANGER_COOKIE_ENABLED_PROP = "ranger.usersync.cookie.enabled";
+    private static final String RANGER_ADMIN_COOKIE_NAME_PROPS      = "ranger.usersync.dest.ranger.session.cookie.name";
 
-    private static final String DEFAULT_UGSYNC_METRICS_FILEPATH                                      = "/tmp/";
-    private static final long   DEFAULT_UGSYNC_METRICS_FREQUENCY_TIME_IN_MILLIS                      = 10_000L;
-
-    /* Policy Manager Configs */
-    public static final String UGSYNC_PM_URL_PROP                                                    = "ranger.usersync.policymanager.baseURL";
-    public static final String UGSYNC_MAX_RECORDS_PER_API_CALL_PROP                                  = "ranger.usersync.policymanager.maxrecordsperapicall";
-    public static final String UGSYNC_MOCK_RUN_PROP                                                  = "ranger.usersync.policymanager.mockrun";
-    public static final String UGSYNC_TEST_RUN_PROP                                                  = "ranger.usersync.policymanager.testrun";
-
-    private static final String SYNC_POLICY_MGR_KEYSTORE                                             = "ranger.usersync.policymgr.keystore";
-    private static final String SYNC_POLICY_MGR_ALIAS                                                = "ranger.usersync.policymgr.alias";
-    private static final String SYNC_POLICY_MGR_PASSWORD                                             = "ranger.usersync.policymgr.password";
-    private static final String SYNC_POLICY_MGR_USERNAME                                             = "ranger.usersync.policymgr.username";
-    private static final String SYNC_POLICY_MGR_MAX_RETRY_ATTEMPTS                                   = "ranger.usersync.policymgr.max.retry.attempts";
-    private static final String SYNC_POLICY_MGR_RETRY_INTERVAL_MS                                    = "ranger.usersync.policymgr.retry.interval.ms";
-    private static final String DEFAULT_POLICYMGR_USERNAME                                           = "rangerusersync";
-
-    /* Other Configs */
-    public static final String UGSYNC_SERVER_HA_ENABLED_PARAM                                        = "ranger-ugsync.server.ha.enabled";
-    public static final String UGSYNC_NAME_VALIDATION_ENABLED                                        = "ranger.usersync.name.validation.enabled";
-    public static final String UGSYNC_SYNC_SOURCE_VALIDATION_ENABLED                                 = "ranger.usersync.syncsource.validation.enabled";
-    private static final String UGSYNC_SLEEP_TIME_IN_MILLIS_BETWEEN_CYCLE_PARAM                      = "ranger.usersync.sleeptimeinmillisbetweensynccycle";
-
-    private static final long UGSYNC_SLEEP_TIME_IN_MILLIS_BETWEEN_CYCLE_MIN_VALUE                    = 60_000L;
-    private static final long UGSYNC_SLEEP_TIME_IN_MILLIS_BETWEEN_CYCLE_UNIX_DEFAULT_VALUE           = 60_000L;
-    private static final long UGSYNC_SLEEP_TIME_IN_MILLIS_BETWEEN_CYCLE_LDAP_DEFAULT_VALUE           = 3_600_000L;
-    private static final long DEFAULT_UGSYNC_UPDATE_MILLIS_MIN                                       = 60_000;
-    private static final long  UGSYNC_INIT_SLEEP_TIME_IN_MILLIS_BETWEEN_CYCLE_MIN_VALUE_FOR_HA       = 5_000L;
-    private static final boolean DEFAULT_UGSYNC_NAME_VALIDATION_ENABLED                              = false;
-    private static final boolean DEFAULT_UGSYNC_SYNC_SOURCE_VALIDATION_ENABLED                       = true;
-
-    private static final String SYNC_SOURCE                                                          = "ranger.usersync.sync.source";
-    private static final String LGSYNC_PAGED_RESULTS_ENABLED                                         = "ranger.usersync.pagedresultsenabled";
-    private static final String LGSYNC_PAGED_RESULTS_SIZE                                            = "ranger.usersync.pagedresultssize";
-    private static final String UGSYNC_DELETES_ENABLED                                               = "ranger.usersync.deletes.enabled";
-    private static final String UGSYNC_DELETES_FREQUENCY                                             = "ranger.usersync.deletes.frequency";
-    private static final String USERSYNC_RANGER_COOKIE_ENABLED_PROP                                  = "ranger.usersync.cookie.enabled";
-    private static final String RANGER_ADMIN_COOKIE_NAME_PROPS                                       = "ranger.usersync.dest.ranger.session.cookie.name";
-
-    private static final boolean DEFAULT_UGSYNC_DELETES_ENABLED                                      = false;
-    private static final long    DEFAULT_UGSYNC_DELETES_FREQUENCY                                    = 10L; // After every 10 sync cycles
+    private static final boolean DEFAULT_UGSYNC_DELETES_ENABLED   = false;
+    private static final long    DEFAULT_UGSYNC_DELETES_FREQUENCY = 10L; // After every 10 sync cycles
 
     /* SSL Configs */
-    private static final String SSL_KEYSTORE_FILE_TYPE_PARAM                                         = "ranger.keystore.file.type";
-    private static final String SSL_TRUSTSTORE_FILE_TYPE_PARAM                                       = "ranger.truststore.file.type";
-    private static final String SSL_KEYSTORE_PATH_PARAM                                              = "ranger.usersync.keystore.file";
-    private static final String SSL_KEYSTORE_PATH_PASSWORD_PARAM                                     = "ranger.usersync.keystore.password";
-    private static final String SSL_TRUSTSTORE_PATH_PARAM                                            = "ranger.usersync.truststore.file";
-    private static final String SSL_TRUSTSTORE_PATH_PASSWORD_PARAM                                   = "ranger.usersync.truststore.password";
-    private static final String SSL_KEYSTORE_PATH_PASSWORD_ALIAS                                     = "usersync.ssl.key.password";
-    private static final String SSL_TRUSTSTORE_PATH_PASSWORD_ALIAS                                   = "usersync.ssl.truststore.password";
+    private static final String SSL_KEYSTORE_FILE_TYPE_PARAM       = "ranger.keystore.file.type";
+    private static final String SSL_TRUSTSTORE_FILE_TYPE_PARAM     = "ranger.truststore.file.type";
+    private static final String SSL_KEYSTORE_PATH_PARAM            = "ranger.usersync.keystore.file";
+    private static final String SSL_KEYSTORE_PATH_PASSWORD_PARAM   = "ranger.usersync.keystore.password";
+    private static final String SSL_TRUSTSTORE_PATH_PARAM          = "ranger.usersync.truststore.file";
+    private static final String SSL_TRUSTSTORE_PATH_PASSWORD_PARAM = "ranger.usersync.truststore.password";
+    private static final String SSL_KEYSTORE_PATH_PASSWORD_ALIAS   = "usersync.ssl.key.password";
+    private static final String SSL_TRUSTSTORE_PATH_PASSWORD_ALIAS = "usersync.ssl.truststore.password";
 
     private static volatile UserGroupSyncConfig me;
-    private final Properties prop = new Properties();
-    private Configuration userGroupConfig;
+    private final           Properties          prop = new Properties();
+    private                 Configuration       userGroupConfig;
 
     private UserGroupSyncConfig() {
         init();
@@ -747,13 +709,13 @@ public class UserGroupSyncConfig {
     }
 
     public String getUserNameCaseConversion() {
-        String ret = prop.getProperty(UGSYNC_USERNAME_CASE_CONVERSION_PARAM, DEFAULT_UGSYNC_USERNAME_CASE_CONVERSION_VALUE);
+        String ret = prop.getProperty(UgsyncCommonConstants.UGSYNC_USERNAME_CASE_CONVERSION_PARAM, UgsyncCommonConstants.DEFAULT_UGSYNC_USERNAME_CASE_CONVERSION_VALUE);
 
         return ret.trim().toLowerCase();
     }
 
     public String getGroupNameCaseConversion() {
-        String ret = prop.getProperty(UGSYNC_GROUPNAME_CASE_CONVERSION_PARAM, DEFAULT_UGSYNC_GROUPNAME_CASE_CONVERSION_VALUE);
+        String ret = prop.getProperty(UgsyncCommonConstants.UGSYNC_GROUPNAME_CASE_CONVERSION_PARAM, UgsyncCommonConstants.DEFAULT_UGSYNC_GROUPNAME_CASE_CONVERSION_VALUE);
 
         return ret.trim().toLowerCase();
     }
@@ -782,7 +744,7 @@ public class UserGroupSyncConfig {
 
     public int getPagedResultsSize() {
         int    pagedResultsSize;
-        String val     = prop.getProperty(LGSYNC_PAGED_RESULTS_SIZE);
+        String val = prop.getProperty(LGSYNC_PAGED_RESULTS_SIZE);
 
         if (val == null || val.trim().isEmpty()) {
             pagedResultsSize = DEFAULT_LGSYNC_PAGED_RESULTS_SIZE;
@@ -795,6 +757,17 @@ public class UserGroupSyncConfig {
         }
 
         return pagedResultsSize;
+    }
+
+    public boolean isDeltaSyncEnabled() {
+        boolean deltaSyncEnabled;
+        String  val = prop.getProperty(LGSYNC_LDAP_DELTASYNC_ENABLED);
+        if (val == null || val.trim().isEmpty()) {
+            deltaSyncEnabled = DEFAULT_LGSYNC_LDAP_DELTASYNC_ENABLED;
+        } else {
+            deltaSyncEnabled = Boolean.valueOf(val);
+        }
+        return deltaSyncEnabled;
     }
 
     public boolean isGroupSearchEnabled() {
@@ -972,7 +945,7 @@ public class UserGroupSyncConfig {
             otherAttributes = DEFAULT_OTHER_GROUP_ATTRIBUTES;
         }
 
-        StringTokenizer st   = new StringTokenizer(otherAttributes, ",");
+        StringTokenizer st                   = new StringTokenizer(otherAttributes, ",");
         Set<String>     otherGroupAttributes = new HashSet<>();
 
         while (st.hasMoreTokens()) {
@@ -1138,20 +1111,20 @@ public class UserGroupSyncConfig {
     }
 
     public String getUserSyncMappingUserNameHandler() {
-        String val = prop.getProperty(SYNC_MAPPING_USERNAME_HANDLER);
+        String val = prop.getProperty(UgsyncCommonConstants.SYNC_MAPPING_USERNAME_HANDLER);
 
         if (val == null) {
-            val = DEFAULT_SYNC_MAPPING_USERNAME_HANDLER;
+            val = UgsyncCommonConstants.DEFAULT_SYNC_MAPPING_USERNAME_HANDLER;
         }
 
         return val;
     }
 
     public String getUserSyncMappingGroupNameHandler() {
-        String val = prop.getProperty(SYNC_MAPPING_GROUPNAME_HANDLER);
+        String val = prop.getProperty(UgsyncCommonConstants.SYNC_MAPPING_GROUPNAME_HANDLER);
 
         if (val == null) {
-            val = DEFAULT_SYNC_MAPPING_GROUPNAME_HANDLER;
+            val = UgsyncCommonConstants.DEFAULT_SYNC_MAPPING_GROUPNAME_HANDLER;
         }
 
         return val;
@@ -1245,19 +1218,6 @@ public class UserGroupSyncConfig {
         }
 
         return starttlsEnabled;
-    }
-
-    public boolean isDeltaSyncEnabled() {
-        boolean deltaSyncEnabled;
-        String  val = prop.getProperty(LGSYNC_LDAP_DELTASYNC_ENABLED);
-
-        if (val == null || val.trim().isEmpty()) {
-            deltaSyncEnabled = DEFAULT_LGSYNC_LDAP_DELTASYNC_ENABLED;
-        } else {
-            deltaSyncEnabled = Boolean.parseBoolean(val);
-        }
-
-        return deltaSyncEnabled;
     }
 
     /* Used only for unit testing */
@@ -1408,8 +1368,8 @@ public class UserGroupSyncConfig {
     }
 
     public String getRegexSeparator() {
-        String ret = DEFAULT_MAPPING_SEPARATOR;
-        String val = prop.getProperty(SYNC_MAPPING_SEPARATOR);
+        String ret = UgsyncCommonConstants.DEFAULT_MAPPING_SEPARATOR;
+        String val = prop.getProperty(UgsyncCommonConstants.SYNC_MAPPING_SEPARATOR);
 
         if (StringUtils.isNotEmpty(val)) {
             if (val.length() == 1) {
@@ -1426,13 +1386,44 @@ public class UserGroupSyncConfig {
 
     public boolean isSyncSourceValidationEnabled() {
         boolean isSyncSourceValidationEnabled = DEFAULT_UGSYNC_SYNC_SOURCE_VALIDATION_ENABLED;
-        String  val           = prop.getProperty(UGSYNC_SYNC_SOURCE_VALIDATION_ENABLED);
+        String  val                           = prop.getProperty(UGSYNC_SYNC_SOURCE_VALIDATION_ENABLED);
 
         if (StringUtils.isNotEmpty(val)) {
             isSyncSourceValidationEnabled = Boolean.parseBoolean(val);
         }
 
         return isSyncSourceValidationEnabled;
+    }
+
+    public Map<String, String> getNameTransformationRules() {
+        Map<String, String> nameTransformationRules = new HashMap<>();
+        nameTransformationRules.put(UgsyncCommonConstants.UGSYNC_USERNAME_CASE_CONVERSION_PARAM, getUserNameCaseConversion());
+        nameTransformationRules.put(UgsyncCommonConstants.UGSYNC_GROUPNAME_CASE_CONVERSION_PARAM, getGroupNameCaseConversion());
+        nameTransformationRules.put(UgsyncCommonConstants.SYNC_MAPPING_USERNAME_HANDLER, getUserSyncMappingUserNameHandler());
+        nameTransformationRules.put(UgsyncCommonConstants.SYNC_MAPPING_GROUPNAME_HANDLER, getUserSyncMappingGroupNameHandler());
+        nameTransformationRules.put(UgsyncCommonConstants.SYNC_MAPPING_SEPARATOR, getRegexSeparator());
+        nameTransformationRules.putAll(getAllRegexPatternsConfig(UgsyncCommonConstants.SYNC_MAPPING_USERNAME));
+        nameTransformationRules.putAll(getAllRegexPatternsConfig(UgsyncCommonConstants.SYNC_MAPPING_GROUPNAME));
+        return nameTransformationRules;
+    }
+
+    public Map<String, String> getAllRegexPatternsConfig(String baseProperty) {
+        Map<String, String> regexPatterns = new HashMap<>();
+        if (prop != null) {
+            String baseRegex = prop.getProperty(baseProperty);
+            if (baseRegex == null) {
+                return regexPatterns;
+            }
+            regexPatterns.put(baseProperty, baseRegex);
+            int    i         = 1;
+            String nextRegex = prop.getProperty(baseProperty + "." + i);
+            while (nextRegex != null) {
+                regexPatterns.put(baseProperty + "." + i, nextRegex);
+                i++;
+                nextRegex = prop.getProperty(baseProperty + "." + i);
+            }
+        }
+        return regexPatterns;
     }
 
     private void init() {

--- a/ugsync/src/main/java/org/apache/ranger/unixusersync/process/PolicyMgrUserGroupBuilder.java
+++ b/ugsync/src/main/java/org/apache/ranger/unixusersync/process/PolicyMgrUserGroupBuilder.java
@@ -152,20 +152,20 @@ public class PolicyMgrUserGroupBuilder extends AbstractUserGroupSource implement
 
         String userNameCaseConversion = config.getUserNameCaseConversion();
 
-        if (UserGroupSyncConfig.UGSYNC_NONE_CASE_CONVERSION_VALUE.equalsIgnoreCase(userNameCaseConversion)) {
+        if (UgsyncCommonConstants.UGSYNC_NONE_CASE_CONVERSION_VALUE.equalsIgnoreCase(userNameCaseConversion)) {
             userNameCaseConversionFlag = false;
         } else {
             userNameCaseConversionFlag = true;
-            userNameLowerCaseFlag      = UserGroupSyncConfig.UGSYNC_LOWER_CASE_CONVERSION_VALUE.equalsIgnoreCase(userNameCaseConversion);
+            userNameLowerCaseFlag      = UgsyncCommonConstants.UGSYNC_LOWER_CASE_CONVERSION_VALUE.equalsIgnoreCase(userNameCaseConversion);
         }
 
         String groupNameCaseConversion = config.getGroupNameCaseConversion();
 
-        if (UserGroupSyncConfig.UGSYNC_NONE_CASE_CONVERSION_VALUE.equalsIgnoreCase(groupNameCaseConversion)) {
+        if (UgsyncCommonConstants.UGSYNC_NONE_CASE_CONVERSION_VALUE.equalsIgnoreCase(groupNameCaseConversion)) {
             groupNameCaseConversionFlag = false;
         } else {
             groupNameCaseConversionFlag = true;
-            groupNameLowerCaseFlag      = UserGroupSyncConfig.UGSYNC_LOWER_CASE_CONVERSION_VALUE.equalsIgnoreCase(groupNameCaseConversion);
+            groupNameLowerCaseFlag      = UgsyncCommonConstants.UGSYNC_LOWER_CASE_CONVERSION_VALUE.equalsIgnoreCase(groupNameCaseConversion);
         }
     }
 

--- a/ugsync/src/main/java/org/apache/ranger/usergroupsync/AbstractUserGroupSource.java
+++ b/ugsync/src/main/java/org/apache/ranger/usergroupsync/AbstractUserGroupSource.java
@@ -18,13 +18,14 @@
  */
 package org.apache.ranger.usergroupsync;
 
+import org.apache.ranger.ugsyncutil.transform.Mapper;
+import org.apache.ranger.ugsyncutil.util.UgsyncCommonConstants;
 import org.apache.ranger.unixusersync.config.UserGroupSyncConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public abstract class AbstractUserGroupSource {
     private static final Logger LOG = LoggerFactory.getLogger(AbstractUserGroupSource.class);
-
     protected UserGroupSyncConfig config = UserGroupSyncConfig.getInstance();
     protected Mapper              userNameRegExInst;
     protected Mapper              groupNameRegExInst;
@@ -39,7 +40,8 @@ public abstract class AbstractUserGroupSource {
                 userNameRegExInst = regExClass.newInstance();
 
                 if (userNameRegExInst != null) {
-                    userNameRegExInst.init(UserGroupSyncConfig.SYNC_MAPPING_USERNAME);
+                    String baseProperty = UgsyncCommonConstants.SYNC_MAPPING_USERNAME;
+                    userNameRegExInst.init(baseProperty, config.getAllRegexPatterns(baseProperty), config.getRegexSeparator());
                 } else {
                     LOG.error("RegEx handler instance for username is null!");
                 }
@@ -59,7 +61,8 @@ public abstract class AbstractUserGroupSource {
                 groupNameRegExInst = regExClass.newInstance();
 
                 if (groupNameRegExInst != null) {
-                    groupNameRegExInst.init(UserGroupSyncConfig.SYNC_MAPPING_GROUPNAME);
+                    String baseProperty = UgsyncCommonConstants.SYNC_MAPPING_GROUPNAME;
+                    groupNameRegExInst.init(baseProperty, config.getAllRegexPatterns(baseProperty), config.getRegexSeparator());
                 } else {
                     LOG.error("RegEx handler instance for groupname is null!");
                 }

--- a/ugsync/src/test/java/org/apache/ranger/unixusersync/process/TestFileSourceUserGroupBuilder.java
+++ b/ugsync/src/test/java/org/apache/ranger/unixusersync/process/TestFileSourceUserGroupBuilder.java
@@ -18,6 +18,7 @@
  */
 package org.apache.ranger.unixusersync.process;
 
+import org.apache.ranger.ugsyncutil.util.UgsyncCommonConstants;
 import org.apache.ranger.unixusersync.config.UserGroupSyncConfig;
 import org.apache.ranger.usergroupsync.PolicyMgrUserGroupBuilderTest;
 import org.junit.Test;
@@ -134,10 +135,10 @@ public class TestFileSourceUserGroupBuilder {
         config.setProperty(UserGroupSyncConfig.UGSYNC_SOURCE_FILE_PROC, "src/test/resources/usergroups-dns.csv");
         config.setProperty(UserGroupSyncConfig.UGSYNC_SOURCE_FILE_DELIMITERER, "|");
 
-        config.setProperty(UserGroupSyncConfig.SYNC_MAPPING_USERNAME, "s/[=]/_/g");
-        config.setProperty(UserGroupSyncConfig.SYNC_MAPPING_USERNAME + ".1", "s/[,]//g");
+        config.setProperty(UgsyncCommonConstants.SYNC_MAPPING_USERNAME, "s/[=]/_/g");
+        config.setProperty(UgsyncCommonConstants.SYNC_MAPPING_USERNAME + ".1", "s/[,]//g");
 
-        config.setProperty(UserGroupSyncConfig.SYNC_MAPPING_GROUPNAME, "s/[=]//g");
+        config.setProperty(UgsyncCommonConstants.SYNC_MAPPING_GROUPNAME, "s/[=]//g");
 
         FileSourceUserGroupBuilder fileBuilder = new FileSourceUserGroupBuilder();
         fileBuilder.init();

--- a/ugsync/src/test/java/org/apache/ranger/usergroupsync/TestLdapUserGroup.java
+++ b/ugsync/src/test/java/org/apache/ranger/usergroupsync/TestLdapUserGroup.java
@@ -30,6 +30,7 @@ import org.apache.directory.server.core.integ.FrameworkRunner;
 import org.apache.directory.server.ldap.LdapServer;
 import org.apache.directory.server.protocol.shared.transport.TcpTransport;
 import org.apache.ranger.ldapusersync.process.LdapUserGroupBuilder;
+import org.apache.ranger.ugsyncutil.util.UgsyncCommonConstants;
 import org.apache.ranger.unixusersync.config.UserGroupSyncConfig;
 import org.junit.After;
 import org.junit.Assert;
@@ -385,8 +386,8 @@ public class TestLdapUserGroup extends AbstractLdapTestUnit {
         config.setGroupSearchEnabled(true);
         config.setGroupSearchFirstEnabled(false);
 
-        config.setProperty(UserGroupSyncConfig.SYNC_MAPPING_USERNAME, "s/[=]/_/g");
-        config.setProperty(UserGroupSyncConfig.SYNC_MAPPING_GROUPNAME, "s/[=]/_/g");
+        config.setProperty(UgsyncCommonConstants.SYNC_MAPPING_USERNAME, "s/[=]/_/g");
+        config.setProperty(UgsyncCommonConstants.SYNC_MAPPING_GROUPNAME, "s/[=]/_/g");
         sink = new PolicyMgrUserGroupBuilderTest();
 
         ldapBuilder.init();


### PR DESCRIPTION


## What changes were proposed in this pull request?
**Problem Statement:**

Currently, when Ranger Usersync is configured with case conversion and special character replacement using regex, it transforms the original user/group names from the source (e.g., AD/LDAP) before storing them in the Ranger Admin database.

**Example:**

Original name in LDAP/AD: John-jacobs
Usersync configuration:

- ranger.usersync.ldap.username.caseconversion = lower
- ranger.usersync.mapping.username.regex = s/[-]/_/g
- Transformed and stored name in Ranger: john_jacobs

**Issue:**

If a Ranger plugin (e.g., Hive) uses the original name John-jacobs during authorization checks, it fails because Ranger Admin only recognizes the transformed name john_jacobs.

**Error Example:**

_Permission denied: user [John-jacobs] does not have [SELECT] privilege on [vehicle/cars/*]_ 
**Solution:**

To ensure consistency, the same transformation logic used by Usersync must also be applied on the plugin side before authorization. This transformation should be made available as a utility library packaged with the plugins.

**Configurability:**

This feature must be configurable at the plugin level via a property (e.g., ranger.plugin.<serviceType>.supports.name.transformation), allowing users to enable or disable it based on their environment needs.

In ranger-admin-site.xml

ranger.plugins.ldap.username.caseconversion
ranger.plugins.ldap.groupname.caseconversion
ranger.plugins.mapping.username.handler
ranger.plugins.mapping.groupname.handler
ranger.plugins.mapping.regex.separator
ranger.plugins.mapping.username.regex
ranger.plugins.mapping.groupname.regex


## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
1.) Build successful with unit test.
2.) Manul testing
