### PR TITLE
RANGER-5239: Decrypt and verify before storing newly re-encypted key …

### DIFF
--- a/kms/src/main/java/org/apache/hadoop/crypto/key/RangerMasterKey.java
+++ b/kms/src/main/java/org/apache/hadoop/crypto/key/RangerMasterKey.java
@@ -308,6 +308,13 @@ public class RangerMasterKey implements RangerKMSMKI {
                 init();
                 PBEKeySpec newPbeKeySpec = getPBEParameterSpec(mkPassword, encrCryptoAlgo);
                 byte[] masterKeyToDB = encryptKey(oldKeyMaterial, newPbeKeySpec);
+                byte[] decryptedMaterialWithNewAlgo = decryptKey(masterKeyToDB, newPbeKeySpec);
+                // This is just a sanity check but important to ensure that returned key material after re-encryption is same as old MK key material.
+                if (!Base64.encode(oldKeyMaterial).equals(Base64.encode(decryptedMaterialWithNewAlgo))) {
+                    String errMsg = "After re-encryption, Latest decrypted MasterKey material is different than original.Aborting the re-encryption, DB is not updated with new encrypted material.";
+                    logger.error(errMsg);
+                    throw new RuntimeException(errMsg);
+                }
 
                 String encodeMKToDB = Base64.encode(masterKeyToDB);
                 updateEncryptedMK(paddingString + "," + encodeMKToDB);


### PR DESCRIPTION
…material into DB

## What changes were proposed in this pull request?

A sanity check (kind of assertion) has been added in the RangerMasterKey to make sure re-encrypted material returns the the same old MK key material after decryption process. It is required , if decrypt operation fails due to any runtime error or returns some wrong material, it would be the case of data loss .   

Since same encrypt/decrypt provider is being used for both MasterKey and Zone keys, I am not adding this check for zone keys. Adding such check for zone keys will impact the performance considering there would be many zone keys.

## How was this patch tested?

mvn build
Unit Test
Manually verified in docker container by configuring the container to support FIPS provider and related configuration. Followed the steps from [](https://issues.apache.org/jira/browse/RANGER-3174)

**What was tested:**

By default, master key got created using PBEWithMD5AndDES, after configuration for FIPS and restart, Master key got re-encrypted using the configured algorithm PBKDF2WithHmacSHA256

 
