### PR TITLE
RANGER-3300: Switch to Chrome Headless

### DIFF
--- a/security-admin/src/test/javascript/karma-common.conf.js
+++ b/security-admin/src/test/javascript/karma-common.conf.js
@@ -84,7 +84,7 @@ module.exports = function(config, appJsLoader, jssrc) {
 
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-    browsers: ['PhantomJS'],
+    browsers: ['ChromeHeadless'],
 
 
     // Continuous Integration mode

--- a/security-admin/src/test/javascript/package.json
+++ b/security-admin/src/test/javascript/package.json
@@ -6,7 +6,6 @@
     "karma": "^3.0.0",
     "karma-chrome-launcher": "^2.2.0",
     "karma-mocha": "^1.3.0",
-    "karma-phantomjs-launcher": "^1.0.4",
     "karma-requirejs": "^1.1.0",
     "mocha": "^5.2.0",
     "requirejs": "^2.3.6"


### PR DESCRIPTION
(cherry picked from commit 68cfbd3936738399e1811a3453511545de9d508d)

## What changes were proposed in this pull request?

Phantom JS is incompatible with Linux ARM 64 so switching the browser to use Chrome Headless instead.

## How was this patch tested?
Pending CI
