### PR TITLE
RANGER-5227: Add healthchecks for all docker containers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,11 +168,10 @@ jobs:
           -f docker-compose.ranger-kafka.yml \
           -f docker-compose.ranger-hive.yml \
           -f docker-compose.ranger-knox.yml \
-          -f docker-compose.ranger-ozone.yml up -d
+          -f docker-compose.ranger-ozone.yml up -d --wait
 
       - name: Check status of containers and remove them
         run: |
-          sleep 60
           containers=(ranger ranger-zk ranger-solr ranger-postgres ranger-usersync ranger-tagsync ranger-kms ranger-hadoop ranger-hbase ranger-kafka ranger-hive ranger-knox ozone-om ozone-scm ozone-datanode);
           flag=true;
           for container in "${containers[@]}"; do

--- a/dev-support/ranger-docker/Dockerfile.ranger-base
+++ b/dev-support/ranger-docker/Dockerfile.ranger-base
@@ -24,7 +24,7 @@ ENV OS_NAME=UBUNTU
 # Install tzdata, Python, Java, python-requests
 RUN apt-get update && \
     DEBIAN_FRONTEND="noninteractive" apt-get -y install tzdata vim\
-    python3 python3-pip openjdk-8-jdk openjdk-11-jdk openjdk-17-jdk bc iputils-ping ssh pdsh xmlstarlet && \
+    python3 python3-pip openjdk-8-jdk openjdk-11-jdk openjdk-17-jdk bc iputils-ping ssh pdsh xmlstarlet curl && \
     pip3 install apache-ranger && \
     pip3 install requests
 

--- a/dev-support/ranger-docker/docker-compose.ranger-hadoop.yml
+++ b/dev-support/ranger-docker/docker-compose.ranger-hadoop.yml
@@ -21,8 +21,8 @@ services:
       ranger:
         condition: service_started
     healthcheck:
-      test: "hdfs dfs -ls /hbase"
-      interval: 1m30s
+      test: [ "CMD-SHELL", "su hdfs -c \"/opt/hadoop/bin/hdfs dfsadmin -report | grep -q 'Live datanodes'\"" ]
+      interval: 30s
       timeout: 10s
       retries: 30
       start_period: 40s

--- a/dev-support/ranger-docker/docker-compose.ranger-hbase.yml
+++ b/dev-support/ranger-docker/docker-compose.ranger-hbase.yml
@@ -23,6 +23,12 @@ services:
         condition: service_healthy
       ranger-zk:
         condition: service_started
+    healthcheck:
+      test: [ "CMD", "wget", "-q", "--spider", "http://localhost:16030/rs-status" ]
+      interval: 30s
+      timeout: 10s
+      retries: 30
+      start_period: 40s
     environment:
       - HBASE_VERSION
       - HBASE_PLUGIN_VERSION

--- a/dev-support/ranger-docker/docker-compose.ranger-hive.yml
+++ b/dev-support/ranger-docker/docker-compose.ranger-hive.yml
@@ -24,6 +24,12 @@ services:
         condition: service_started
       ranger-hadoop:
         condition: service_healthy
+    healthcheck:
+      test: [ "CMD-SHELL", "su hdfs -c \"/opt/hadoop/bin/hdfs dfsadmin -report | grep -q 'Live datanodes'\"" ]
+      interval: 30s
+      timeout: 10s
+      retries: 30
+      start_period: 40s
     environment:
       - HIVE_HADOOP_VERSION
       - HIVE_VERSION

--- a/dev-support/ranger-docker/docker-compose.ranger-kafka.yml
+++ b/dev-support/ranger-docker/docker-compose.ranger-kafka.yml
@@ -20,9 +20,18 @@ services:
         condition: service_started
       ranger-zk:
         condition: service_started
+    healthcheck:
+      test: [ "CMD-SHELL", "echo 'ping' | kafka-console-producer.sh --broker-list localhost:9092 --topic health-check-topic && kafka-console-consumer.sh --bootstrap-server localhost:9092 --topic health-check-topic --from-beginning --max-messages 1 | grep 'ping'" ]
+      interval: 60s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
     environment:
-      - KAFKA_VERSION
-      - KAFKA_PLUGIN_VERSION
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://ranger-kafka:9092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_VERSION: ${KAFKA_VERSION}
+      KAFKA_PLUGIN_VERSION: ${KAFKA_PLUGIN_VERSION}
 
 networks:
   ranger:

--- a/dev-support/ranger-docker/docker-compose.ranger-kms.yml
+++ b/dev-support/ranger-docker/docker-compose.ranger-kms.yml
@@ -18,6 +18,12 @@ services:
     depends_on:
       ranger:
         condition: service_started
