### PR TITLE
RANGER-5251: dedupTags() doesn’t remove duplicate tag IDs within a si…

### DIFF
--- a/agents-common/src/main/java/org/apache/ranger/plugin/util/ServiceTags.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/util/ServiceTags.java
@@ -33,10 +33,12 @@ import org.apache.ranger.plugin.model.RangerTagDef;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
+import java.util.Set;
 
 @JsonAutoDetect(fieldVisibility = Visibility.ANY)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
@@ -280,6 +282,7 @@ public class ServiceTags implements java.io.Serializable {
         final int finalTagsCount = tags.size();
 
         for (Map.Entry<Long, List<Long>> resourceEntry : resourceToTagIds.entrySet()) {
+            Set<Long> uniqueTagIds = new HashSet<>(resourceEntry.getValue().size());
             for (ListIterator<Long> listIter = resourceEntry.getValue().listIterator(); listIter.hasNext(); ) {
                 final Long tagId       = listIter.next();
                 Long       mappedTagId = null;
@@ -289,6 +292,11 @@ public class ServiceTags implements java.io.Serializable {
                 }
 
                 if (mappedTagId == null) {
+                    continue;
+                }
+
+                if (!uniqueTagIds.add(mappedTagId)) {
+                    listIter.remove();
                     continue;
                 }
 


### PR DESCRIPTION
…ngle resource’s resourceToTagIds list

## What changes were proposed in this pull request?

removed the duplicate entries from resourceTotagIds


## How was this patch tested?

Added a new test testDedupTags_DuplicateResourceToTagIds, this test will fail without fix and pass with fix. I ran mvn clean install and no failures were observed.
