### PR TITLE
RANGER-5224: dedupTags removes the valid tags while deduplicating tags

### DIFF
--- a/agents-common/src/main/java/org/apache/ranger/plugin/util/ServiceTags.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/util/ServiceTags.java
@@ -247,6 +247,7 @@ public class ServiceTags implements java.io.Serializable {
         final Map<Long, Long> replacedIds      = new HashMap<>();
         final int             initialTagsCount = tags.size();
         final List<Long>      tagIdsToRemove   = new ArrayList<>();
+        final Map<Long, RangerTag> tagsToAdd   = new HashMap<>();
 
         for (Iterator<Map.Entry<Long, RangerTag>> iter = tags.entrySet().iterator(); iter.hasNext(); ) {
             Map.Entry<Long, RangerTag> entry     = iter.next();
@@ -263,6 +264,7 @@ public class ServiceTags implements java.io.Serializable {
                     cachedTag.left = tagId;
                 } else {
                     replacedIds.put(tagId, cachedTag.left);
+                    tagsToAdd.put(cachedTag.left, tag);
                     iter.remove();
                 }
             }
@@ -271,6 +273,9 @@ public class ServiceTags implements java.io.Serializable {
         for (Long tagIdToRemove : tagIdsToRemove) {
             tags.remove(tagIdToRemove);
         }
+
+        // Add all the tags whose tagIds are modified back to tags
+        tags.putAll(tagsToAdd);
 
         final int finalTagsCount = tags.size();
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

When tag de duplication is enabled in Apache Ranger, deleting and recreating one resource causes the tag-based policy to fail for another resource that retains the same tag in Apache Atlas. After recreating the first resource, a user with access via the tag-based policy is unexpectedly denied access to the second resource, despite the tag still being associated with it.
 
In the dedupTags() method, if a tag’s ID is higher than the retained ID, the tag is removed from the tags map instead of updating its ID. This can invalidate the tag’s mapping for the second resource after the first resource’s deletion, breaking the policy.

## How was this patch tested?

Modified the extsting test(TestServiceTags.java) and newly added test will fail without fix and passes after fix.
