### PR TITLE
RANGER-5147: Modernize some Python scripts now that Python 3 is a requirement

### DIFF
--- a/security-admin/scripts/db_setup.py
+++ b/security-admin/scripts/db_setup.py
@@ -151,7 +151,7 @@ def dbversionBasedOnUserName(userName):
 	return version
 
 def set_env_val(command):
-	proc = subprocess.Popen(command, stdout = subprocess.PIPE)
+	proc = subprocess.Popen(command, stdout = subprocess.PIPE, text=True)
 	for line in proc.stdout:
 		(key, _, value) = line.decode('utf8').partition('=')
 		os.environ[key] = value.rstrip()


### PR DESCRIPTION
## What changes were proposed in this pull request?
* in db_setup.py script, there's subprocess.Popen function.
* From python 3, the stdout of Popen instance is byte by default. it means it is not str anymore
* So if you are trying to execute this script, you will see error below
```python
TypeError: a bytes-like object is required, not 'str'
```
* To avoid this problem, simply just add text=True option in Popen()

## How was this patch tested?
* Manually Tested.
