### PR TITLE
RANGER-5292: Add Unit Tests for Ranger Metrics Package in Security Ad…

### DIFF
--- a/security-admin/src/test/java/org/apache/ranger/metrics/TestRangerAdminMetricsWrapper.java
+++ b/security-admin/src/test/java/org/apache/ranger/metrics/TestRangerAdminMetricsWrapper.java
@@ -1,0 +1,184 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ranger.metrics;
+
+import org.apache.ranger.metrics.source.RangerAdminMetricsSourceContextEnricher;
+import org.apache.ranger.metrics.source.RangerAdminMetricsSourceDenyConditions;
+import org.apache.ranger.metrics.source.RangerAdminMetricsSourcePolicyMasking;
+import org.apache.ranger.metrics.source.RangerAdminMetricsSourcePolicyResourceAccess;
+import org.apache.ranger.metrics.source.RangerAdminMetricsSourcePolicyRowFiltering;
+import org.apache.ranger.metrics.source.RangerAdminMetricsSourceService;
+import org.apache.ranger.metrics.source.RangerAdminMetricsSourceUserGroup;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.anyList;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class TestRangerAdminMetricsWrapper {
+    @InjectMocks
+    RangerAdminMetricsWrapper metricsWrapper;
+
+    @Mock
+    RangerAdminMetricsSourceUserGroup userGroupSource;
+
+    @Mock
+    RangerAdminMetricsSourceService serviceSource;
+
+    @Mock
+    RangerAdminMetricsSourcePolicyResourceAccess policyResourceAccessSource;
+
+    @Mock
+    RangerAdminMetricsSourcePolicyRowFiltering policyRowFilteringSource;
+
+    @Mock
+    RangerAdminMetricsSourcePolicyMasking policyMaskingSource;
+
+    @Mock
+    RangerAdminMetricsSourceContextEnricher contextEnricherSource;
+
+    @Mock
+    RangerAdminMetricsSourceDenyConditions denyConditionSource;
+
+    @Mock
+    RangerMetricsSystemWrapper metricsSystemWrapper;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        Field field = RangerAdminMetricsWrapper.class.getDeclaredField("rangerMetricsSystemWrapper");
+        field.setAccessible(true);
+        field.set(metricsWrapper, metricsSystemWrapper);
+    }
+
+    @Test
+    public void testInit() {
+        metricsWrapper.init();
+
+        verify(metricsSystemWrapper).init(eq("admin"), anyList(), eq(Collections.emptyList()));
+    }
+
+    @Test
+    public void testInitWithException() throws Exception {
+        doThrow(new RuntimeException("Exception occured while initializing Metric Starter")).when(metricsSystemWrapper).init(anyString(), anyList(), anyList());
+
+        metricsWrapper.init();
+
+        verify(metricsSystemWrapper).init(anyString(), anyList(), anyList());
+    }
+
+    @Test
+    public void testGetRangerMetricsInPrometheusFormat() throws Exception {
+        String mockOutput = "mock_prometheus_metrics";
+        when(metricsSystemWrapper.getRangerMetricsInPrometheusFormat()).thenReturn(mockOutput);
+
+        String result = metricsWrapper.getRangerMetricsInPrometheusFormat();
+
+        assertEquals(mockOutput, result);
+        verify(metricsSystemWrapper).getRangerMetricsInPrometheusFormat();
+    }
+
+    @Test
+    public void testGetRangerMetricsInPrometheusFormatWithException() throws Exception {
+        when(metricsSystemWrapper.getRangerMetricsInPrometheusFormat()).thenThrow(new IOException("Exception occurred while getting metric."));
+
+        IOException exception = assertThrows(IOException.class, () -> {
+            metricsWrapper.getRangerMetricsInPrometheusFormat();
+        });
+
+        assertEquals("Exception occurred while getting metric.", exception.getMessage());
+        verify(metricsSystemWrapper).getRangerMetricsInPrometheusFormat();
+    }
+
+    @Test
+    public void testGetRangerMetricsInPrometheusFormat_NullReturn() throws Exception {
+        when(metricsSystemWrapper.getRangerMetricsInPrometheusFormat()).thenReturn(null);
+
+        String result = metricsWrapper.getRangerMetricsInPrometheusFormat();
+
+        assertNull(result);
+        verify(metricsSystemWrapper).getRangerMetricsInPrometheusFormat();
+    }
+
+    @Test
+    public void testGetRangerMetrics() {
+        Map<String, Map<String, Object>> mockMetrics = new HashMap<>();
+        Map<String, Object> userGroupMetrics = new HashMap<>();
+        userGroupMetrics.put("total_users", 100);
+        userGroupMetrics.put("total_groups", 20);
+        mockMetrics.put("UserGroup", userGroupMetrics);
+
+        Map<String, Object> serviceMetrics = new HashMap<>();
+        serviceMetrics.put("total_services", 5);
+        serviceMetrics.put("active_services", 4);
+        mockMetrics.put("Service", serviceMetrics);
+
+        when(metricsSystemWrapper.getRangerMetrics()).thenReturn(mockMetrics);
+
+        Map<String, Map<String, Object>> result = metricsWrapper.getRangerMetrics();
+
+        assertNotNull(result);
+        assertEquals(mockMetrics, result);
+        assertEquals(2, result.size());
+        assertTrue(result.containsKey("UserGroup"));
+        assertTrue(result.containsKey("Service"));
+        assertEquals(100, result.get("UserGroup").get("total_users"));
+        assertEquals(5, result.get("Service").get("total_services"));
+        verify(metricsSystemWrapper).getRangerMetrics();
+    }
+
+    @Test
+    public void testGetRangerMetricsWithEmptyResult() {
+        when(metricsSystemWrapper.getRangerMetrics()).thenReturn(new HashMap<>());
+
+        Map<String, Map<String, Object>> result = metricsWrapper.getRangerMetrics();
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+        verify(metricsSystemWrapper).getRangerMetrics();
+    }
+
+    @Test
+    public void testGetRangerMetricsWithNullResult() {
+        when(metricsSystemWrapper.getRangerMetrics()).thenReturn(null);
+
+        Map<String, Map<String, Object>> result = metricsWrapper.getRangerMetrics();
+
+        assertNull(result);
+        verify(metricsSystemWrapper).getRangerMetrics();
+    }
+}

