### PR TITLE
RANGER-5295: fix GDS policy evaluation handling of row-filters

### DIFF
--- a/agents-common/src/main/java/org/apache/ranger/plugin/policyengine/RangerPolicyEngineImpl.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/policyengine/RangerPolicyEngineImpl.java
@@ -1072,12 +1072,35 @@ public class RangerPolicyEngineImpl implements RangerPolicyEngine {
 
         if (gdsResult != null) {
             if (result.getPolicyType() == RangerPolicy.POLICY_TYPE_ACCESS) {
+                // pick access result from GDS policies only if there is no decision yet
                 if (!result.getIsAccessDetermined() && gdsResult.getIsAllowed()) {
                     result.setIsAllowed(true);
                     result.setIsAccessDetermined(true);
                     result.setPolicyId(gdsResult.getPolicyId());
                     result.setPolicyVersion(gdsResult.getPolicyVersion());
                     result.setPolicyPriority(RangerPolicy.POLICY_PRIORITY_NORMAL);
+                }
+            } else if (result.getPolicyType() == RangerPolicy.POLICY_TYPE_ROWFILTER) {
+                // pick row-filter from GDS policies only if there is no decision yet
+                if (result.getPolicyId() != -1 && CollectionUtils.isNotEmpty(gdsResult.getRowFilters())) {
+                    result.setIsAllowed(true);
+                    result.setIsAccessDetermined(true);
+                    result.setPolicyId(gdsResult.getPolicyId());
+                    result.setPolicyVersion(gdsResult.getPolicyVersion());
+                    result.setPolicyPriority(RangerPolicy.POLICY_PRIORITY_NORMAL);
+                    result.setFilterExpr(gdsResult.getRowFilters().get(0));
+                }
+            } else if (result.getPolicyType() == RangerPolicy.POLICY_TYPE_DATAMASK) {
+                // pick data-mask from GDS policies only if there is no decision yet
+                if (result.getPolicyId() != -1 && StringUtils.isNotEmpty(gdsResult.getMaskType())) {
+                    result.setIsAllowed(true);
+                    result.setIsAccessDetermined(true);
+                    result.setPolicyId(gdsResult.getPolicyId());
+                    result.setPolicyVersion(gdsResult.getPolicyVersion());
+                    result.setPolicyPriority(RangerPolicy.POLICY_PRIORITY_NORMAL);
+                    result.setMaskType(gdsResult.getMaskType());
+                    result.setMaskedValue(gdsResult.getMaskedValue());
+                    result.setMaskCondition(gdsResult.getMaskCondition());
                 }
             }
 

--- a/agents-common/src/main/java/org/apache/ranger/plugin/policyengine/RangerPolicyEngineImpl.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/policyengine/RangerPolicyEngineImpl.java
@@ -1074,47 +1074,46 @@ public class RangerPolicyEngineImpl implements RangerPolicyEngine {
             if (result.getPolicyType() == RangerPolicy.POLICY_TYPE_ACCESS) {
                 // pick access result from GDS policies only if there is no decision yet
                 if (!result.getIsAccessDetermined() && gdsResult.getIsAllowed()) {
-                    result.setIsAllowed(true);
-                    result.setIsAccessDetermined(true);
-                    result.setPolicyId(gdsResult.getPolicyId());
-                    result.setPolicyVersion(gdsResult.getPolicyVersion());
-                    result.setPolicyPriority(RangerPolicy.POLICY_PRIORITY_NORMAL);
+                    copyFromGdsResult(gdsResult, result);
                 }
             } else if (result.getPolicyType() == RangerPolicy.POLICY_TYPE_ROWFILTER) {
                 // pick row-filter from GDS policies only if there is no decision yet
                 if (result.getPolicyId() == -1 && CollectionUtils.isNotEmpty(gdsResult.getRowFilters())) {
-                    result.setIsAllowed(true);
-                    result.setIsAccessDetermined(true);
-                    result.setPolicyId(gdsResult.getPolicyId());
-                    result.setPolicyVersion(gdsResult.getPolicyVersion());
-                    result.setPolicyPriority(RangerPolicy.POLICY_PRIORITY_NORMAL);
+                    copyFromGdsResult(gdsResult, result);
+
                     result.setFilterExpr(gdsResult.getRowFilters().get(0));
                 }
             } else if (result.getPolicyType() == RangerPolicy.POLICY_TYPE_DATAMASK) {
                 // pick data-mask from GDS policies only if there is no decision yet
                 if (result.getPolicyId() == -1 && StringUtils.isNotEmpty(gdsResult.getMaskType())) {
-                    result.setIsAllowed(true);
-                    result.setIsAccessDetermined(true);
-                    result.setPolicyId(gdsResult.getPolicyId());
-                    result.setPolicyVersion(gdsResult.getPolicyVersion());
-                    result.setPolicyPriority(RangerPolicy.POLICY_PRIORITY_NORMAL);
+                    copyFromGdsResult(gdsResult, result);
+
                     result.setMaskType(gdsResult.getMaskType());
                     result.setMaskedValue(gdsResult.getMaskedValue());
                     result.setMaskCondition(gdsResult.getMaskCondition());
                 }
             }
-
-            if (!result.getIsAuditedDetermined() && gdsResult.getIsAudited()) {
-                result.setIsAudited(true);
-            }
-
-            result.setDatasets(gdsResult.getDatasets());
-            result.setProjects(gdsResult.getProjects());
         } else {
             LOG.debug("updateFromGdsResult(): no GdsAccessResult found in request context({})", request);
         }
 
         LOG.debug("<== updateFromGdsResult(result={})", result);
+    }
+
+    private void copyFromGdsResult(GdsAccessResult gdsResult, RangerAccessResult result) {
+        if (gdsResult != null && result != null) {
+            result.setIsAllowed(true);
+            result.setIsAccessDetermined(true);
+            result.setPolicyId(gdsResult.getPolicyId());
+            result.setPolicyVersion(gdsResult.getPolicyVersion());
+            result.setPolicyPriority(RangerPolicy.POLICY_PRIORITY_NORMAL);
+            result.setDatasets(gdsResult.getDatasets());
+            result.setProjects(gdsResult.getProjects());
+
+            if (!result.getIsAuditedDetermined() && gdsResult.getIsAudited()) {
+                result.setIsAudited(true);
+            }
+        }
     }
 
     private static class ServiceConfig {

--- a/agents-common/src/main/java/org/apache/ranger/plugin/policyengine/RangerPolicyEngineImpl.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/policyengine/RangerPolicyEngineImpl.java
@@ -1093,6 +1093,13 @@ public class RangerPolicyEngineImpl implements RangerPolicyEngine {
                     result.setMaskCondition(gdsResult.getMaskCondition());
                 }
             }
+
+            if (!result.getIsAuditedDetermined() && gdsResult.getIsAudited()) {
+                result.setIsAudited(true);
+            }
+
+            result.setDatasets(gdsResult.getDatasets());
+            result.setProjects(gdsResult.getProjects());
         } else {
             LOG.debug("updateFromGdsResult(): no GdsAccessResult found in request context({})", request);
         }
