### PR TITLE
RANGER-4993 : Ranger KMS - Missing HSTS Headers for 404 Not found requests port 9494

### DIFF
--- a/kms/config/webserver/ranger-kms-site.xml
+++ b/kms/config/webserver/ranger-kms-site.xml
@@ -12,67 +12,66 @@
   limitations under the License. See accompanying LICENSE file.
 -->
 
-
 <configuration>
-	<property>
-		<name>ranger.service.host</name>
-		<value>localhost</value>
-	</property>
+    <property>
+        <name>ranger.service.host</name>
+        <value>localhost</value>
+    </property>
 
-	<property>
-		<name>ranger.service.http.port</name>
-		<value>9292</value>
-	</property>
-	
-	<property>
-		<name>ranger.service.shutdown.port</name>
-		<value>7085</value>
-	</property>
-	
-	<property>
-		<name>ranger.contextName</name>
-		<value>/kms</value>
-	</property>			
-	
-	<property>
-		<name>xa.webapp.dir</name>
-		<value>./webapp</value>
-	</property>	
-	<property>
-		<name>ranger.service.https.port</name>
-		<value>9393</value>
-	</property>
-	<property>
-		<name>ranger.service.https.attrib.ssl.enabled</name>
-		<value>false</value>
-	</property>
-	<property>
-		<name>ajp.enabled</name>
-		<value>false</value>
-	</property>
-	<property>
-		<name>ranger.service.https.attrib.client.auth</name>
-		<value>want</value>
-	</property>
-	<property>
-		<name>ranger.credential.provider.path</name>
-		<value>/etc/ranger/kms/rangerkms.jceks</value>
-	</property>
-	<property>
-		<name>ranger.service.https.attrib.keystore.file</name>
-		<value></value>
-	</property>
-	<property>
-		<name>ranger.service.https.attrib.keystore.keyalias</name>
-		<value>rangerkms</value>
-	</property>
-	<property>
-		<name>ranger.service.https.attrib.keystore.pass</name>
-		<value></value>
-	</property>
-	<property>
-		<name>ranger.service.https.attrib.keystore.credential.alias</name>
-		<value>keyStoreCredentialAlias</value>
-	</property>
+    <property>
+        <name>ranger.service.http.port</name>
+        <value>9292</value>
+    </property>
+
+    <property>
+        <name>ranger.service.shutdown.port</name>
+        <value>7085</value>
+    </property>
+
+    <property>
+        <name>ranger.contextName</name>
+        <value>/</value>
+    </property>
+
+    <property>
+        <name>xa.webapp.dir</name>
+        <value>./webapp</value>
+    </property>
+    <property>
+        <name>ranger.service.https.port</name>
+        <value>9393</value>
+    </property>
+    <property>
+        <name>ranger.service.https.attrib.ssl.enabled</name>
+        <value>false</value>
+    </property>
+    <property>
+        <name>ajp.enabled</name>
+        <value>false</value>
+    </property>
+    <property>
+        <name>ranger.service.https.attrib.client.auth</name>
+        <value>want</value>
+    </property>
+    <property>
+        <name>ranger.credential.provider.path</name>
+        <value>/etc/ranger/kms/rangerkms.jceks</value>
+    </property>
+    <property>
+        <name>ranger.service.https.attrib.keystore.file</name>
+        <value></value>
+    </property>
+    <property>
+        <name>ranger.service.https.attrib.keystore.keyalias</name>
+        <value>rangerkms</value>
+    </property>
+    <property>
+        <name>ranger.service.https.attrib.keystore.pass</name>
+        <value></value>
+    </property>
+    <property>
+        <name>ranger.service.https.attrib.keystore.credential.alias</name>
+        <value>keyStoreCredentialAlias</value>
+    </property>
 
 </configuration>