--- a/security-admin/src/test/java/org/apache/ranger/metrics/TestRangerMetricsFetcher.java
+++ b/security-admin/src/test/java/org/apache/ranger/metrics/TestRangerMetricsFetcher.java
@@ -1,0 +1,224 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ranger.metrics;
+
+import org.apache.ranger.biz.ServiceDBStore;
+import org.apache.ranger.biz.XUserMgr;
+import org.apache.ranger.common.RangerConstants;
+import org.apache.ranger.service.XGroupService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class TestRangerMetricsFetcher {
+    @InjectMocks
+    RangerMetricsFetcher metricsFetcher;
+
+    @Mock
+    XUserMgr xUserMgr;
+
+    @Mock
+    ServiceDBStore svcStore;
+
+    @Mock
+    XGroupService groupService;
+
+    @Test
+    public void testGetGroupCount() {
+        when(groupService.getAllGroupCount()).thenReturn(5L);
+        Long result = metricsFetcher.getGroupCount();
+
+        assertEquals(5L, result);
+        verify(groupService).getAllGroupCount();
+    }
+
+    @Test
+    public void testGetGroupCount_NullReturn() {
+        when(groupService.getAllGroupCount()).thenReturn(null);
+
+        Long result = metricsFetcher.getGroupCount();
+
+        assertNull(result);
+        verify(groupService).getAllGroupCount();
+    }
+
+    @Test
+    public void testGetUserMetrics() {
+        Map<String, Long> mockData = new HashMap<>();
+        mockData.put(RangerConstants.ROLE_SYS_ADMIN, 2L);
+        mockData.put(RangerConstants.ROLE_ADMIN_AUDITOR, 3L);
+        mockData.put(RangerConstants.ROLE_KEY_ADMIN, 4L);
+        mockData.put(RangerConstants.ROLE_KEY_ADMIN_AUDITOR, 5L);
+        mockData.put(RangerConstants.ROLE_USER, 6L);
+        mockData.put("INVALID_ROLE", 1L);
+
+        when(xUserMgr.getUserCountByRole()).thenReturn(mockData);
+
+        Map<String, Long> result = metricsFetcher.getUserMetrics();
+
+        assertEquals(2L, result.get("SysAdmin"));
+        assertEquals(3L, result.get("AdminAuditor"));
+        assertEquals(4L, result.get("KeyAdmin"));
+        assertEquals(5L, result.get("KeyAdminAuditor"));
+        assertEquals(6L, result.get("User"));
+        assertEquals(21L, result.get("Total"));
+
+        assertFalse(result.containsKey("INVALID_ROLE"));
+        verify(xUserMgr).getUserCountByRole();
+    }
+
+    @Test
+    public void testGetUserMetrics_WithNullMap() {
+        when(xUserMgr.getUserCountByRole()).thenReturn(null);
+
+        assertThrows(NullPointerException.class, () -> {
+            metricsFetcher.getUserMetrics();
+        });
+    }
+
+    @Test
+    public void testGetRangerServiceMetrics() {
+        Map<String, Long> mockData = new HashMap<>();
+        mockData.put("hdfs", 2L);
+        mockData.put("hive", 3L);
+
+        when(svcStore.getServiceCountByType()).thenReturn(mockData);
+
+        Map<String, Long> result = metricsFetcher.getRangerServiceMetrics();
+
+        assertEquals(2L, result.get("hdfs"));
+        assertEquals(3L, result.get("hive"));
+        assertEquals(5L, result.get("Total"));
+        verify(svcStore).getServiceCountByType();
+    }
+
+    @Test
+    public void testGetRangerServiceMetrics_EmptyMap() {
+        when(svcStore.getServiceCountByType()).thenReturn(new HashMap<>());
+
+        Map<String, Long> result = metricsFetcher.getRangerServiceMetrics();
+
+        assertNotNull(result);
+        assertEquals(0L, result.get("Total"));
+    }
+
+    @Test
+    public void testGetPolicyMetrics() {
+        int policyType = 0;
+        Map<String, Long> mockData = new HashMap<>();
+        mockData.put("hdfs", 4L);
+        mockData.put("hive", 6L);
+
+        when(svcStore.getPolicyCountByTypeAndServiceType(policyType)).thenReturn(mockData);
+
+        Map<String, Long> result = metricsFetcher.getPolicyMetrics(policyType);
+
+        assertEquals(4L, result.get("hdfs"));
+        assertEquals(6L, result.get("hive"));
+        assertEquals(10L, result.get("Total"));
+        verify(svcStore).getPolicyCountByTypeAndServiceType(policyType);
+    }
+
+    @Test
+    public void testGetPolicyMetrics_EmptyData() {
+        int policyType = 0;
+        when(svcStore.getPolicyCountByTypeAndServiceType(policyType)).thenReturn(new HashMap<>());
+
+        Map<String, Long> result = metricsFetcher.getPolicyMetrics(policyType);
+
+        assertNotNull(result);
+        assertEquals(0L, result.get("Total"));
+    }
+
+    @Test
+    public void testGetPolicyMetrics_NullType_ThrowsException() {
+        NullPointerException ex = assertThrows(NullPointerException.class, () -> {
+            metricsFetcher.getPolicyMetrics(null);
+        });
+
+        assertEquals("Policy type must not be null to get policy metrics.", ex.getMessage());
+    }
+
+    @Test
+    public void testGetDenyConditionsMetrics() {
+        Map<String, Long> mockData = new HashMap<>();
+        mockData.put("hdfs", 2L);
+        mockData.put("hive", 3L);
+
+        when(svcStore.getPolicyCountByDenyConditionsAndServiceDef()).thenReturn(mockData);
+
+        Map<String, Long> result = metricsFetcher.getDenyConditionsMetrics();
+
+        assertEquals(5L, result.get("Total"));
+        verify(svcStore).getPolicyCountByDenyConditionsAndServiceDef();
+    }
+
+    @Test
+    public void testGetDenyConditionsMetrics_NullMap() {
+        when(svcStore.getPolicyCountByDenyConditionsAndServiceDef()).thenReturn(null);
+
+        assertThrows(NullPointerException.class, () -> {
+            metricsFetcher.getDenyConditionsMetrics();
+        });
+    }
+
+    @Test
+    public void testGetContextEnrichersMetrics() {
+        List<String> serviceDefs = Arrays.asList("hdfs", "hive", "kafka");
+
+        when(svcStore.findAllServiceDefNamesHavingContextEnrichers()).thenReturn(serviceDefs);
+
+        Map<String, Long> result = metricsFetcher.getContextEnrichersMetrics();
+
+        assertEquals(1L, result.get("hdfs"));
+        assertEquals(1L, result.get("hive"));
+        assertEquals(1L, result.get("kafka"));
+        assertEquals(3L, result.get("Total"));
+        verify(svcStore).findAllServiceDefNamesHavingContextEnrichers();
+    }
+
+    @Test
+    public void testGetContextEnrichersMetrics_EmptyList() {
+        when(svcStore.findAllServiceDefNamesHavingContextEnrichers()).thenReturn(Collections.emptyList());
+
+        Map<String, Long> result = metricsFetcher.getContextEnrichersMetrics();
+
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        assertTrue(result.containsKey("Total"));
+        assertEquals(0L, result.get("Total"));
+    }
+}