@@ -1107,12 +1114,6 @@ public class RangerPolicyEngineImpl implements RangerPolicyEngine {
             result.setPolicyId(gdsResult.getPolicyId());
             result.setPolicyVersion(gdsResult.getPolicyVersion());
             result.setPolicyPriority(RangerPolicy.POLICY_PRIORITY_NORMAL);
-            result.setDatasets(gdsResult.getDatasets());
-            result.setProjects(gdsResult.getProjects());
-
-            if (!result.getIsAuditedDetermined() && gdsResult.getIsAudited()) {
-                result.setIsAudited(true);
-            }
         }
     }
 

--- a/agents-common/src/main/java/org/apache/ranger/plugin/policyengine/RangerPolicyEngineImpl.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/policyengine/RangerPolicyEngineImpl.java
@@ -1082,7 +1082,7 @@ public class RangerPolicyEngineImpl implements RangerPolicyEngine {
                 }
             } else if (result.getPolicyType() == RangerPolicy.POLICY_TYPE_ROWFILTER) {
                 // pick row-filter from GDS policies only if there is no decision yet
-                if (result.getPolicyId() != -1 && CollectionUtils.isNotEmpty(gdsResult.getRowFilters())) {
+                if (result.getPolicyId() == -1 && CollectionUtils.isNotEmpty(gdsResult.getRowFilters())) {
                     result.setIsAllowed(true);
                     result.setIsAccessDetermined(true);
                     result.setPolicyId(gdsResult.getPolicyId());
@@ -1092,7 +1092,7 @@ public class RangerPolicyEngineImpl implements RangerPolicyEngine {
                 }
             } else if (result.getPolicyType() == RangerPolicy.POLICY_TYPE_DATAMASK) {
                 // pick data-mask from GDS policies only if there is no decision yet
-                if (result.getPolicyId() != -1 && StringUtils.isNotEmpty(gdsResult.getMaskType())) {
+                if (result.getPolicyId() == -1 && StringUtils.isNotEmpty(gdsResult.getMaskType())) {
                     result.setIsAllowed(true);
                     result.setIsAccessDetermined(true);
                     result.setPolicyId(gdsResult.getPolicyId());

--- a/agents-common/src/test/resources/policyengine/gds/gds_info_hive_row_filter.json
+++ b/agents-common/src/test/resources/policyengine/gds/gds_info_hive_row_filter.json
@@ -169,6 +169,11 @@
       "id": 61, "dataShareId": 6, "conditionExpr": "", "accessTypes": [ "select" ],
       "resource": { "database": { "values": [ "customers" ] }, "table": { "values": [ "contact_info" ] } }, "rowFilter": { "filterExpr": "country = 'US'" },
       "subResourceType": "column", "subResource": { "values": [ "*" ] }, "subResourceMasks": null
+    },
+    {
+      "id": 71, "dataShareId": 6, "conditionExpr": "", "accessTypes": [ "select" ],
+      "resource": { "database": { "values": [ "customers" ] }, "table": { "values": [ "shipping_address" ] } }, "rowFilter": { "filterExpr": "country = 'US'" },
+      "subResourceType": "column", "subResource": { "values": [ "phone", "city", "zip" ] }, "subResourceMasks": [ { "values": [ "phone" ], "maskInfo": { "dataMaskType": "MASK_SHOW_LAST_4" } }]
     }
   ],
   "gdsVersion": 1

--- a/agents-common/src/test/resources/policyengine/gds/test_gds_policy_hive_row_filter.json
+++ b/agents-common/src/test/resources/policyengine/gds/test_gds_policy_hive_row_filter.json
@@ -29,7 +29,7 @@
         "resource":   { "elements": { "database": "sales" } },
         "accessType": "", "user": "ds-user", "userGroups": []
       },
-      "result": { "datasets": [ "dataset-1" ], "projects": [ "project-1" ], "allowedByDatasets": [ "dataset-1" ], "isAllowed": true, "isAudited": true, "policyId": 2001, "rowFilters": [ "created_time >= '2023-01-01' and created_time < '2024-01-01'" ] }
+      "result": { "datasets": [ "dataset-1" ], "projects": [ "project-1" ], "allowedByDatasets": [ "dataset-1" ], "isAllowed": true, "isAudited": true, "policyId": 2001, "rowFilters": null }
     },
     {
       "name":    "table: finance.invoices, user: ds-user, access: select",
@@ -69,7 +69,7 @@
         "resource":   { "elements": { "database": "finance" } },
         "accessType": "", "user": "ds-user", "userGroups": []
       },
-      "result": { "datasets": [ "dataset-1", "dataset-2" ], "projects": [ "project-1" ], "allowedByDatasets": [ "dataset-1", "dataset-2" ], "isAllowed": true, "isAudited": true, "policyId": 2001, "rowFilters": [ "created_time >= '2023-01-01' and created_time < '2024-01-01'" ] }
+      "result": { "datasets": [ "dataset-1", "dataset-2" ], "projects": [ "project-1" ], "allowedByDatasets": [ "dataset-1", "dataset-2" ], "isAllowed": true, "isAudited": true, "policyId": 2001, "rowFilters": null }
     },
     {
       "name":    "table: shipping.shipments, user: ds-user, access: select",
@@ -85,7 +85,7 @@
         "resource":   { "elements": { "database": "shipping" } },
         "accessType": "", "user": "ds-user", "userGroups": []
       },
