### PR TITLE
RANGER-5277: Ranger Audit to kerberized solr fails

### DIFF
--- a/agents-audit/dest-solr/src/main/java/org/apache/ranger/audit/destination/SolrAuditDestination.java
+++ b/agents-audit/dest-solr/src/main/java/org/apache/ranger/audit/destination/SolrAuditDestination.java
@@ -239,7 +239,8 @@ public class SolrAuditDestination extends AuditDestination {
                     if (zkHosts != null && !zkHosts.isEmpty()) {
                         LOG.info("Connecting to solr cloud using zkHosts={}", zkHosts);
 
-                        try (Krb5HttpClientBuilder krbBuild = new Krb5HttpClientBuilder()) {
+                        try {
+                            Krb5HttpClientBuilder krbBuild = new Krb5HttpClientBuilder();
                             SolrHttpClientBuilder kb = krbBuild.getBuilder();
 
                             HttpClientUtil.setHttpClientBuilder(kb);
@@ -255,7 +256,8 @@ public class SolrAuditDestination extends AuditDestination {
                             LOG.error("Can't connect to Solr server. ZooKeepers={}", zkHosts, t);
                         }
                     } else if (solrURLs != null && !solrURLs.isEmpty()) {
-                        try (Krb5HttpClientBuilder krbBuild = new Krb5HttpClientBuilder()) {
+                        try {
+                            Krb5HttpClientBuilder krbBuild = new Krb5HttpClientBuilder();
                             LOG.info("Connecting to Solr using URLs={}", solrURLs);
 
                             SolrHttpClientBuilder kb = krbBuild.getBuilder();


### PR DESCRIPTION
## What changes were proposed in this pull request?
* Removes try-with-resources during Krb5HttpClientBuilder object creation 
* So that Krb5HttpClientBuilder won't be closed.

## How was this patch tested?
* By manual tests.
  * Using Trino and Trino Ranger Plugin.
  * Query Execution and then Checking Solr Audit.