--- a/security-admin/src/test/java/org/apache/ranger/metrics/source/TestRangerAdminMetricsSourceBase.java
+++ b/security-admin/src/test/java/org/apache/ranger/metrics/source/TestRangerAdminMetricsSourceBase.java
@@ -1,0 +1,308 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.metrics.source;
+
+import org.apache.hadoop.metrics2.MetricsCollector;
+import org.apache.hadoop.metrics2.MetricsRecordBuilder;
+import org.apache.ranger.metrics.RangerMetricsInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class TestRangerAdminMetricsSourceBase {
+    private static final String TEST_CONTEXT = "test-context";
+    private static final String TEST_RECORD = "test-record";
+
+    @Mock
+    MetricsCollector metricsCollector;
+
+    @Mock
+    MetricsRecordBuilder metricsRecordBuilder;
+
+    private TestableRangerAdminMetricsSourceBase metricsSource;
+
+    private static class TestableRangerAdminMetricsSourceBase extends RangerAdminMetricsSourceBase {
+        public TestableRangerAdminMetricsSourceBase(String context, String record) {
+            super(context, record);
+        }
+
+        @Override
+        protected void refresh() {
+            // No-op for testing
+        }
+
+        public void testAddMetricEntry(String prefix, String suffix, Long value) {
+            addMetricEntry(prefix, suffix, value);
+        }
+
+        public void testAddMetricEntries(String prefix, Map<String, Long> metrics) {
+            addMetricEntries(prefix, metrics);
+        }
+
+        public Map<String, Long> getMetricsMap() {
+            return metricsMap;
+        }
+
+        public String getContext() {
+            return context;
+        }
+
+        public String getRecord() {
+            return record;
+        }
+    }
+
+    @BeforeEach
+    public void setUp() {
+        metricsSource = new TestableRangerAdminMetricsSourceBase(TEST_CONTEXT, TEST_RECORD);
+    }
+
+    @Test
+    public void testConstructor() {
+        assertEquals(TEST_CONTEXT, metricsSource.getContext());
+        assertEquals(TEST_RECORD, metricsSource.getRecord());
+        assertNotNull(metricsSource.getMetricsMap());
+        assertTrue(metricsSource.getMetricsMap().isEmpty());
+    }
+
+    @Test
+    public void testAddMetricEntry_WithNormalPrefixAndSuffix() {
+        String prefix = "TestMetric";
+        String suffix = "Count";
+        Long value = 100L;
+
+        metricsSource.testAddMetricEntry(prefix, suffix, value);
+
+        Map<String, Long> metricsMap = metricsSource.getMetricsMap();
+        assertEquals(1, metricsMap.size());
+        assertEquals(value, metricsMap.get("TestMetricCOUNT"));
+    }
+
+    @Test
+    public void testAddMetricEntry_WithNullSuffix() {
+        String prefix = "TestMetric";
+        String suffix = null;
+        Long value = 200L;
+
+        metricsSource.testAddMetricEntry(prefix, suffix, value);
+
+        Map<String, Long> metricsMap = metricsSource.getMetricsMap();
+        assertEquals(1, metricsMap.size());
+        assertEquals(value, metricsMap.get("TestMetric"));
+    }
+
+    @Test
+    public void testAddMetricEntry_WithEmptySuffix() {
+        String prefix = "TestMetric";
+        String suffix = "";
+        Long value = 300L;
+
+        metricsSource.testAddMetricEntry(prefix, suffix, value);
+
+        Map<String, Long> metricsMap = metricsSource.getMetricsMap();
+        assertEquals(1, metricsMap.size());
+        assertEquals(value, metricsMap.get("TestMetric"));
+    }
+
+    @Test
+    public void testAddMetricEntry_WithTotalSuffix() {
+        String prefix = "TestMetric";
+        String suffix = "Total";
+        Long value = 400L;
+
+        metricsSource.testAddMetricEntry(prefix, suffix, value);
+
+        Map<String, Long> metricsMap = metricsSource.getMetricsMap();
+        assertEquals(1, metricsMap.size());
+        assertEquals(value, metricsMap.get("TestMetric"));
+    }
+
+    @Test
+    public void testAddMetricEntry_WithTotalSuffixCaseInsensitive() {
+        String prefix = "TestMetric";
+        String suffix = "total";
+        Long value = 500L;
+
+        metricsSource.testAddMetricEntry(prefix, suffix, value);
+
+        Map<String, Long> metricsMap = metricsSource.getMetricsMap();
+        assertEquals(1, metricsMap.size());
+        assertEquals(value, metricsMap.get("TestMetric"));
+    }
+
+    @Test
+    public void testAddMetricEntry_WithNullPrefix() {
+        String prefix = null;
+        String suffix = "Count";
+        Long value = 600L;
+
+        metricsSource.testAddMetricEntry(prefix, suffix, value);
+
+        Map<String, Long> metricsMap = metricsSource.getMetricsMap();
+        assertTrue(metricsMap.isEmpty());
+    }
+
+    @Test
+    public void testAddMetricEntry_WithNullValue() {
+        String prefix = "TestMetric";
+        String suffix = "Count";
+        Long value = null;
+
+        metricsSource.testAddMetricEntry(prefix, suffix, value);
+
+        Map<String, Long> metricsMap = metricsSource.getMetricsMap();
+        assertEquals(1, metricsMap.size());
+        assertNull(metricsMap.get("TestMetricCOUNT"));
+    }
+
+    @Test
+    public void testAddMetricEntry_MultipleEntries() {
+        metricsSource.testAddMetricEntry("Metric1", "Count", 10L);
+        metricsSource.testAddMetricEntry("Metric2", "Size", 20L);
+        metricsSource.testAddMetricEntry("Metric3", null, 30L);
+        metricsSource.testAddMetricEntry("Metric4", "Total", 40L);
+
+        Map<String, Long> metricsMap = metricsSource.getMetricsMap();
+        assertEquals(4, metricsMap.size());
+        assertEquals(10L, metricsMap.get("Metric1COUNT"));
+        assertEquals(20L, metricsMap.get("Metric2SIZE"));
+        assertEquals(30L, metricsMap.get("Metric3"));
+        assertEquals(40L, metricsMap.get("Metric4"));
+    }
+
+    @Test
+    public void testAddMetricEntries_WithValidMap() {
+        Map<String, Long> metrics = new HashMap<>();
+        metrics.put("User", 10L);
+        metrics.put("Admin", 5L);
+        metrics.put("Total", 15L);
+
+        metricsSource.testAddMetricEntries("Count", metrics);
+
+        Map<String, Long> metricsMap = metricsSource.getMetricsMap();
+        assertTrue(metricsMap.containsKey("CountUSER"));
+        assertTrue(metricsMap.containsKey("CountADMIN"));
+        assertTrue(metricsMap.containsKey("Count"));
+        assertEquals(3, metricsMap.size());
+        assertEquals(10L, metricsMap.get("CountUSER"));
+        assertEquals(5L,  metricsMap.get("CountADMIN"));
+        assertEquals(15L, metricsMap.get("Count"));
+    }
+
+    @Test
+    public void testAddMetricEntries_WithEmptyMap() {
+        Map<String, Long> metrics = new HashMap<>();
+
+        metricsSource.testAddMetricEntries("Count", metrics);
+
+        Map<String, Long> metricsMap = metricsSource.getMetricsMap();
+        assertTrue(metricsMap.isEmpty());
+    }
+
+    @Test
+    public void testAddMetricEntries_WithNullMap() {
+        assertThrows(NullPointerException.class, () -> {
+            metricsSource.testAddMetricEntries("Count", null);
+        });
+    }
+
+    @Test
+    public void testAddMetricEntries_WithNullPrefix() {
+        Map<String, Long> metrics = new HashMap<>();
+        metrics.put("User", 10L);
+
+        metricsSource.testAddMetricEntries(null, metrics);
+
+        Map<String, Long> metricsMap = metricsSource.getMetricsMap();
+
+        assertTrue(metricsMap.isEmpty());
+    }
+
+    @Test
+    public void testUpdate_WithMetrics() {
+        metricsSource.testAddMetricEntry("TestMetric1", "Count", 100L);
+        metricsSource.testAddMetricEntry("TestMetric2", "Size", 200L);
+
+        when(metricsCollector.addRecord(TEST_RECORD)).thenReturn(metricsRecordBuilder);
+        when(metricsRecordBuilder.setContext(TEST_CONTEXT)).thenReturn(metricsRecordBuilder);
+        when(metricsRecordBuilder.addGauge(any(RangerMetricsInfo.class), any(Long.class))).thenReturn(metricsRecordBuilder);
+
+        metricsSource.update(metricsCollector, true);
+
+        verify(metricsCollector).addRecord(TEST_RECORD);
+        verify(metricsRecordBuilder).setContext(TEST_CONTEXT);
+        verify(metricsRecordBuilder, times(2)).addGauge(any(RangerMetricsInfo.class), any(Long.class));
+
+        ArgumentCaptor<RangerMetricsInfo> infoCaptor = ArgumentCaptor.forClass(RangerMetricsInfo.class);
+        ArgumentCaptor<Long> valueCaptor = ArgumentCaptor.forClass(Long.class);
+        verify(metricsRecordBuilder, times(2)).addGauge(infoCaptor.capture(), valueCaptor.capture());
+        assertTrue(infoCaptor.getAllValues().stream().anyMatch(info -> "TestMetric1COUNT".equals(info.name())));
+        assertTrue(infoCaptor.getAllValues().stream().anyMatch(info -> "TestMetric2SIZE".equals(info.name())));
+        assertTrue(valueCaptor.getAllValues().contains(100L));
+        assertTrue(valueCaptor.getAllValues().contains(200L));
+    }
+
+    @Test
+    public void testUpdate_WithEmptyMetrics() {
+        when(metricsCollector.addRecord(TEST_RECORD)).thenReturn(metricsRecordBuilder);
+        when(metricsRecordBuilder.setContext(TEST_CONTEXT)).thenReturn(metricsRecordBuilder);
+
+        metricsSource.update(metricsCollector, false);
+
+        verify(metricsCollector).addRecord(TEST_RECORD);
+        verify(metricsRecordBuilder).setContext(TEST_CONTEXT);
+        verify(metricsRecordBuilder, never()).addGauge(any(RangerMetricsInfo.class), any(Long.class));
+    }
+
+    @Test
+    public void testUpdate_BooleanParameterIgnored() {
+        metricsSource.testAddMetricEntry("TestMetric", "Count", 50L);
+
+        when(metricsCollector.addRecord(TEST_RECORD)).thenReturn(metricsRecordBuilder);
+        when(metricsRecordBuilder.setContext(TEST_CONTEXT)).thenReturn(metricsRecordBuilder);
+        when(metricsRecordBuilder.addGauge(any(RangerMetricsInfo.class), any(Long.class))).thenReturn(metricsRecordBuilder);
+
+        metricsSource.update(metricsCollector, true);
+        metricsSource.update(metricsCollector, false);
+
+        verify(metricsCollector, times(2)).addRecord(TEST_RECORD);
+        verify(metricsRecordBuilder, times(2)).setContext(TEST_CONTEXT);
+        verify(metricsRecordBuilder, times(2)).addGauge(any(RangerMetricsInfo.class), eq(50L));
+    }
+}