-      "result": { "datasets": [ "dataset-2" ], "projects": [ "project-1" ], "allowedByDatasets": [ "dataset-2" ], "isAllowed": true, "isAudited": true, "policyId": 2002, "rowFilters": [ "created_time >= '2023-01-01' and created_time < '2024-01-01'" ] }
+      "result": { "datasets": [ "dataset-2" ], "projects": [ "project-1" ], "allowedByDatasets": [ "dataset-2" ], "isAllowed": true, "isAudited": true, "policyId": 2002, "rowFilters": null }
     },
     {
       "name":    "table: customers.contact_info, user: ds-user, access: select",
@@ -117,8 +117,43 @@
         "resource":   { "elements": { "database": "customers" } },
         "accessType": "", "user": "ds-user", "userGroups": []
       },
-      "result": { "datasets": [ "dataset-3", "dataset-6" ], "projects": [ "project-2", "project-4" ], "allowedByDatasets": [ "dataset-3", "dataset-6" ], "isAllowed": true, "isAudited": true, "policyId": 2003, "rowFilters": [ "created_time >= '2023-01-01' and created_time < '2024-01-01'", "country = 'US'" ] }
+      "result": { "datasets": [ "dataset-3", "dataset-6" ], "projects": [ "project-2", "project-4" ], "allowedByDatasets": [ "dataset-3", "dataset-6" ], "isAllowed": true, "isAudited": true, "policyId": 2003, "rowFilters": null }
     },
