### PR TITLE
RANGER-5280: Fix for test case failure in TestKMSMetricsWrapper

### DIFF
--- a/kms/src/test/java/org/apache/ranger/kms/metrics/TestKMSMetricsWrapper.java
+++ b/kms/src/test/java/org/apache/ranger/kms/metrics/TestKMSMetricsWrapper.java
@@ -44,6 +44,10 @@ public class TestKMSMetricsWrapper {
     public void testNonThreadsafeCounterMetrics() throws NoSuchFieldException, IllegalAccessException {
         // set the "isMetricCollectionThreadsafe" value to true to verify different flow.
         setKmsMetricsCollectorThreadSafelyFlag(false);
+        DefaultMetricsSystem.instance().publishMetricsNow();
+
+        long prevKeyCreateCount =  (long) kmsMetricWrapper.getRangerMetricsInJsonFormat().get("KMS").get(KMSMetrics.KMSMetric.KEY_CREATE_COUNT.getKey());
+        long prevKeyCreateElapsedTime = (long) kmsMetricWrapper.getRangerMetricsInJsonFormat().get("KMS").get(KMSMetrics.KMSMetric.KEY_CREATE_ELAPSED_TIME.getKey());
 
         // For COUNTER type
         kmsMetricsCollector.incrementCounter(KMSMetrics.KMSMetric.KEY_CREATE_COUNT);
@@ -53,14 +57,21 @@ public class TestKMSMetricsWrapper {
 
         DefaultMetricsSystem.instance().publishMetricsNow();
 
-        Assertions.assertEquals(1L, kmsMetricWrapper.getRangerMetricsInJsonFormat().get("KMS").get(KMSMetrics.KMSMetric.KEY_CREATE_COUNT.getKey()));
-        Assertions.assertEquals(100L, kmsMetricWrapper.getRangerMetricsInJsonFormat().get("KMS").get(KMSMetrics.KMSMetric.KEY_CREATE_ELAPSED_TIME.getKey()));
+        long expectedKeyCreateCount = prevKeyCreateCount + 1;
+        long expectedKeyCreateElapsedTime = prevKeyCreateElapsedTime + 100L;
+
+        Assertions.assertEquals(expectedKeyCreateCount, kmsMetricWrapper.getRangerMetricsInJsonFormat().get("KMS").get(KMSMetrics.KMSMetric.KEY_CREATE_COUNT.getKey()));
+        Assertions.assertEquals(expectedKeyCreateElapsedTime, kmsMetricWrapper.getRangerMetricsInJsonFormat().get("KMS").get(KMSMetrics.KMSMetric.KEY_CREATE_ELAPSED_TIME.getKey()));
     }
 
     @Test
     public void testThreadsafeCounterMetrics() throws NoSuchFieldException, IllegalAccessException {
         // set the "isMetricCollectionThreadsafe" value to true to verify different flow.
         setKmsMetricsCollectorThreadSafelyFlag(true);
+        DefaultMetricsSystem.instance().publishMetricsNow();
+
+        long prevKeyCreateCount =  (long) kmsMetricWrapper.getRangerMetricsInJsonFormat().get("KMS").get(KMSMetrics.KMSMetric.KEY_CREATE_COUNT.getKey());
+        long prevKeyCreateElapsedTime = (long) kmsMetricWrapper.getRangerMetricsInJsonFormat().get("KMS").get(KMSMetrics.KMSMetric.KEY_CREATE_ELAPSED_TIME.getKey());
 
         // For COUNTER type
         kmsMetricsCollector.incrementCounter(KMSMetrics.KMSMetric.KEY_CREATE_COUNT);
@@ -70,8 +81,11 @@ public class TestKMSMetricsWrapper {
 
         DefaultMetricsSystem.instance().publishMetricsNow();
 
-        Assertions.assertEquals(1L, kmsMetricWrapper.getRangerMetricsInJsonFormat().get("KMS").get(KMSMetrics.KMSMetric.KEY_CREATE_COUNT.getKey()));
-        Assertions.assertEquals(200L, kmsMetricWrapper.getRangerMetricsInJsonFormat().get("KMS").get(KMSMetrics.KMSMetric.KEY_CREATE_ELAPSED_TIME.getKey()));
+        long expectedKeyCreateCount = prevKeyCreateCount + 1;
+        long expectedKeyCreateElapsedTime = prevKeyCreateElapsedTime + 200L;
+
+        Assertions.assertEquals(expectedKeyCreateCount, kmsMetricWrapper.getRangerMetricsInJsonFormat().get("KMS").get(KMSMetrics.KMSMetric.KEY_CREATE_COUNT.getKey()));
+        Assertions.assertEquals(expectedKeyCreateElapsedTime, kmsMetricWrapper.getRangerMetricsInJsonFormat().get("KMS").get(KMSMetrics.KMSMetric.KEY_CREATE_ELAPSED_TIME.getKey()));
     }
 
     private void setKmsMetricsCollectorThreadSafelyFlag(boolean isMetricCollectionThreadsafe) throws IllegalAccessException, NoSuchFieldException {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix for intermittent test cases failure in TestKMSMetricsWrapper.

**RCA:** 
Counters are incremented at REST layer. Earlier we didn't have UT for KMS.createKey() REST API. TestKMSMetricsWrapper  was incrementing the counter and asserting the same (1 as expected value) by fetching the counter value through metric collector API. Since this was the only place from where counter was being incremented, so it was working fine.

Recently, Team added more test cases in TestKMS.java, that creates more keys and hence counter increased.  And in TestKMSMetricsWrapper file, it was still expecting "1" as expected value, hence failed.

Hadoop metric2 API doesn't provide API to reset the counters as it is made for continuous monitoring.

Solution: Now we are explicitly flushing before each metric test execution and reading the value , And expected value is readValue + 1.

## How was this patch tested?

- mvn build is working. 
- Changes are in test file and all test cases are passing.
