### PR TITLE
RANGER-5126: Updates to upgrade workflow

### DIFF
--- a/.github/workflows/upgrade-ranger.yaml
+++ b/.github/workflows/upgrade-ranger.yaml
@@ -1,0 +1,109 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Upgrade Ranger
+
+on:
+  workflow_dispatch:
+    inputs:
+      build-branch:
+        description: 'branch to checkout and build'
+        required: true
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.build-branch }}
+
+      - name: Clean up Docker space
+        run: docker system prune --all --force --volumes
+
+      - name: Build Ranger from branch ${{ inputs.build-branch }} in Docker
+        run: |
+          cd dev-support/ranger-docker
+          docker compose -f docker-compose.ranger-build.yml build
+          docker compose -f docker-compose.ranger-build.yml up -d
+
+          # Get container ID of ranger-build
+          CONTAINER_ID=$(docker ps -aqf "name=ranger-build")
+
+          docker logs -f $CONTAINER_ID &
+
+          # Wait for the container to exit
+          docker wait $CONTAINER_ID
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.build-branch }}-build-artifacts
+          path: dev-support/ranger-docker/dist/*
+
+  upgrade:
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        earlier-release: [2.6.0]
+        db: [postgres, mysql, oracle]
+    runs-on: ubuntu-22.04
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.build-branch }}
+
+      - name: Download previous build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.build-branch }}-build-artifacts
+
+      - name: Copy artifacts for docker build
+        run: |
+          cp ranger-*.tar.gz dev-support/ranger-docker/dist
+          cp version dev-support/ranger-docker/dist
+          ls -lrt dev-support/ranger-docker/dist/
+      
+      - name: Run download-archives.sh
+        run: |
+          cd dev-support/ranger-docker
+          ./download-archives.sh none
+      
+      - name: Bringing up Ranger ${{ matrix.earlier-release }} in Docker
+        run: |
+          cd dev-support/ranger-docker
+          chmod +x download-ranger.sh && ./download-ranger.sh
+          export RANGER_DB_TYPE=${{ matrix.db }}
+          export RANGER_VERSION=${{ matrix.earlier-release }}
+          docker compose -f docker-compose.ranger.yml build
+          docker compose -f docker-compose.ranger.yml up -d
+          sleep 30
+          docker logs ranger
+
+      - name: Upgrading to ${{ inputs.build-branch }} in Docker
+        run: |
+          cd dev-support/ranger-docker
+          export RANGER_DB_TYPE=${{ matrix.db }}
+          docker compose -f docker-compose.ranger.yml  build
+          docker compose -f docker-compose.ranger.yml  up -d
+          sleep 180
+          docker logs ranger
+
+      - name: Remove running containers
+        run: |
+          docker stop $(docker ps -q) && docker rm $(docker ps -aq)

--- a/dev-support/ranger-docker/download-ranger.sh
+++ b/dev-support/ranger-docker/download-ranger.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -u -o pipefail
+
+: ${BASE_URL:="https://www.apache.org/dyn/closer.lua?action=download&filename="}
+: ${CHECKSUM_BASE_URL:="https://downloads.apache.org/"}
+: ${RANGER_VERSION:=2.6.0}
+
+source lib.sh
+
+mkdir -p dist
+
+# source
+download_and_verify "ranger/${RANGER_VERSION}/apache-ranger-${RANGER_VERSION}.tar.gz"
+# binary
+download_and_verify "ranger/${RANGER_VERSION}/services/admin/ranger-${RANGER_VERSION}-admin.tar.gz"

--- a/dev-support/ranger-docker/lib.sh
+++ b/dev-support/ranger-docker/lib.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+: ${BASE_URL:="https://www.apache.org/dyn/closer.lua?action=download&filename="}
+: ${CHECKSUM_BASE_URL:="https://downloads.apache.org/"}
+
+download_if_not_exists() {
+  local url="$1"
+  local file="$2"
+
+  if [[ -e "${file}" ]]; then
+    echo "${file} already downloaded"
+  else
+    echo "Downloading ${file} from ${url}"
+    curl --fail --location --output "${file}" --show-error --silent "${url}" || rm -fv "${file}"
+  fi
+}
+
+download_and_verify() {
+  local remote_path="$1"
+  local file="$(basename "${remote_path}")"
+
+  pushd dist
+  download_if_not_exists "${BASE_URL}${remote_path}" "${file}"
+  download_if_not_exists "${CHECKSUM_BASE_URL}${remote_path}.asc" "${file}.asc"
+  gpg --verify "${file}.asc" "${file}" || exit 1
+  popd
+}


### PR DESCRIPTION
- download earlier releases instead of building them
- refactor changes to include build-branch as input, for ex: ranger-2.7