+
+    {
+      "name":    "table: customers.shipping_address, user: ds-user, access: select",
+      "request": {
+        "resource":   { "elements": { "database": "customers", "table": "shipping_address" } },
+        "accessType": "select", "user": "ds-user", "userGroups": []
+      },
+      "result": { "datasets": [ "dataset-6" ], "projects": [ "project-4" ], "allowedByDatasets": [ "dataset-6" ], "isAllowed": false, "isAudited": true, "policyId": 2006, "rowFilters": [ "country = 'US'" ] }
+    },
+    {
+      "name":    "table: customers.shipping_address, user: ds3-user, access: select",
+      "request": {
+        "resource":   { "elements": { "database": "customers", "table": "shipping_address" } },
+        "accessType": "select", "user": "ds3-user", "userGroups": []
+      },
+      "result": { "datasets": [ "dataset-6" ], "projects": [ "project-4" ], "allowedByDatasets": null, "isAllowed": false, "isAudited": true, "policyId": -1, "rowFilters": null }
+    },
+    {
+      "name":    "table: customers.shipping_address, user: ds6-user, access: select",
+      "request": {
+        "resource":   { "elements": { "database": "customers", "table": "shipping_address" } },
+        "accessType": "select", "user": "ds6-user", "userGroups": []
+      },
+      "result": { "datasets": [ "dataset-6" ], "projects": [ "project-4" ], "allowedByDatasets": [ "dataset-6" ], "isAllowed": false, "isAudited": true, "policyId": 2006, "rowFilters": [ "country = 'US'" ] }
+    },
+    {
+      "name":    "database: customers, user: ds-user, access: _any",
+      "request": {
+        "resource":   { "elements": { "database": "customers" } },
+        "accessType": "", "user": "ds-user", "userGroups": []
+      },
+      "result": { "datasets": [ "dataset-3", "dataset-6" ], "projects": [ "project-2", "project-4" ], "allowedByDatasets": [ "dataset-3", "dataset-6" ], "isAllowed": true, "isAudited": true, "policyId": 2003, "rowFilters": null }
+    },
+
+
     {
       "name":    "table: operations.facilities, user: ds-user, access: select",
       "request": {
@@ -133,7 +168,7 @@
         "resource":   { "elements": { "database": "operations" } },
         "accessType": "", "user": "ds-user", "userGroups": []
       },
-      "result": { "datasets": [ "dataset-4" ], "projects": null, "allowedByDatasets": [ "dataset-4" ], "isAllowed": true, "isAudited": true, "policyId": 2004, "rowFilters": [ "country = 'US'" ] }
+      "result": { "datasets": [ "dataset-4" ], "projects": null, "allowedByDatasets": [ "dataset-4" ], "isAllowed": true, "isAudited": true, "policyId": 2004, "rowFilters": null }
     },
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

GDS policy evaluation updated to evaluate row-filter policies even when GDS policy does not grant access to all sub-resources of a resource.

## How was this patch tested?

added unit tests to cover this use case; verified that all tests pass