### PR TITLE
RANGER-3174: Support for strong cryptography algorithm-PBKDF2WithHmacSHA256

### DIFF
--- a/kms/src/main/java/org/apache/hadoop/crypto/key/RangerKMSMKI.java
+++ b/kms/src/main/java/org/apache/hadoop/crypto/key/RangerKMSMKI.java
@@ -32,5 +32,9 @@ public interface RangerKMSMKI {
         return null;
     }
 
-    default void onInitialization() throws Exception                     {}
+    default void onInitialization() throws Exception {}
+
+    default boolean reencryptMKWithFipsAlgo(String mkPassword) throws Exception {
+        return  false;
+    }
 }

--- a/kms/src/main/java/org/apache/hadoop/crypto/key/RangerKeyStore.java
+++ b/kms/src/main/java/org/apache/hadoop/crypto/key/RangerKeyStore.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.crypto.key.RangerKeyStoreProvider.KeyMetadata;
 import org.apache.ranger.entity.XXRangerKeyStore;
 import org.apache.ranger.kms.dao.DaoManager;
 import org.apache.ranger.kms.dao.RangerKMSDao;
+import org.apache.ranger.plugin.util.JsonUtilsV2;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,7 +38,6 @@ import javax.crypto.SealedObject;
 import javax.crypto.SecretKey;
 import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.PBEKeySpec;
-import javax.crypto.spec.PBEParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 import javax.xml.bind.DatatypeConverter;
 
