### PR TITLE
RANGER-5282:Admin Audit Log not generated for DataSet validity schedule modification

### DIFF
--- a/security-admin/src/main/java/org/apache/ranger/service/RangerGdsDatasetService.java
+++ b/security-admin/src/main/java/org/apache/ranger/service/RangerGdsDatasetService.java
@@ -90,6 +90,7 @@ public class RangerGdsDatasetService extends RangerGdsBaseModelService<XXGdsData
         trxLogAttrs.put("labels",      new VTrxLogAttr("labels", "Labels"));
         trxLogAttrs.put("keywords",    new VTrxLogAttr("keywords", "keywords"));
         trxLogAttrs.put("description", new VTrxLogAttr("description", "Description"));
+        trxLogAttrs.put("validitySchedule", new VTrxLogAttr("validitySchedule", "Validity Schedule"));
     }
 
     @Override


### PR DESCRIPTION

## What changes were proposed in this pull request?
When validity period on the Data Set is modified, the change logs which gets recorded in the ranger admin is not generated.
This change log is needed  for tracking all the modifications done on the GDS data set.


## How was this patch tested?

Verified in Ranger Docker with this patch and executing the REST call to update the GDS DataSet validity period.

