### PR TITLE
RANGER-5271 : Last login date and time on Ranger Home page

### DIFF
--- a/security-admin/src/main/java/org/apache/ranger/biz/SessionMgr.java
+++ b/security-admin/src/main/java/org/apache/ranger/biz/SessionMgr.java
@@ -475,6 +475,18 @@ public class SessionMgr {
         }
     }
 
+    public Date getLastSuccessLoginAuthTimeByUserId(String loginId) {
+        XXAuthSession xXAuthSession = daoManager.getXXAuthSession().getLastSuccessLoginAuthSessionByUserId(loginId);
+
+        if (xXAuthSession != null) {
+            return authSessionService.populateViewBean(xXAuthSession).getAuthTime();
+        } else {
+            logger.info("Session cleaned up or  User logged in for first time");
+        }
+
+        return null;
+    }
+
     protected boolean validateUserSession(UserSessionBase userSession, String currentLoginId) {
         if (currentLoginId.equalsIgnoreCase(userSession.getXXPortalUser().getLoginId())) {
             return true;

--- a/security-admin/src/main/java/org/apache/ranger/biz/UserMgr.java
+++ b/security-admin/src/main/java/org/apache/ranger/biz/UserMgr.java
@@ -648,6 +648,7 @@ public class UserMgr {
             userProfile.setUserRoleList(userRoleList);
         }
 
+        userProfile.setLastLoginTime(sessionMgr.getLastSuccessLoginAuthTimeByUserId(sess.getLoginId()));
         userProfile.setUserSource(user.getUserSource());
 
         return userProfile;

--- a/security-admin/src/main/java/org/apache/ranger/db/XXAuthSessionDao.java
+++ b/security-admin/src/main/java/org/apache/ranger/db/XXAuthSessionDao.java
@@ -68,6 +68,23 @@ public class XXAuthSessionDao extends BaseDao<XXAuthSession> {
         }
     }
 
+    public XXAuthSession getLastSuccessLoginAuthSessionByUserId(String loginId) {
+        if (loginId == null) {
+            return null;
+        }
+        try {
+            List<XXAuthSession> sessions = getEntityManager()
+                    .createNamedQuery("XXAuthSession.getSuccessAuthSessionsByUserId", tClass)
+                    .setParameter("loginId", loginId)
+                    .setParameter("authStatus", XXAuthSession.AUTH_STATUS_SUCCESS)
+                    .setMaxResults(2)
+                    .getResultList();
+            return sessions.size() >= 2 ? sessions.get(1) : null;
+        } catch (NoResultException ignoreNoResultFound) {
+            return null;
+        }
+    }
+
     public long getRecentAuthFailureCountByLoginId(String loginId, int timeRangezSecond) {
         Date utcDate             = DateUtil.getUTCDate();
         Date authWindowStartTime = new Date((utcDate != null ? utcDate.getTime() : System.currentTimeMillis()) - timeRangezSecond * 1000L);

--- a/security-admin/src/main/java/org/apache/ranger/view/VXPortalUser.java
+++ b/security-admin/src/main/java/org/apache/ranger/view/VXPortalUser.java
@@ -23,9 +23,12 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.apache.ranger.common.AppConstants;
+import org.apache.ranger.json.JsonDateSerializer;
 
 import java.util.Collection;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -90,6 +93,8 @@ public class VXPortalUser extends VXDataObject implements java.io.Serializable {
      * sync Source Attribute.
      */
     protected String syncSource;
+    @JsonSerialize(using = JsonDateSerializer.class)
+    protected Date lastLoginTime;
 
     /**
      * Configuration properties.
@@ -318,6 +323,7 @@ public class VXPortalUser extends VXDataObject implements java.io.Serializable {
         str += "userRoleList={" + userRoleList + "} ";
         str += "otherAttributes={" + otherAttributes + "} ";
         str += "syncSource={" + syncSource + "} ";
+        str += "lastLoginTime={" + lastLoginTime + "} ";
         str += "}";
         return str;
     }
@@ -384,5 +390,13 @@ public class VXPortalUser extends VXDataObject implements java.io.Serializable {
      */
     public void setSyncSource(final String syncSource) {
         this.syncSource = syncSource;
+    }
+
+    public Date getLastLoginTime() {
+        return lastLoginTime;
+    }
+
+    public void setLastLoginTime(Date lastLoginTime) {
+        this.lastLoginTime = lastLoginTime;
     }
 }

--- a/security-admin/src/main/resources/META-INF/jpa_named_queries.xml
+++ b/security-admin/src/main/resources/META-INF/jpa_named_queries.xml
@@ -48,6 +48,11 @@
 		<query>DELETE FROM XXAuthSession obj WHERE obj.id in :ids
 		</query>
 	</named-query>
+	<named-query name="XXAuthSession.getSuccessAuthSessionsByUserId">
+		<query>SELECT obj FROM XXAuthSession obj WHERE obj.loginId = :loginId and obj.authStatus = :authStatus order by obj.id DESC
+		</query>
+	</named-query>
+
 
 	<!-- XXPortalUser -->
 	<named-query name="XXPortalUser.findByEmailAddress">

--- a/security-admin/src/main/webapp/react-webapp/src/styles/style.css
+++ b/security-admin/src/main/webapp/react-webapp/src/styles/style.css
@@ -1317,7 +1317,7 @@ header {
 }
 
 .top-scroll {
-  bottom: 3px;
+  bottom: 10px;
   right: 5px;
 }
 

--- a/security-admin/src/main/webapp/react-webapp/src/views/Layout.jsx
+++ b/security-admin/src/main/webapp/react-webapp/src/views/Layout.jsx
@@ -40,6 +40,7 @@ import { Loader } from "../components/CommonComponents";
 import { Suspense } from "react";
 import { PathAssociateWithModule } from "../utils/XAEnums";
 import { flatMap, values } from "lodash";
+import dateFormat from "dateformat";
 
 const Layout = () => {
   let location = useLocation();
@@ -93,6 +94,13 @@ const Layout = () => {
     setOpen(false);
     activate();
   };
+
+  const lastLoginInformation = userProfile?.lastLoginTime
+    ? `You last logged in on, ${dateFormat(
+        new Date(userProfile.lastLoginTime),
+        "dddd, mmm dd, yyyy, hh:MM:ss TT"
+      )}`
+    : "";
 
   useEffect(() => {
     const interval = setInterval(() => {
@@ -170,6 +178,9 @@ const Layout = () => {
                 >
                   Licensed under the Apache License, Version 2.0
                 </a>
+                <span className="float-end mb-2 me-4" style={{ color: "#999" }}>
+                  {lastLoginInformation}
+                </span>
               </p>
             </div>
           </footer>

--- a/security-admin/src/main/webapp/react-webapp/src/views/SideBar/SideBar.jsx
+++ b/security-admin/src/main/webapp/react-webapp/src/views/SideBar/SideBar.jsx
@@ -107,7 +107,7 @@ export const SideBar = () => {
 
   const userProps = getUserProfile();
   const loginId = (
-    <span className="login-id user-name">{userProps?.loginId}</span>
+    <span className="login-id user-name p-0">{userProps?.loginId}</span>
   );
 
   let location = useLocation();


### PR DESCRIPTION
## What changes were proposed in this pull request?
The Ranger UI should display the logged in user's last login date and time. This information is currently available under Ranger > Audits > Login Sessions, but it would be more convenient for security audits if it were available on the homepage.


## How was this patch tested?

- Applied the patch locally and verified that the build completed successfully.
- Started the development server and confirmed there were no errors.
- Logged in with different users and verified that the last login date and time is displayed correctly on the homepage.
- Cross-checked the displayed value with the data shown in Ranger > Audits > Login Sessions to ensure accuracy.
- Performed sanity testing across other homepage components to confirm no regressions.
