### PR TITLE
RANGER-5269 : Update UI hint for Ranger service definition for HA enabled HDFS

### DIFF
--- a/agents-common/src/main/resources/service-defs/ranger-servicedef-hdfs.json
+++ b/agents-common/src/main/resources/service-defs/ranger-servicedef-hdfs.json
@@ -86,7 +86,7 @@
 			"mandatory": true,
 			"validationRegEx":"",
 			"validationMessage": "",
-			"uiHint":"{\"TextFieldWithIcon\":true, \"info\": \"1.For one Namenode Url, eg.<br>hdfs://&lt;host&gt;:&lt;port&gt;<br>2.For HA Namenode Urls(use , delimiter), eg.<br>hdfs://&lt;host&gt;:&lt;port&gt;,hdfs://&lt;host2&gt;:&lt;port2&gt;<br>\"}",
+			"uiHint":"{\"TextFieldWithIcon\":true, \"info\": \"1. For a single NameNode URL, use:<br>hdfs://&lt;host&gt;:&lt;port&gt;<br><br>2. For HDFS High Availability (HA) setup, use the nameservice-based URL:<br>hdfs://&lt;nameservice&gt;<br><br>Note: Do not provide multiple NameNode URLs separated by commas. Instead, use the nameservice configured for your HDFS cluster.<br><br>You can confirm the correct value from the Hadoop configuration property <strong>fs.defaultFS</strong> in <em>core-site.xml</em>.\"}",
 			"label": "Namenode URL"
 		},
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
We need to update the Ranger service definition for HA HDFS.

For hdfs Namenode URL, the instruction says:
For HA namenode Urls (use , delimiter),eg. hdfs://<host>:<port>,hdfs://<host2>:<port2>

https://github.com/apache/ranger/blob/84667176ea3b6e7a01c3fdd5eb726e2fd474a194/agents- common/src/main/resources/service-defs/ranger-servicedef-hdfs.json#L89C3-L89C4

But the correct setting should be hdfs://nameservicename


## How was this patch tested?
Updated changes on local machine and verified that UI hint msg come with proper config details.