--- a/kms/src/main/java/org/apache/hadoop/crypto/key/kms/server/HSTSFilter.java
+++ b/kms/src/main/java/org/apache/hadoop/crypto/key/kms/server/HSTSFilter.java
@@ -34,7 +34,6 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 public class HSTSFilter implements Filter {
-
     static final Logger LOG = LoggerFactory.getLogger(HSTSFilter.class);
 
     @Override

--- a/kms/src/main/java/org/apache/hadoop/crypto/key/kms/server/HSTSFilter.java
+++ b/kms/src/main/java/org/apache/hadoop/crypto/key/kms/server/HSTSFilter.java
@@ -44,16 +44,13 @@ public class HSTSFilter implements Filter {
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
             throws IOException, ServletException {
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("===> HSTSFilter:doFilter()");
-        }
+        LOG.debug("===> HSTSFilter:doFilter()");
         String path = ((HttpServletRequest) request).getRequestURI();
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("==> HSTSFilter:doFilter() path = " + path);
-        }
+        LOG.debug("==> HSTSFilter:doFilter() path = " + path);
         HttpServletResponse resp = (HttpServletResponse) response;
         resp.setHeader("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
         chain.doFilter(request, response);
+        LOG.debug("<=== HSTSFilter:doFilter()");
     }
 
     @Override

--- a/kms/src/main/java/org/apache/hadoop/crypto/key/kms/server/HSTSFilter.java
+++ b/kms/src/main/java/org/apache/hadoop/crypto/key/kms/server/HSTSFilter.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hadoop.crypto.key.kms.server;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+public class HSTSFilter implements Filter {
+
+    static final Logger LOG = LoggerFactory.getLogger(HSTSFilter.class);
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+        // Initialization logic if needed
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("===> HSTSFilter:doFilter()");
+        }
+        String path = ((HttpServletRequest) request).getRequestURI();
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("==> HSTSFilter:doFilter() path = " + path);
+        }
+        HttpServletResponse resp = (HttpServletResponse) response;
+        resp.setHeader("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
+        chain.doFilter(request, response);
+    }
+
+    @Override
+    public void destroy() {
+        // Cleanup logic if needed
+    }
+}

