### PR TITLE
RANGER-5265: Update ranger build instructions in Docker README

### DIFF
--- a/dev-support/ranger-docker/README.md
+++ b/dev-support/ranger-docker/README.md
@@ -50,6 +50,9 @@ Use Dockerfiles in this directory to create docker images and run them to build 
 
 Execute following command to build Apache Ranger:
 ~~~
+
+chmod +x scripts/*.sh
+
 # optional step: a fresh build ensures that the correct jdk version is used
 docker compose -f docker-compose.ranger-build.yml build
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Build instructions should be updated to do:
```
chmod +x scripts/*.sh
```
when executing a ranger build in docker.

This is required when building directly from release src artifacts.


## How was this patch tested?

Successful `docker compose -f docker-compose.ranger-build.yml up -d` from dir: `dev-support/ranger-docker`