### PR TITLE
RANGER-5225: Override policy should take precedence over normal deny policy

### DIFF
--- a/agents-common/src/main/java/org/apache/ranger/plugin/policyevaluator/RangerDefaultPolicyEvaluator.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/policyevaluator/RangerDefaultPolicyEvaluator.java
@@ -616,8 +616,7 @@ public class RangerDefaultPolicyEvaluator extends RangerAbstractPolicyEvaluator 
                                 if (getPolicyPriority() > oldPriority) {
                                     if (allowResult != null) {
                                         accessTypeResults.put(accessType, allowResult);
-                                    }
-                                    else if (denyResult != null) {
+                                    } else if (denyResult != null) {
                                         accessTypeResults.put(accessType, denyResult);
                                     }
                                 }

--- a/agents-common/src/main/java/org/apache/ranger/plugin/policyevaluator/RangerDefaultPolicyEvaluator.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/policyevaluator/RangerDefaultPolicyEvaluator.java
@@ -620,7 +620,6 @@ public class RangerDefaultPolicyEvaluator extends RangerAbstractPolicyEvaluator 
                                     else if (denyResult != null) {
                                         accessTypeResults.put(accessType, denyResult);
                                     }
-
                                 }
                             }
                         }

--- a/agents-common/src/main/java/org/apache/ranger/plugin/policyevaluator/RangerDefaultPolicyEvaluator.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/policyevaluator/RangerDefaultPolicyEvaluator.java
@@ -613,8 +613,14 @@ public class RangerDefaultPolicyEvaluator extends RangerAbstractPolicyEvaluator 
                             if (getPolicyPriority() >= oldPriority && allowResult != null && (oneRequest.isAccessTypeAny() || RangerAccessRequestUtil.getIsAnyAccessInContext(oneRequest.getContext()))) {
                                 accessTypeResults.put(accessType, allowResult);
                             } else {
-                                if (getPolicyPriority() > oldPriority && denyResult != null) {
-                                    accessTypeResults.put(accessType, denyResult);
+                                if (getPolicyPriority() > oldPriority) {
+                                    if (allowResult != null) {
+                                        accessTypeResults.put(accessType, allowResult);
+                                    }
+                                    else if (denyResult != null) {
+                                        accessTypeResults.put(accessType, denyResult);
+                                    }
+
                                 }
                             }
                         }

--- a/agents-common/src/test/resources/policyengine/test_policyengine_tag_hdfs.json
+++ b/agents-common/src/test/resources/policyengine/test_policyengine_tag_hdfs.json
@@ -89,6 +89,31 @@
         }
       ],
       "denyExceptions":[ ]
+    },
+    {
+      "id": 3,
+      "name": "/override-resource: allow: users=user-td, user-ra-td, user-rd-td",
+      "isEnabled": true,
+      "isAuditEnabled": false,
+      "policyPriority":1,
+      "resources": {
+        "path": { "values": [ "/override-resource" ], "isRecursive": true }
+      },
+      "policyItems": [
+        {
+          "accesses":[
+            {"type":"read" },
+            {"type":"write" }
+          ],
+          "users":["user-td", "user-ra-td", "user-rd-td"],
+          "groups":[],
+          "delegateAdmin":false,
+          "conditions" : []
+        }
+      ],
+      "allowExceptions":[],
+      "denyPolicyItems": [],
+      "denyExceptions":[]
     }
   ],
 
@@ -688,8 +713,21 @@
       },
       "result": { "isAudited": false, "isAllowed": false, "policyId": -1 }
     }
-
-
+    ,
+    {
+      "name": "ALLOW 'read /override-resource' for u=user-td",
+      "request": {
+        "resource": { "elements": { "path": "/override-resource" } },
+        "accessType": "read",
+        "user": "user-td",
+        "userGroups": [ ],
+        "requestData": "read /override-resource",
+        "context": {
+          "TAGS": "[{\"type\":\"PII\"}]"
+        }
+      },
+      "result": { "isAudited": true, "isAllowed": true, "policyId": 3 }
+    }
   ]
 }
 

--- a/agents-common/src/test/resources/policyengine/test_policyengine_tag_hive.json
+++ b/agents-common/src/test/resources/policyengine/test_policyengine_tag_hive.json
@@ -55,6 +55,12 @@
       "denyPolicyItems":[
         {"accesses":[{"type":"select","isAllowed":true}],"users":["denieduser"],"groups":[],"delegateAdmin":false}
       ]
+    },
+    {"id":104,"name":"db=default, table=table-override: audit-all-access","isEnabled":true,"isAuditEnabled":true,"policyPriority":1,
+      "resources":{"database":{"values":["default"]},"table":{"values":["table-override"]},"column":{"values":["*"]}},
+      "policyItems":[
+        {"accesses":[{"type":"read","isAllowed":true}],"users":["user-override"],"groups":[],"delegateAdmin":false}
+      ]
     }
   ],
   "tagPolicyInfo": {
@@ -185,6 +191,9 @@
         "resources":{"tag":{"values":["PII"],"isRecursive":false}},
         "policyItems":[
           {"accesses":[{"type":"hive:select","isAllowed":true}],"users":["hive"],"groups":[],"delegateAdmin":false}
+        ],
+        "denyPolicyItems":[
+          {"accesses":[{"type":"hive:select","isAllowed":true}],"users":["user-override"],"groups":[],"delegateAdmin":false}
         ]
       },
       {"id":3,"name":"PII_TAG_POLICY-FINAL","isEnabled":true,"isAuditEnabled":true,
@@ -367,8 +376,15 @@
         "context": {"TAGS":"[{\"type\":\"PII\", \"attributes\":{\"expiry\":\"2026/06/15\"}}]"}
       },
       "result":{"isAudited":true,"isAllowed":true,"policyId":2}
+    },
+    {"name":"ALLOW 'select * from default.table-override;' for user-override",
+      "request":{
+        "resource":{"elements":{"database":"default", "table":"table-override", "column":"name"}},
+        "accessType":"read","user":"user-override","userGroups":[],"requestData":"select * from default.table-override",
+        "context": {"TAGS":"[{\"type\":\"PII\"}]"}
+      },
+      "result":{"isAudited":true,"isAllowed":true,"policyId":104}
     }
-
   ]
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Steps to reproduce:
Tag an hdfs path /override-path in atlas as PII
Deny PII policy for user userx
Allow override policy for user userx
hdfs dfs -ls /override-path
User gets access denied. 
Expected behavior is access allowed

Behavior also reproducible by additional unit tests in policy engine

The PR fixes the bug wherein allow result overrides the previous deny result if priority of allow policy is greater than the priority of the deny policy

## How was this patch tested?

Added new unit tests which failed without the proposed changes.
The new unit tests pass after the bug fix.