--- a/security-admin/src/test/java/org/apache/ranger/metrics/source/TestRangerAdminMetricsSourceContextEnricher.java
+++ b/security-admin/src/test/java/org/apache/ranger/metrics/source/TestRangerAdminMetricsSourceContextEnricher.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.metrics.source;
+
+import org.apache.ranger.metrics.RangerMetricsFetcher;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class TestRangerAdminMetricsSourceContextEnricher {
+    private static final String EXPECTED_METRIC_PREFIX = "ContextEnricherCount";
+
+    @InjectMocks
+    RangerAdminMetricsSourceContextEnricher contextEnricherSource;
+
+    @Mock
+    RangerMetricsFetcher rangerMetricsFetcher;
+
+    @Test
+    public void testRefresh_WithValidMetrics() {
+        RangerAdminMetricsSourceContextEnricher spyContextEnricherSource = spy(contextEnricherSource);
+
+        Map<String, Long> mockMetrics = new HashMap<>();
+        mockMetrics.put("hdfs", 3L);
+        mockMetrics.put("hive", 2L);
+        mockMetrics.put("total", 5L);
+
+        when(rangerMetricsFetcher.getContextEnrichersMetrics()).thenReturn(mockMetrics);
+
+        spyContextEnricherSource.refresh();
+
+        verify(spyContextEnricherSource).addMetricEntries(EXPECTED_METRIC_PREFIX, mockMetrics);
+        verify(rangerMetricsFetcher).getContextEnrichersMetrics();
+    }
+
+    @Test
+    public void testRefresh_WithEmptyMetrics() {
+        RangerAdminMetricsSourceContextEnricher spyContextEnricherSource = spy(contextEnricherSource);
+
+        Map<String, Long> emptyMetrics = new HashMap<>();
+        when(rangerMetricsFetcher.getContextEnrichersMetrics()).thenReturn(emptyMetrics);
+
+        spyContextEnricherSource.refresh();
+
+        verify(spyContextEnricherSource).addMetricEntries(EXPECTED_METRIC_PREFIX, emptyMetrics);
+        verify(rangerMetricsFetcher).getContextEnrichersMetrics();
+    }
+
+    @Test
+    public void testRefresh_WithNullMetrics() {
+        when(rangerMetricsFetcher.getContextEnrichersMetrics()).thenReturn(null);
+
+        assertThrows(NullPointerException.class, () -> {
+            contextEnricherSource.refresh();
+        });
+
+        verify(rangerMetricsFetcher).getContextEnrichersMetrics();
+    }
+}