--- a/kms/src/main/java/org/apache/hadoop/crypto/key/kms/server/KMSMDCFilter.java
+++ b/kms/src/main/java/org/apache/hadoop/crypto/key/kms/server/KMSMDCFilter.java
@@ -64,8 +64,6 @@ public class KMSMDCFilter implements Filter {
             String              path = ((HttpServletRequest) request).getRequestURI();
             HttpServletResponse resp = (HttpServletResponse) response;
 
-            resp.setHeader("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
-
             if (path.startsWith(RANGER_KMS_REST_API_PATH)) {
                 chain.doFilter(request, resp);
             } else {

--- a/kms/src/main/webapp/WEB-INF/web.xml
+++ b/kms/src/main/webapp/WEB-INF/web.xml
@@ -18,56 +18,66 @@
 
 <web-app version="2.4" xmlns="http://java.sun.com/xml/ns/j2ee">
 
-  <display-name>ranger-kms</display-name>
-  <absolute-ordering />
+    <display-name>ranger-kms</display-name>
+    <absolute-ordering />
 
-  <listener>
-    <listener-class>org.apache.hadoop.crypto.key.kms.server.KMSWebApp</listener-class>
-  </listener>
+    <listener>
+        <listener-class>org.apache.hadoop.crypto.key.kms.server.KMSWebApp</listener-class>
+    </listener>
 
-  <servlet>
-    <servlet-name>webservices-driver</servlet-name>
-    <servlet-class>com.sun.jersey.spi.container.servlet.ServletContainer</servlet-class>
-    <init-param>
-      <param-name>com.sun.jersey.config.property.packages</param-name>
-      <param-value>org.apache.hadoop.crypto.key.kms.server</param-value>
-    </init-param>
-    <load-on-startup>1</load-on-startup>
-  </servlet>
+    <servlet>
+        <servlet-name>webservices-driver</servlet-name>
+        <servlet-class>com.sun.jersey.spi.container.servlet.ServletContainer</servlet-class>
+        <init-param>
+            <param-name>com.sun.jersey.config.property.packages</param-name>
+            <param-value>org.apache.hadoop.crypto.key.kms.server</param-value>
+        </init-param>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
 
-  <servlet>
-    <servlet-name>jmx-servlet</servlet-name>
-    <servlet-class>org.apache.hadoop.crypto.key.kms.server.KMSJMXServlet</servlet-class>
-  </servlet>
+    <servlet>
+        <servlet-name>jmx-servlet</servlet-name>
+        <servlet-class>org.apache.hadoop.crypto.key.kms.server.KMSJMXServlet</servlet-class>
+    </servlet>
 
-  <servlet-mapping>
-    <servlet-name>webservices-driver</servlet-name>
-    <url-pattern>/*</url-pattern>
-  </servlet-mapping>
+    <servlet-mapping>
+        <servlet-name>webservices-driver</servlet-name>
+        <url-pattern>/kms/*</url-pattern>
+    </servlet-mapping>
 
-  <servlet-mapping>
-    <servlet-name>jmx-servlet</servlet-name>
-    <url-pattern>/jmx</url-pattern>
-  </servlet-mapping>
+    <servlet-mapping>
+        <servlet-name>jmx-servlet</servlet-name>
+        <url-pattern>/jmx</url-pattern>
+    </servlet-mapping>
 
-  <filter>
-    <filter-name>authFilter</filter-name>
-    <filter-class>org.apache.hadoop.crypto.key.kms.server.KMSAuthenticationFilter</filter-class>
-  </filter>
+    <filter>
+        <filter-name>authFilter</filter-name>
+        <filter-class>org.apache.hadoop.crypto.key.kms.server.KMSAuthenticationFilter</filter-class>
+    </filter>
 
-  <filter>
-    <filter-name>MDCFilter</filter-name>
-    <filter-class>org.apache.hadoop.crypto.key.kms.server.KMSMDCFilter</filter-class>
-  </filter>
+    <filter>
+        <filter-name>MDCFilter</filter-name>
+        <filter-class>org.apache.hadoop.crypto.key.kms.server.KMSMDCFilter</filter-class>
+    </filter>
 
-  <filter-mapping>
-    <filter-name>authFilter</filter-name>
-    <url-pattern>/*</url-pattern>
-  </filter-mapping>
+    <filter>
+        <filter-name>HSTSFilter</filter-name>
+        <filter-class>org.apache.hadoop.crypto.key.kms.server.HSTSFilter</filter-class>
+    </filter>
 
-  <filter-mapping>
-    <filter-name>MDCFilter</filter-name>
-    <url-pattern>/*</url-pattern>
-  </filter-mapping>
+    <filter-mapping>
+        <filter-name>authFilter</filter-name>
+        <url-pattern>/kms/*</url-pattern>
+    </filter-mapping>
+
+    <filter-mapping>
+        <filter-name>MDCFilter</filter-name>
+        <url-pattern>/kms/*</url-pattern>
+    </filter-mapping>
+
+    <filter-mapping>
+        <filter-name>HSTSFilter</filter-name>
+        <url-pattern>/*</url-pattern>
+    </filter-mapping>
 
 </web-app>

--- a/kms/src/main/webapp/WEB-INF/web.xml
+++ b/kms/src/main/webapp/WEB-INF/web.xml
@@ -51,6 +51,11 @@
     </servlet-mapping>
 
     <filter>
+        <filter-name>HSTSFilter</filter-name>
+        <filter-class>org.apache.hadoop.crypto.key.kms.server.HSTSFilter</filter-class>
+    </filter>
+
+    <filter>
         <filter-name>authFilter</filter-name>
         <filter-class>org.apache.hadoop.crypto.key.kms.server.KMSAuthenticationFilter</filter-class>
     </filter>
@@ -60,10 +65,10 @@
         <filter-class>org.apache.hadoop.crypto.key.kms.server.KMSMDCFilter</filter-class>
     </filter>
 
-    <filter>
+    <filter-mapping>
         <filter-name>HSTSFilter</filter-name>
-        <filter-class>org.apache.hadoop.crypto.key.kms.server.HSTSFilter</filter-class>
-    </filter>
+        <url-pattern>/*</url-pattern>
+    </filter-mapping>
 
     <filter-mapping>
         <filter-name>authFilter</filter-name>
@@ -73,11 +78,6 @@
     <filter-mapping>
         <filter-name>MDCFilter</filter-name>
         <url-pattern>/kms/*</url-pattern>
-    </filter-mapping>
-
-    <filter-mapping>
-        <filter-name>HSTSFilter</filter-name>
-        <url-pattern>/*</url-pattern>
     </filter-mapping>
 
 </web-app>


### PR DESCRIPTION
## What changes were proposed in this pull request?
RANGER-4993 : Ranger KMS - Missing HSTS Headers for 404 Not found requests port 9494

HSTS header is missing for 404 Not found requests .

E.G.
curl -ivk -u  keyadmin:Admin123  [https://<fqdn>:9494/](https://%3Cfqdn%3E:9494/)

OR

curl -ivk --negotiate -u : [https://<fqdn>:9494](https://%3Cfqdn%3E:9494/)


```
< HTTP/1.1 404 Not Found
HTTP/1.1 404 Not Found
< Content-Type: text/html;charset=utf-8
Content-Type: text/html;charset=utf-8
< Content-Language: en
Content-Language: en
< Content-Length: 682
Content-Length: 682
< Date: Mon, 26 Aug 2024 13:12:21 GMT
Date: Mon, 26 Aug 2024 13:12:21 GMT
< Server: Apache Ranger
Server: Apache Ranger
```


## How was this patch tested?

Successfully validated the HSTS header for above API and all the existing APIs such as GET keys, create keys, rollover keys , delete keys.