+    healthcheck:
+      test: [ "CMD-SHELL", "grep 'Ranger KMS Started' /var/log/ranger/kms/ranger-kms*.log" ]
+      interval: 40s
+      timeout: 5s
+      retries: 10
+      start_period: 40s
     environment:
       - KMS_VERSION
       - RANGER_DB_TYPE

--- a/dev-support/ranger-docker/docker-compose.ranger-knox.yml
+++ b/dev-support/ranger-docker/docker-compose.ranger-knox.yml
@@ -20,6 +20,12 @@ services:
         condition: service_started
       ranger-zk:
         condition: service_started
+    healthcheck:
+      test: [ "CMD-SHELL", "curl -k -i -u admin:admin-password 'https://localhost:8443/gateway/sandbox/webhdfs/v1/?op=LISTSTATUS'" ]
+      interval: 60s
+      timeout: 10s
+      retries: 10
+      start_period: 10s
     environment:
       - KNOX_VERSION
       - KNOX_PLUGIN_VERSION

--- a/dev-support/ranger-docker/docker-compose.ranger-ozone.yml
+++ b/dev-support/ranger-docker/docker-compose.ranger-ozone.yml
@@ -38,6 +38,12 @@ services:
         condition: service_started
       ranger-solr:
         condition: service_started
+    healthcheck:
+      test: [ "CMD-SHELL", "su om -c \"/opt/hadoop/bin/ozone fs -ls ofs://om/\"" ]
+      interval: 40s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
     environment:
       ENSURE_OM_INITIALIZED: /data/metadata/om/current/VERSION
       OZONE_OPTS: -Dcom.sun.net.ssl.checkRevocation=false

--- a/dev-support/ranger-docker/docker-compose.ranger-tagsync.yml
+++ b/dev-support/ranger-docker/docker-compose.ranger-tagsync.yml
@@ -15,6 +15,12 @@ services:
     depends_on:
       ranger:
         condition: service_started
+    healthcheck:
+      test: [ "CMD-SHELL", "grep 'Initializing TAG source and sink' /var/log/ranger/tagsync/tagsync*log*" ]
+      interval: 30s
+      timeout: 3s
+      retries: 10
+      start_period: 40s
     environment:
       - TAGSYNC_VERSION
       - DEBUG_TAGSYNC=${DEBUG_TAGSYNC:-false}

--- a/dev-support/ranger-docker/docker-compose.ranger-usersync.yml
+++ b/dev-support/ranger-docker/docker-compose.ranger-usersync.yml
@@ -15,6 +15,12 @@ services:
     depends_on:
       ranger:
         condition: service_started
+    healthcheck:
+      test: [ "CMD-SHELL", "grep 'uploaded to ranger admin' /var/log/ranger/usersync/usersync*.log*" ]
+      interval: 30s
+      timeout: 3s
+      retries: 10
+      start_period: 40s
     environment:
       - USERSYNC_VERSION
       - ENABLE_FILE_SYNC_SOURCE

--- a/dev-support/ranger-docker/docker-compose.ranger.yml
+++ b/dev-support/ranger-docker/docker-compose.ranger.yml
@@ -23,6 +23,12 @@ services:
         condition: service_healthy
       ranger-solr:
         condition: service_started
+    healthcheck:
+      test: [ "CMD-SHELL", "curl -i -u admin:rangerR0cks! 'http://localhost:6080'" ]
+      interval: 60s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
     environment:
       - RANGER_VERSION
       - RANGER_DB_TYPE
@@ -48,6 +54,14 @@ services:
       - ranger
     ports:
       - "2181:2181"
+    healthcheck:
+      test: [ "CMD-SHELL", "echo ruok | nc localhost 2181 | grep imok" ]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 20s
+    environment:
+      ZOO_4LW_COMMANDS_WHITELIST: "mntr,conf,ruok"
 
   ranger-solr:
     build:
@@ -66,6 +80,12 @@ services:
       - solr-precreate
       - ranger_audits
       - /opt/solr/server/solr/configsets/ranger_audits/
+    healthcheck:
+      test: [ "CMD-SHELL", "curl -f http://localhost:8983/solr/ranger_audits/admin/ping" ]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 20s
 
 networks:
   ranger:


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Add health checks in `docker-compose.yaml` for all supported docker services.
- Add `curl` to the `ranger-base` image to aid in generic health checks across containers.
- Update env variables to allow creation of topic in Kafka container.
- Explicitly allow `ruok` command in whitelist for Zookeeper container.


## How was this patch tested?

Tested changes locally for all containers, `docker ps` reports all containers as `healthy`.