--- a/security-admin/src/test/java/org/apache/ranger/metrics/source/TestRangerAdminMetricsSourceDenyConditions.java
+++ b/security-admin/src/test/java/org/apache/ranger/metrics/source/TestRangerAdminMetricsSourceDenyConditions.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.metrics.source;
+
+import org.apache.ranger.metrics.RangerMetricsFetcher;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class TestRangerAdminMetricsSourceDenyConditions {
+    private static final String EXPECTED_METRIC_PREFIX = "DenyConditionCount";
+
+    @InjectMocks
+    RangerAdminMetricsSourceDenyConditions denyConditionsSource;
+
+    @Mock
+    RangerMetricsFetcher rangerMetricsFetcher;
+
+    @Test
+    public void testRefresh_WithValidMetrics() {
+        RangerAdminMetricsSourceDenyConditions spyDenyConditionsSource = spy(denyConditionsSource);
+
+        Map<String, Long> mockMetrics = new HashMap<>();
+        mockMetrics.put("hdfs", 3L);
+        mockMetrics.put("hive", 2L);
+        mockMetrics.put("total", 5L);
+
+        when(rangerMetricsFetcher.getDenyConditionsMetrics()).thenReturn(mockMetrics);
+
+        spyDenyConditionsSource.refresh();
+
+        verify(spyDenyConditionsSource).addMetricEntries(EXPECTED_METRIC_PREFIX, mockMetrics);
+        verify(rangerMetricsFetcher).getDenyConditionsMetrics();
+    }
+
+    @Test
+    public void testRefresh_WithEmptyMetrics() {
+        RangerAdminMetricsSourceDenyConditions spyDenyConditionsSource = spy(denyConditionsSource);
+
+        Map<String, Long> emptyMetrics = new HashMap<>();
+
+        when(rangerMetricsFetcher.getDenyConditionsMetrics()).thenReturn(emptyMetrics);
+
+        spyDenyConditionsSource.refresh();
+
+        verify(spyDenyConditionsSource).addMetricEntries(EXPECTED_METRIC_PREFIX, emptyMetrics);
+        verify(rangerMetricsFetcher).getDenyConditionsMetrics();
+    }
+
+    @Test
+    public void testRefresh_WithNullMetrics() {
+        when(rangerMetricsFetcher.getDenyConditionsMetrics()).thenReturn(null);
+
+        assertThrows(NullPointerException.class, () -> {
+            denyConditionsSource.refresh();
+        });
+
+        verify(rangerMetricsFetcher).getDenyConditionsMetrics();
+    }
+}

