### PR TITLE
RANGER-5126: Add workflow to test Ranger Upgrades in Docker

### DIFF
--- a/.github/workflows/upgrade-ranger.yaml
+++ b/.github/workflows/upgrade-ranger.yaml
@@ -1,0 +1,126 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Upgrade Ranger
+
+on:
+  workflow_dispatch:
+    inputs:
+      build-branch:
+        description: 'branch to checkout and build'
+        required: true
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.build-branch }}
+
+      - name: Cache for maven dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.m2/repository/*/*/*
+            !~/.m2/repository/org/apache/ranger
+          key: maven-repo-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            maven-repo-
+
+      - name: Set up .m2 directory and permissions
+        run: |
+            mkdir -p ~/.m2/repository
+            chmod -R 777 ~/.m2
+            chmod -R 777 ./
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v4
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+
+      - name: Clean up Docker space
+        run: docker system prune --all --force --volumes
+
+      - name: Build Ranger from branch ${{ inputs.build-branch }} in Docker
+        run: |
+          cd dev-support/ranger-docker
+          docker compose -f docker-compose.ranger-build.yml build
+          docker compose -f docker-compose.ranger-build.yml up -d
+          docker logs -f ranger-build &
+          # Wait for the container to exit
+          docker wait ranger-build
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.build-branch }}-build-artifacts
+          path: dev-support/ranger-docker/dist/*
+
+  upgrade:
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        ranger-release: [2.6.0]
+        db: [postgres, mysql, oracle]
+    runs-on: ubuntu-22.04
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.build-branch }}
+
+      - name: Download previous build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.build-branch }}-build-artifacts
+
+      - name: Copy artifacts for docker build
+        run: |
+          cp ranger-*.tar.gz dev-support/ranger-docker/dist
+          cp version dev-support/ranger-docker/dist
+          ls -lrt dev-support/ranger-docker/dist/
+      
+      - name: Run download-archives.sh
+        run: |
+          cd dev-support/ranger-docker
+          ./download-archives.sh none
+
+      - name: Bringing up Ranger ${{ matrix.ranger-release }} in Docker
+        run: |
+          cd dev-support/ranger-docker
+          chmod +x download-ranger.sh && ./download-ranger.sh
+          export RANGER_DB_TYPE=${{ matrix.db }}
+          export RANGER_VERSION=${{ matrix.ranger-release }}
+          docker compose -f docker-compose.ranger.yml build
+          docker compose -f docker-compose.ranger.yml up -d
+          timeout 60 docker logs -f ranger || true
+          docker logs ranger | grep "Apache Ranger Admin Service with pid [0-9]* has started."
+
+      - name: Upgrading to ${{ inputs.build-branch }} in Docker
+        run: |
+          cd dev-support/ranger-docker
+          export RANGER_DB_TYPE=${{ matrix.db }}
+          docker compose -f docker-compose.ranger.yml  build
+          docker compose -f docker-compose.ranger.yml  up -d
+          timeout 180 docker logs -f ranger || true
+          docker logs ranger | grep "Apache Ranger Admin Service with pid [0-9]* has started."
+
+      - name: Remove running containers
+        run: |
+          docker stop $(docker ps -q) && docker rm $(docker ps -aq)

--- a/dev-support/ranger-docker/download-ranger.sh
+++ b/dev-support/ranger-docker/download-ranger.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -u -o pipefail
+
+: ${BASE_URL:="https://www.apache.org/dyn/closer.lua?action=download&filename="}
+: ${CHECKSUM_BASE_URL:="https://downloads.apache.org/"}
+: ${RANGER_VERSION:=2.6.0}
+
+source lib.sh
+
+mkdir -p dist
+
+# source
+download_and_verify "ranger/${RANGER_VERSION}/apache-ranger-${RANGER_VERSION}.tar.gz"
+# binary
+download_and_verify "ranger/${RANGER_VERSION}/services/admin/ranger-${RANGER_VERSION}-admin.tar.gz"

--- a/dev-support/ranger-docker/lib.sh
+++ b/dev-support/ranger-docker/lib.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+: ${BASE_URL:="https://www.apache.org/dyn/closer.lua?action=download&filename="}
+: ${CHECKSUM_BASE_URL:="https://downloads.apache.org/"}
+
+download_if_not_exists() {
+  local url="$1"
+  local file="$2"
+
+  if [[ -e "${file}" ]]; then
+    echo "${file} already downloaded"
+  else
+    echo "Downloading ${file} from ${url}"
+    curl --fail --location --output "${file}" --show-error --silent "${url}" || rm -fv "${file}"
+  fi
+}
+
+download_and_verify() {
+  local remote_path="$1"
+  local file="$(basename "${remote_path}")"
+
+  pushd dist
+  download_if_not_exists "${BASE_URL}${remote_path}" "${file}"
+  download_if_not_exists "${CHECKSUM_BASE_URL}${remote_path}.asc" "${file}.asc"
+  curl -fsSL https://downloads.apache.org/ranger/KEYS | gpg --import
+  gpg --verify "${file}.asc" "${file}" || exit 1
+  popd
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adding an on-demand workflow to run and test ranger upgrades from released versions to the upcoming release. 

- download earlier releases instead of building them
- run upgrades across multiple db flavors: `mysql`, `oracle` and `postgres`
- refactor changes to include build-branch as input (upcoming release), for ex: ranger-2.7

(cherry picked from commit f33a8764d4488aaf4db404d827cbe8eb9e329709)

## How was this patch tested?
Triggered GitHub Actions using the below command:
```
╰─ gh workflow run upgrade-ranger.yaml --field build-branch="ranger-2.7" -R https://github.com/kumaab/ranger
✓ Created workflow_dispatch event for upgrade-ranger.yaml at master
```

CI run: https://github.com/kumaab/ranger/actions/runs/16309860266