@@ -78,6 +78,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -95,16 +96,23 @@ public class RangerKeyStore extends KeyStoreSpi {
     private static final String  AZURE_KEYVAULT_ENABLED  = "ranger.kms.azurekeyvault.enabled";
     private static final String  METADATA_FIELDNAME      = "metadata";
     private static final int     NUMBER_OF_BITS_PER_BYTE = 8;
-    private static final String  SECRET_KEY_HASH_WORD    = "Apache Ranger";
+    private static final String SECRET_KEY_HASH_WORD     = "Apache Ranger";
+    public  static final String KEY_CRYPTO_ALGO_NAME     = "keyCryptoAlgoName";
 
     private final    RangerKMSDao        kmsDao;
     private final    RangerKMSMKI        masterKeyProvider;
     private final    boolean             keyVaultEnabled;
+    private          boolean             isFIPSEnabled;
     private final    Map<String, Object> deltaEntries = new ConcurrentHashMap<>();
     private volatile Map<String, Object> keyEntries   = new ConcurrentHashMap<>();
 
     public RangerKeyStore(DaoManager daoManager) {
         this(daoManager, false, null);
+    }
+
+    public RangerKeyStore(boolean isFIPSEnabled, DaoManager daoManager) {
+        this(daoManager);
+        this.isFIPSEnabled = isFIPSEnabled;
     }
 
     public RangerKeyStore(DaoManager daoManager, Configuration conf, KeyVaultClient kvClient) {
@@ -131,7 +139,7 @@ public class RangerKeyStore extends KeyStoreSpi {
 
         if (entry instanceof SecretKeyEntry) {
             try {
-                ret = unsealKey(((SecretKeyEntry) entry).sealedKey, password);
+                ret = unsealKey((SecretKeyEntry) entry, password);
             } catch (Exception e) {
                 logger.error("engineGetKey({}) error", alias, e);
             }
@@ -470,13 +478,20 @@ public class RangerKeyStore extends KeyStoreSpi {
         logger.debug("<== addSecureKeyByteEntry({})", alias);
     }
 
+    private String addEncrAlgoNameInKeyAttrib(String jsonAttrib) throws Exception {
+        Map<String, String> attribMap = JsonUtilsV2.jsonToMap(jsonAttrib);
+        attribMap.put(KEY_CRYPTO_ALGO_NAME, SupportedPBECryptoAlgo.PBKDF2WithHmacSHA256.getAlgoName());
+        return JsonUtilsV2.mapToJson(attribMap);
+    }
+
     public void addKeyEntry(String alias, Key key, char[] password, String cipher, int bitLength, String description, int version, String attributes) throws KeyStoreException {
         logger.debug("==> addKeyEntry({})", alias);
 
         SecretKeyEntry entry;
 
         try {
-            entry = new SecretKeyEntry(sealKey(key, password), cipher, bitLength, description, version, attributes);
+            String updatedAttribute = isFIPSEnabled ? addEncrAlgoNameInKeyAttrib(attributes) : attributes;
+            entry = new SecretKeyEntry(sealKey(key, password), cipher, bitLength, description, version, updatedAttribute);
         } catch (Exception e) {
             logger.error("addKeyEntry({}) error", alias, e);
 
@@ -916,62 +931,110 @@ public class RangerKeyStore extends KeyStoreSpi {
     }
 
     private SealedObject sealKey(Key key, char[] password) throws Exception {
-        logger.debug("==> sealKey()");
+        logger.debug("==> RangerKeyStore.sealKey()");
 
         // Create SecretKey
-        SecretKeyFactory secretKeyFactory = SecretKeyFactory.getInstance("PBEWithMD5AndTripleDES");
-        PBEKeySpec       pbeKeySpec       = new PBEKeySpec(password);
-        SecretKey        secretKey        = secretKeyFactory.generateSecret(pbeKeySpec);
+        SupportedPBECryptoAlgo encrAlgo         = isFIPSEnabled ? SupportedPBECryptoAlgo.PBKDF2WithHmacSHA256 : SupportedPBECryptoAlgo.PBEWithMD5AndTripleDES;
+        SecretKeyFactory       secretKeyFactory = SecretKeyFactory.getInstance(encrAlgo.getAlgoName());
 
-        pbeKeySpec.clearPassword();
-
-        // Generate random bytes, set up the PBEParameterSpec, seal the key
+        PBEKeySpec             pbeKeySpec = null;
+        PBEKeySpec             pbeCipherSpec = null;
+        byte[] salt = null;
         SecureRandom random = new SecureRandom();
-        byte[]       salt   = new byte[8];
-
-        random.nextBytes(salt);
-
-        PBEParameterSpec pbeSpec = new PBEParameterSpec(salt, 20);
-        Cipher           cipher  = Cipher.getInstance("PBEWithMD5AndTripleDES");
-
-        cipher.init(Cipher.ENCRYPT_MODE, secretKey, pbeSpec);
-
-        RangerSealedObject ret = new RangerSealedObject(key, cipher);
-
-        logger.debug("<== sealKey(): ret={}", ret);
-
-        return ret;
-    }
-
-    private Key unsealKey(SealedObject sealedKey, char[] password) throws Exception {
-        logger.debug("==> unsealKey()");
-
-        // Create SecretKey
-        SecretKeyFactory secretKeyFactory = SecretKeyFactory.getInstance("PBEWithMD5AndTripleDES");
-        PBEKeySpec       pbeKeySpec       = new PBEKeySpec(password);
-        SecretKey        secretKey        = secretKeyFactory.generateSecret(pbeKeySpec);
-
-        pbeKeySpec.clearPassword();
-
-        // Get the AlgorithmParameters from RangerSealedObject
-        AlgorithmParameters algorithmParameters;
-
-        if (sealedKey instanceof RangerSealedObject) {
-            algorithmParameters = ((RangerSealedObject) sealedKey).getParameters();
+        if (SupportedPBECryptoAlgo.PBKDF2WithHmacSHA256.equals(encrAlgo)) {
+            salt = new byte[8 * 2];
+            random.nextBytes(salt);
+            pbeKeySpec = new PBEKeySpec(password, salt, 20, encrAlgo.getKeyLength());
+            pbeCipherSpec = pbeKeySpec;
         } else {
-            algorithmParameters = new RangerSealedObject(sealedKey).getParameters();
+            salt = new byte[8];
+            random.nextBytes(salt);
+            pbeKeySpec = new PBEKeySpec(password);
+            pbeCipherSpec = new PBEKeySpec(password, salt, 20);
         }
 
+        SecretKey secretKey = secretKeyFactory.generateSecret(pbeKeySpec);
+        pbeKeySpec.clearPassword();
+
+        // Seal the Key
+        Cipher cipher = Cipher.getInstance(encrAlgo.getCipherTransformation());
+        cipher.init(Cipher.ENCRYPT_MODE, secretKey, encrAlgo.getAlgoParamSpec(pbeCipherSpec));
+
+        logger.debug("<== RangerKeyStore.sealKey()");
+
+        return new RangerSealedObject(key, cipher, salt);
+    }
+
+    private Key unsealKey(SecretKeyEntry secretKeyEntry, char[] password) throws Exception {
+        logger.debug("==> RangerKeyStore.unsealKey()");
+
+        // fetch encryption algo name
+        String encrAlgoName = JsonUtilsV2.jsonToMap(secretKeyEntry.attributes).get(KEY_CRYPTO_ALGO_NAME);
+        SupportedPBECryptoAlgo encrAlgo;
+        if (StringUtils.isNotEmpty(encrAlgoName)) {
+            encrAlgo = SupportedPBECryptoAlgo.valueOf(encrAlgoName);
+        } else {
+            encrAlgo = SupportedPBECryptoAlgo.PBEWithMD5AndTripleDES;
+        }
+
+        SealedObject sealedKey = secretKeyEntry.sealedKey;
+        // Get the AlgorithmParameters from RangerSealedObject
+        AlgorithmParameters algorithmParameters = null;
+        byte[] salt = null;
+        PBEKeySpec pbeKeySpec = null;
+
+        if (SupportedPBECryptoAlgo.PBKDF2WithHmacSHA256.equals(encrAlgo)) {
+            salt = ((RangerSealedObject) sealedKey).getSalt();
+            pbeKeySpec = new PBEKeySpec(password, salt, 20, encrAlgo.getKeyLength());
+        } else { // not yet re-encrypted, older algo
+            if (sealedKey instanceof RangerSealedObject) {
+                algorithmParameters = ((RangerSealedObject) sealedKey).getParameters(encrAlgo.getAlgoName());
+            } else {
+                algorithmParameters = new RangerSealedObject(sealedKey).getParameters(encrAlgo.getAlgoName());
+            }
+            pbeKeySpec = new PBEKeySpec(password);
+        }
+
+        // Create SecretKey
+        SecretKeyFactory secretKeyFactory = SecretKeyFactory.getInstance(encrAlgo.getAlgoName());
+        SecretKey secretKey = secretKeyFactory.generateSecret(pbeKeySpec);
+        pbeKeySpec.clearPassword();
+
         // Unseal the Key
-        Cipher cipher = Cipher.getInstance("PBEWithMD5AndTripleDES");
+        Cipher cipher = Cipher.getInstance(encrAlgo.getCipherTransformation());
 
-        cipher.init(Cipher.DECRYPT_MODE, secretKey, algorithmParameters);
+        if (SupportedPBECryptoAlgo.PBKDF2WithHmacSHA256.equals(encrAlgo)) {
+            cipher.init(Cipher.DECRYPT_MODE, secretKey, encrAlgo.getAlgoParamSpec(pbeKeySpec));
+        } else {
+            cipher.init(Cipher.DECRYPT_MODE, secretKey, algorithmParameters);
+        }
 
-        Key ret = (Key) sealedKey.getObject(cipher);
+        logger.debug("<== RangerKeyStore.unsealKey()");
 
-        logger.debug("<== unsealKey(): ret={}", ret);
+        return (Key) sealedKey.getObject(cipher);
+    }
 
-        return ret;
+    public void reencryptZoneKeysWithNewAlgo(InputStream stream, char[] password) throws Exception {
+        logger.debug("==> RangerKeyStore.reencryptZoneKeysWithNewAlgo");
+
+        try {
+            this.engineLoad(stream, password);
+            Set<String> keyAliases = new HashSet<>(keyEntries.keySet());
+            logger.info("Count of key aliases to be re-encrypted=" + keyAliases.size());
+            for (String keyAlias : keyAliases) {
+                Key key = this.engineGetKey(keyAlias, password);
+                SecretKeyEntry entry = (SecretKeyEntry) keyEntries.remove(keyAlias);
+                this.addKeyEntry(keyAlias, key, password, entry.cipherField, entry.bitLength, entry.description, entry.version, entry.attributes);
+            }
+            this.engineStore(null, password);
+            logger.info("All zone keys got re-encrypted");
+        } catch (IOException | NoSuchAlgorithmException | CertificateException | UnrecoverableKeyException | KeyStoreException e) {
+            logger.error("Error occurred while re-encrypting the zone keys", e);
+            throw e;
+        }
+        finally {
+            logger.debug("<== RangerKeyStore.reencryptZoneKeysWithNewAlgo");
+        }
     }
 
     // keys
@@ -1034,6 +1097,8 @@ public class RangerKeyStore extends KeyStoreSpi {
     private static class RangerSealedObject extends SealedObject {
         private static final long serialVersionUID = -7551578543434362070L;
 
+        private byte[] salt;
+
         /**
          *
          */
@@ -1045,12 +1110,21 @@ public class RangerKeyStore extends KeyStoreSpi {
             super(object, cipher);
         }
 
-        public AlgorithmParameters getParameters() throws NoSuchAlgorithmException, IOException {
-            AlgorithmParameters algorithmParameters = AlgorithmParameters.getInstance("PBEWithMD5AndTripleDES");
+        protected RangerSealedObject(Serializable object, Cipher cipher, byte[] salt) throws IllegalBlockSizeException, IOException {
+            this(object, cipher);
+            this.salt =  salt;
+        }
+
+        public AlgorithmParameters getParameters(String algoName) throws NoSuchAlgorithmException, IOException {
+            AlgorithmParameters algorithmParameters = AlgorithmParameters.getInstance(algoName);
 
             algorithmParameters.init(super.encodedParams);
 
             return algorithmParameters;
+        }
+
+        public byte[] getSalt() {
+            return this.salt;
         }
     }
 

--- a/kms/src/main/java/org/apache/hadoop/crypto/key/RangerKeyStore.java
+++ b/kms/src/main/java/org/apache/hadoop/crypto/key/RangerKeyStore.java
@@ -1020,7 +1020,7 @@ public class RangerKeyStore extends KeyStoreSpi {
         try {
             this.engineLoad(stream, password);
             Set<String> keyAliases = new HashSet<>(keyEntries.keySet());
-            logger.info("Count of key aliases to be re-encrypted=" + keyAliases.size());
+            logger.info("Count of key aliases to be re-encrypted = {}", keyAliases.size());
             for (String keyAlias : keyAliases) {
                 Key key = this.engineGetKey(keyAlias, password);
                 SecretKeyEntry entry = (SecretKeyEntry) keyEntries.remove(keyAlias);

--- a/kms/src/main/java/org/apache/hadoop/crypto/key/RangerKeyStore.java
+++ b/kms/src/main/java/org/apache/hadoop/crypto/key/RangerKeyStore.java
@@ -970,12 +970,7 @@ public class RangerKeyStore extends KeyStoreSpi {
 
         // fetch encryption algo name
         String encrAlgoName = JsonUtilsV2.jsonToMap(secretKeyEntry.attributes).get(KEY_CRYPTO_ALGO_NAME);
-        SupportedPBECryptoAlgo encrAlgo;
-        if (StringUtils.isNotEmpty(encrAlgoName)) {
-            encrAlgo = SupportedPBECryptoAlgo.valueOf(encrAlgoName);
-        } else {
-            encrAlgo = SupportedPBECryptoAlgo.PBEWithMD5AndTripleDES;
-        }
+        SupportedPBECryptoAlgo encrAlgo = StringUtils.isNotEmpty(encrAlgoName) ? SupportedPBECryptoAlgo.valueOf(encrAlgoName) : SupportedPBECryptoAlgo.PBEWithMD5AndTripleDES;
 
         SealedObject sealedKey = secretKeyEntry.sealedKey;
         // Get the AlgorithmParameters from RangerSealedObject
@@ -987,11 +982,7 @@ public class RangerKeyStore extends KeyStoreSpi {
             salt = ((RangerSealedObject) sealedKey).getSalt();
             pbeKeySpec = new PBEKeySpec(password, salt, 20, encrAlgo.getKeyLength());
         } else { // not yet re-encrypted, older algo
-            if (sealedKey instanceof RangerSealedObject) {
-                algorithmParameters = ((RangerSealedObject) sealedKey).getParameters(encrAlgo.getAlgoName());
-            } else {
-                algorithmParameters = new RangerSealedObject(sealedKey).getParameters(encrAlgo.getAlgoName());
-            }
+            algorithmParameters = sealedKey instanceof RangerSealedObject ? ((RangerSealedObject) sealedKey).getParameters(encrAlgo.getAlgoName()) : new RangerSealedObject(sealedKey).getParameters(encrAlgo.getAlgoName());
             pbeKeySpec = new PBEKeySpec(password);
         }
 

--- a/kms/src/main/java/org/apache/hadoop/crypto/key/RangerKeyStoreProvider.java
+++ b/kms/src/main/java/org/apache/hadoop/crypto/key/RangerKeyStoreProvider.java
@@ -17,6 +17,7 @@
 
 package org.apache.hadoop.crypto.key;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
@@ -93,6 +94,10 @@ public class RangerKeyStoreProvider extends KeyProvider {
     private final boolean               keyVaultEnabled;
     private       boolean               changed;
 
+    private        boolean isFIPSEnabled;
+    private        boolean isMKReencrypted;
+    private        boolean isNewMKGenerated;
+
     public RangerKeyStoreProvider(Configuration conf) throws Throwable {
         super(conf);
 
@@ -122,6 +127,10 @@ public class RangerKeyStoreProvider extends KeyProvider {
         final RangerKMSDB  rangerKMSDB = new RangerKMSDB(conf);
         final DaoManager   daoManager  = rangerKMSDB.getDaoManager();
         final RangerKMSMKI masterKeyProvider;
+
+        String storeType = conf.get("ranger.keystore.file.type", KeyStore.getDefaultType());
+        this.isFIPSEnabled = StringUtils.equalsIgnoreCase("bcfks", storeType) ? true : false;
+        logger.info("isFIPSEnabled={}",  isFIPSEnabled);
 
         if (isHSMEnabled) {
             logger.info("Ranger KMS HSM is enabled for storing master key.");
@@ -216,8 +225,30 @@ public class RangerKeyStoreProvider extends KeyProvider {
             logger.info("Ranger KMS Database is enabled for storing master key.");
 
             masterKeyProvider = new RangerMasterKey(daoManager);
-            dbStore           = new RangerKeyStore(daoManager);
-            masterKey         = this.generateAndGetMasterKey(masterKeyProvider, password);
+
+            dbStore   = new RangerKeyStore(isFIPSEnabled, daoManager);
+            char[] tempMK;
+            tempMK = this.generateAndGetMasterKey(masterKeyProvider, password);
+
+            if (isFIPSEnabled && !isNewMKGenerated) {
+                logger.info("MasterKey already exists and FIPS is enabled, may require re-encryption with compliant algorithm");
+                this.isMKReencrypted = masterKeyProvider.reencryptMKWithFipsAlgo(password);
+                logger.info("MasterKey re-encryption status {}", this.isMKReencrypted);
+
+                // initialize with new MK
+                try {
+                    tempMK = masterKeyProvider.getMasterKey(password).toCharArray();
+                } catch (Throwable e) {
+                    throw new RuntimeException("Error while getting Ranger Master key, Error - " + e.getMessage());
+                }
+            }
+
+            this.masterKey = tempMK;
+        }
+
+        // If MK required re-encryption, means Zone keys were also encrypted using older algo and needs to be re-encrypted.
+        if (isFIPSEnabled  && isMKReencrypted) {
+            this.dbStore.reencryptZoneKeysWithNewAlgo(null, this.masterKey);
         }
 
         reloadKeys();
@@ -595,7 +626,7 @@ public class RangerKeyStoreProvider extends KeyProvider {
         char[] ret;
 
         try {
-            masterKeyProvider.generateMasterKey(password);
+            this.isNewMKGenerated = masterKeyProvider.generateMasterKey(password);
         } catch (Throwable cause) {
             throw new RuntimeException("Error while generating Ranger Master key, Error - ", cause);
         }

--- a/kms/src/main/java/org/apache/hadoop/crypto/key/SupportedPBECryptoAlgo.java
+++ b/kms/src/main/java/org/apache/hadoop/crypto/key/SupportedPBECryptoAlgo.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.crypto.key;
+
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.PBEKeySpec;
+import javax.crypto.spec.PBEParameterSpec;
+
+import java.security.spec.AlgorithmParameterSpec;
+import java.util.function.Function;
+
+public enum SupportedPBECryptoAlgo {
+    @Deprecated
+    PBEWithMD5AndTripleDES("PBEWithMD5AndTripleDES",
+      "PBEWithMD5AndTripleDES",
+      0, keySpec -> new PBEParameterSpec(keySpec.getSalt(), keySpec.getIterationCount())),
+    @Deprecated
+    PBEWithMD5AndDES("PBEWithMD5AndDES",
+      "PBEWithMD5AndDES",
+      0, keySpec -> new PBEParameterSpec(keySpec.getSalt(), keySpec.getIterationCount())),
+    PBKDF2WithHmacSHA256("PBKDF2WithHmacSHA256",
+      "AES/CBC/PKCS7Padding",
+      64 * 4, keySpec -> new IvParameterSpec(keySpec.getSalt()));
+    private final String encrAlgoName;
+    private final String  cipherTransformation;
+    private final int     keyLength;
+    private final Function<PBEKeySpec, AlgorithmParameterSpec> algoParamSpecFunc;
+
+    SupportedPBECryptoAlgo(String encrAlgoName, String cipherTransformation, int keyLength, Function<PBEKeySpec, AlgorithmParameterSpec> algoParamSpecFunc) {
+        this.encrAlgoName         = encrAlgoName;
+        this.cipherTransformation = cipherTransformation;
+        this.keyLength            = keyLength;
+        this.algoParamSpecFunc    = algoParamSpecFunc;
+    }
+
+    public int getKeyLength() {
+        return this.keyLength;
+    }
+
+    public String getAlgoName() {
+        return this.encrAlgoName;
+    }
+
+    public String getCipherTransformation() {
+        return this.cipherTransformation;
+    }
+
+    public AlgorithmParameterSpec getAlgoParamSpec(PBEKeySpec keySpec) {
+        return this.algoParamSpecFunc.apply(keySpec);
+    }
+
+    public static SupportedPBECryptoAlgo getFIPSCompliantAlgorithm() {
+        return SupportedPBECryptoAlgo.PBKDF2WithHmacSHA256;
+    }
+
+    public static boolean isFIPSCompliantAlgorithm(SupportedPBECryptoAlgo encrAlgo) {
+        return SupportedPBECryptoAlgo.PBKDF2WithHmacSHA256.equals(encrAlgo);
+    }
+}


### PR DESCRIPTION
…PBE encryption

## What changes were proposed in this pull request?

Currently Ranger KMS supports following Password based encryption  (PBE) to encrypt/decrypt MasterKey and Zone keys:
**PBEWithMD5AndDES, PBEWithMD5AndTripleDES**

Both algorithms are weak .

With this commit, now KMS will start supporting PBKDF2WithHmacSHA256 algorithm if FIPS is enabled. This algorithm is FIPS complaint and being provided by many SecurityProviders. 
Currently I have kept this if FIPS is enabled, means, if keyStoreType is **"bcfks"**

So if FIPS is enabled, then following will happen:
1. All new keys material will be encrypted/decrypted using PBKDF2WithHmacSHA256 algorithm.
2. Any older keys (including MasterKey) will be re-encrypted using  PBKDF2WithHmacSHA256 on KMS service start. This is an one time operation. Here re-encryption means, decrypting the older keys using older algorithm and re-encryption it using the current PBKDF2WithHmacSHA256 algorithm.

Please note that key material is not changing, only it is being re-encrypted before storing into DB. hence, there is no risk of data loss.
 

## How was this patch tested?
1. basic mvn build and UnitTest cases.
2. Manual testing in docker setup. I used following steps to prepare  docker container for this testing:
   -  I used **bc-fips-2.0.0.jar** as SecurityProvider for PBKDF2WithHmacSHA256
   -  Copied **bc-fips-2.0.0.jar** jar to the `/usr/lib/jvm/java-8-openjdk-arm64/jre/lib/ext/`
   - Update java.security file at `/etc/java-8-openjdk/security/java.security` to contain following content:
        
        security.provider.1=org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider
        org.bouncycastle.fips.approved_only=true

   - **For rangerkms.jceks** (that contains MasterKey password and DB password) : created corresponding keystore in bcfks formart named  rangerkms.localbcfks
   - **dbks-site.xml** :  Updated following properties in this file:
        
        Key: ranger.ks.jpa.jdbc.credential.provider.path
        Value: localbcfks://file/opt/ranger/kms/ews/webapp/WEB-INF/classes/conf/rangerkms.localbcfks
        
        Key: ranger.keystore.file.type
        Value: bcfks

**Scenarios Tested:**

1. **Fresh setup:** Masterkey and Zone keys got created using latest algorithm. And basic encryption/decryption was working fine.
2. **Cluster having old keys with older algorithm:**
      - Here created one zone key (zonekey1) and one encryption Zone and copied one test file inside the zone key
      - Means, file got encrypted using DEK , and this DEK was encrypted using corresponding zone keys . This zone keys was   encrypted using PBEWithMD5AndDES.
      - Then, created a new ranger-kms docker image with new changes. And started the container.
      -  Here Masterkey and all zone keys got re-encypted using new algorithm.
      -  Files kept inside encryptionZone was accessible after keys re-encryption.
      -  Also, basic key life cycle like create/rotate/delete was also working.