--- a/security-admin/src/test/java/org/apache/ranger/metrics/source/TestRangerAdminMetricsSourcePolicyMasking.java
+++ b/security-admin/src/test/java/org/apache/ranger/metrics/source/TestRangerAdminMetricsSourcePolicyMasking.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.metrics.source;
+
+import org.apache.ranger.metrics.RangerMetricsFetcher;
+import org.apache.ranger.plugin.model.RangerPolicy;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class TestRangerAdminMetricsSourcePolicyMasking {
+    private static final String EXPECTED_METRIC_PREFIX = "MaskingCount";
+
+    @InjectMocks
+    RangerAdminMetricsSourcePolicyMasking policyMaskingSource;
+
+    @Mock
+    RangerMetricsFetcher rangerMetricsFetcher;
+
+    @Test
+    public void testRefresh_WithValidMetrics() {
+        RangerAdminMetricsSourcePolicyMasking spyPolicyMaskingSource = spy(policyMaskingSource);
+
+        Map<String, Long> mockMetrics = new HashMap<>();
+        mockMetrics.put("hdfs", 3L);
+        mockMetrics.put("hive", 2L);
+        mockMetrics.put("total", 5L);
+
+        when(rangerMetricsFetcher.getPolicyMetrics(RangerPolicy.POLICY_TYPE_DATAMASK)).thenReturn(mockMetrics);
+
+        spyPolicyMaskingSource.refresh();
+
+        verify(spyPolicyMaskingSource).addMetricEntries(EXPECTED_METRIC_PREFIX, mockMetrics);
+        verify(rangerMetricsFetcher).getPolicyMetrics(RangerPolicy.POLICY_TYPE_DATAMASK);
+    }
+
+    @Test
+    public void testRefresh_WithEmptyMetrics() {
+        RangerAdminMetricsSourcePolicyMasking spyPolicyMaskingSource = spy(policyMaskingSource);
+
+        Map<String, Long> emptyMetrics = new HashMap<>();
+
+        when(rangerMetricsFetcher.getPolicyMetrics(RangerPolicy.POLICY_TYPE_DATAMASK)).thenReturn(emptyMetrics);
+
+        spyPolicyMaskingSource.refresh();
+
+        verify(spyPolicyMaskingSource).addMetricEntries(EXPECTED_METRIC_PREFIX, emptyMetrics);
+        verify(rangerMetricsFetcher).getPolicyMetrics(RangerPolicy.POLICY_TYPE_DATAMASK);
+    }
+
+    @Test
+    public void testRefresh_WithNullMetrics() {
+        when(rangerMetricsFetcher.getPolicyMetrics(RangerPolicy.POLICY_TYPE_DATAMASK)).thenReturn(null);
+
+        assertThrows(NullPointerException.class, () -> {
+            policyMaskingSource.refresh();
+        });
+
+        verify(rangerMetricsFetcher).getPolicyMetrics(RangerPolicy.POLICY_TYPE_DATAMASK);
+    }
+}

