### PR TITLE
RANGER-3965: Handling for DB runtime error when key attribute is very…

### DIFF
--- a/kms/src/main/java/org/apache/hadoop/crypto/key/RangerKeyStore.java
+++ b/kms/src/main/java/org/apache/hadoop/crypto/key/RangerKeyStore.java
@@ -529,6 +529,7 @@ public class RangerKeyStore extends KeyStoreSpi {
             }
         } catch (Exception e) {
             logger.error("dbOperationStore({}) error", rangerKeyStore.getAlias(), e);
+            throw new RuntimeException("Error while storing object in the DB. " + e.getMessage());
         }
 
         logger.debug("<== dbOperationStore({})", rangerKeyStore.getAlias());

--- a/kms/src/main/java/org/apache/ranger/kms/dao/BaseDao.java
+++ b/kms/src/main/java/org/apache/ranger/kms/dao/BaseDao.java
@@ -117,6 +117,7 @@ public abstract class BaseDao<T> {
             logger.error("create({}) failed", tClass.getSimpleName(), e);
 
             rollbackTransaction();
+            throw e;
         }
 
         return ret;


### PR DESCRIPTION

## What changes were proposed in this pull request?

This PR contains fix for RANGER-3965. If key attribute is very long ( more than 1024, schema defined column length), KMS logs exception (as expected) but same exception is not being propagated. On UI, it was showing as key created but failed to list.  
This fix propagates the exception so that API returns error instead of simply logging the exception and doing nothing.


## How was this patch tested?
-  KMS build and UT
- Created new KMS docker image and manually verified the scenario.