--- a/security-admin/src/test/java/org/apache/ranger/metrics/source/TestRangerAdminMetricsSourcePolicyResourceAccess.java
+++ b/security-admin/src/test/java/org/apache/ranger/metrics/source/TestRangerAdminMetricsSourcePolicyResourceAccess.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.metrics.source;
+
+import org.apache.ranger.metrics.RangerMetricsFetcher;
+import org.apache.ranger.plugin.model.RangerPolicy;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class TestRangerAdminMetricsSourcePolicyResourceAccess {
+    private static final String EXPECTED_METRIC_PREFIX = "ResourceAccessCount";
+
+    @InjectMocks
+    RangerAdminMetricsSourcePolicyResourceAccess resourceAccessSource;
+
+    @Mock
+    RangerMetricsFetcher rangerMetricsFetcher;
+
+    @Test
+    public void testRefresh_WithValidMetrics() {
+        RangerAdminMetricsSourcePolicyResourceAccess spyResourceAccessSource = spy(resourceAccessSource);
+
+        Map<String, Long> mockMetrics = new HashMap<>();
+        mockMetrics.put("hdfs", 3L);
+        mockMetrics.put("hive", 2L);
+        mockMetrics.put("total", 5L);
+
+        when(rangerMetricsFetcher.getPolicyMetrics(RangerPolicy.POLICY_TYPE_ACCESS)).thenReturn(mockMetrics);
+
+        spyResourceAccessSource.refresh();
+
+        verify(spyResourceAccessSource).addMetricEntries(EXPECTED_METRIC_PREFIX, mockMetrics);
+        verify(rangerMetricsFetcher).getPolicyMetrics(RangerPolicy.POLICY_TYPE_ACCESS);
+    }
+
+    @Test
+    public void testRefresh_WithEmptyMetrics() {
+        RangerAdminMetricsSourcePolicyResourceAccess spyResourceAccessSource = spy(resourceAccessSource);
+
+        Map<String, Long> emptyMetrics = new HashMap<>();
+
+        when(rangerMetricsFetcher.getPolicyMetrics(RangerPolicy.POLICY_TYPE_ACCESS)).thenReturn(emptyMetrics);
+
+        spyResourceAccessSource.refresh();
+
+        verify(spyResourceAccessSource).addMetricEntries(EXPECTED_METRIC_PREFIX, emptyMetrics);
+        verify(rangerMetricsFetcher).getPolicyMetrics(RangerPolicy.POLICY_TYPE_ACCESS);
+    }
+
+    @Test
+    public void testRefresh_WithNullMetrics() {
+        when(rangerMetricsFetcher.getPolicyMetrics(RangerPolicy.POLICY_TYPE_ACCESS)).thenReturn(null);
+
+        assertThrows(NullPointerException.class, () -> {
+            resourceAccessSource.refresh();
+        });
+
+        verify(rangerMetricsFetcher).getPolicyMetrics(RangerPolicy.POLICY_TYPE_ACCESS);
+    }
+}

--- a/security-admin/src/test/java/org/apache/ranger/metrics/source/TestRangerAdminMetricsSourcePolicyRowFiltering.java
+++ b/security-admin/src/test/java/org/apache/ranger/metrics/source/TestRangerAdminMetricsSourcePolicyRowFiltering.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.metrics.source;
+
+import org.apache.ranger.metrics.RangerMetricsFetcher;
+import org.apache.ranger.plugin.model.RangerPolicy;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class TestRangerAdminMetricsSourcePolicyRowFiltering {
+    private static final String EXPECTED_METRIC_PREFIX = "RowFilteringCount";
+
+    @InjectMocks
+    RangerAdminMetricsSourcePolicyRowFiltering rowFilteringSource;
+
+    @Mock
+    RangerMetricsFetcher rangerMetricsFetcher;
+
+    @Test
+    public void testRefresh_WithValidMetrics() {
+        RangerAdminMetricsSourcePolicyRowFiltering spyRowFilteringSource = spy(rowFilteringSource);
+
+        Map<String, Long> mockMetrics = new HashMap<>();
+        mockMetrics.put("hdfs", 3L);
+        mockMetrics.put("hive", 2L);
+        mockMetrics.put("total", 5L);
+
+        when(rangerMetricsFetcher.getPolicyMetrics(RangerPolicy.POLICY_TYPE_ROWFILTER)).thenReturn(mockMetrics);
+
+        spyRowFilteringSource.refresh();
+
+        verify(spyRowFilteringSource).addMetricEntries(EXPECTED_METRIC_PREFIX, mockMetrics);
+        verify(rangerMetricsFetcher).getPolicyMetrics(RangerPolicy.POLICY_TYPE_ROWFILTER);
+    }
+
+    @Test
+    public void testRefresh_WithEmptyMetrics() {
+        RangerAdminMetricsSourcePolicyRowFiltering spyRowFilteringSource = spy(rowFilteringSource);
+
+        Map<String, Long> emptyMetrics = new HashMap<>();
+
+        when(rangerMetricsFetcher.getPolicyMetrics(RangerPolicy.POLICY_TYPE_ROWFILTER)).thenReturn(emptyMetrics);
+
+        spyRowFilteringSource.refresh();
+
+        verify(spyRowFilteringSource).addMetricEntries(EXPECTED_METRIC_PREFIX, emptyMetrics);
+        verify(rangerMetricsFetcher).getPolicyMetrics(RangerPolicy.POLICY_TYPE_ROWFILTER);
+    }
+
+    @Test
+    public void testRefresh_WithNullMetrics() {
+        when(rangerMetricsFetcher.getPolicyMetrics(RangerPolicy.POLICY_TYPE_ROWFILTER)).thenReturn(null);
+
+        assertThrows(NullPointerException.class, () -> {
+            rowFilteringSource.refresh();
+        });
+
+        verify(rangerMetricsFetcher).getPolicyMetrics(RangerPolicy.POLICY_TYPE_ROWFILTER);
+    }
+}

--- a/security-admin/src/test/java/org/apache/ranger/metrics/source/TestRangerAdminMetricsSourceService.java
+++ b/security-admin/src/test/java/org/apache/ranger/metrics/source/TestRangerAdminMetricsSourceService.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.metrics.source;
+
+import org.apache.ranger.metrics.RangerMetricsFetcher;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class TestRangerAdminMetricsSourceService {
+    private static final String EXPECTED_METRIC_PREFIX = "ServiceCount";
+
+    @InjectMocks
+    RangerAdminMetricsSourceService serviceSource;
+
+    @Mock
+    RangerMetricsFetcher rangerMetricsFetcher;
+
+    @Test
+    public void testRefresh_WithValidMetrics() {
+        RangerAdminMetricsSourceService spyService = spy(serviceSource);
+
+        Map<String, Long> mockMetrics = new HashMap<>();
+        mockMetrics.put("hdfs", 3L);
+        mockMetrics.put("hive", 2L);
+        mockMetrics.put("total", 5L);
+
+        when(rangerMetricsFetcher.getRangerServiceMetrics()).thenReturn(mockMetrics);
+
+        spyService.refresh();
+
+        verify(spyService).addMetricEntries(EXPECTED_METRIC_PREFIX, mockMetrics);
+        verify(rangerMetricsFetcher).getRangerServiceMetrics();
+    }
+
+    @Test
+    public void testRefresh_WithEmptyMetrics() {
+        RangerAdminMetricsSourceService spyService = spy(serviceSource);
+
+        Map<String, Long> emptyMetrics = new HashMap<>();
+        when(rangerMetricsFetcher.getRangerServiceMetrics()).thenReturn(new HashMap<>());
+
+        spyService.refresh();
+
+        verify(spyService).addMetricEntries(EXPECTED_METRIC_PREFIX, emptyMetrics);
+        verify(rangerMetricsFetcher).getRangerServiceMetrics();
+    }
+
+    @Test
+    public void testRefresh_WithNullMetrics() {
+        when(rangerMetricsFetcher.getRangerServiceMetrics()).thenReturn(null);
+
+        assertThrows(NullPointerException.class, () -> {
+            serviceSource.refresh();
+        });
+        verify(rangerMetricsFetcher).getRangerServiceMetrics();
+    }
+}

--- a/security-admin/src/test/java/org/apache/ranger/metrics/source/TestRangerAdminMetricsSourceUserGroup.java
+++ b/security-admin/src/test/java/org/apache/ranger/metrics/source/TestRangerAdminMetricsSourceUserGroup.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.metrics.source;
+
+import org.apache.ranger.metrics.RangerMetricsFetcher;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class TestRangerAdminMetricsSourceUserGroup {
+    private static final String USER_COUNT_METRIC_PREFIX = "UserCount";
+    private static final String GROUP_COUNT_METRIC_NAME = "GroupCount";
+
+    @InjectMocks
+    RangerAdminMetricsSourceUserGroup userGroupSource;
+
+    @Mock
+    RangerMetricsFetcher rangerMetricsFetcher;
+
+    @Test
+    public void testRefresh_WithValidUserGroupMetrics() {
+        RangerAdminMetricsSourceUserGroup spyUserGroupSource = spy(userGroupSource);
+
+        Map<String, Long> mockUserMetrics = new HashMap<>();
+        mockUserMetrics.put("admin", 3L);
+        mockUserMetrics.put("user", 2L);
+        mockUserMetrics.put("total", 5L);
+
+        long mockGroupCount = 7L;
+
+        when(rangerMetricsFetcher.getUserMetrics()).thenReturn(mockUserMetrics);
+        when(rangerMetricsFetcher.getGroupCount()).thenReturn(mockGroupCount);
+
+        spyUserGroupSource.refresh();
+
+        verify(spyUserGroupSource).addMetricEntries(USER_COUNT_METRIC_PREFIX, mockUserMetrics);
+        verify(spyUserGroupSource).addMetricEntry(GROUP_COUNT_METRIC_NAME, "", mockGroupCount);
+        verify(rangerMetricsFetcher).getUserMetrics();
+        verify(rangerMetricsFetcher).getGroupCount();
+    }
+
+    @Test
+    public void testRefresh_WithEmptyMetrics() {
+        RangerAdminMetricsSourceUserGroup spyUserGroupSource = spy(userGroupSource);
+
+        Map<String, Long> mockUserMetrics = new HashMap<>();
+
+        long mockGroupCount = 7L;
+
+        when(rangerMetricsFetcher.getUserMetrics()).thenReturn(mockUserMetrics);
+        when(rangerMetricsFetcher.getGroupCount()).thenReturn(mockGroupCount);
+
+        spyUserGroupSource.refresh();
+
+        verify(spyUserGroupSource).addMetricEntries(USER_COUNT_METRIC_PREFIX, mockUserMetrics);
+        verify(spyUserGroupSource).addMetricEntry(GROUP_COUNT_METRIC_NAME, "", mockGroupCount);
+        verify(rangerMetricsFetcher).getUserMetrics();
+        verify(rangerMetricsFetcher).getGroupCount();
+    }
+
+    @Test
+    public void testRefresh_WithNullUserMetrics() {
+        when(rangerMetricsFetcher.getUserMetrics()).thenReturn(null);
+
+        assertThrows(NullPointerException.class, () -> {
+            userGroupSource.refresh();
+        });
+
+        verify(rangerMetricsFetcher).getUserMetrics();
+        verify(rangerMetricsFetcher, never()).getGroupCount();
+    }
+}


### PR DESCRIPTION
…min Module

## What changes were proposed in this pull request?

### AI Disclosure   
Added AI-generated Test methods/Test classes for the org.apache.ranger.metrics and org.apache.ranger.metrics.source modules using Cursor AI and manually reviewed.

Added unit tests for classes in the org.apache.ranger.metrics and org.apache.ranger.metrics.source packages within the Security Admin module.


## How was this patch tested?

Build completed successfully along with all test cases using the command: mvn clean compile package install.

As per Jacoco
Apache -> Security-Admin Module

Packages Covered

org.apache.ranger.metrics 	      -> 0% to 100% Coverage

org.apache.ranger.metrics.source -> 0% to 100% Coverage
