### PR TITLE
RANGER-5271 : Last login date and time on Ranger Home page

### DIFF
--- a/security-admin/src/main/java/org/apache/ranger/biz/SessionMgr.java
+++ b/security-admin/src/main/java/org/apache/ranger/biz/SessionMgr.java
@@ -21,6 +21,7 @@
 
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -325,6 +326,18 @@ public class SessionMgr {
 		gjAuthSession = storeAuthSession(gjAuthSession);
 		return gjAuthSession;
 	}
+
+    public Date getLastSuccessLoginAuthTimeByUserId(String loginId) {
+        XXAuthSession xXAuthSession = daoManager.getXXAuthSession().getLastSuccessLoginAuthSessionByUserId(loginId);
+
+        if (xXAuthSession != null) {
+            return authSessionService.populateViewBean(xXAuthSession).getAuthTime();
+        } else {
+            logger.info("Session cleaned up or  User logged in for first time");
+        }
+
+        return null;
+    }
 
 	protected boolean validateUserSession(UserSessionBase userSession,
 			String currentLoginId) {

--- a/security-admin/src/main/java/org/apache/ranger/biz/UserMgr.java
+++ b/security-admin/src/main/java/org/apache/ranger/biz/UserMgr.java
@@ -585,7 +585,9 @@ public class UserMgr {
 
 			userProfile.setUserRoleList(userRoleList);
 		}
+		userProfile.setLastLoginTime(sessionMgr.getLastSuccessLoginAuthTimeByUserId(sess.getLoginId()));
 		userProfile.setUserSource(user.getUserSource());
+
 		return userProfile;
 	}
 

--- a/security-admin/src/main/java/org/apache/ranger/db/XXAuthSessionDao.java
+++ b/security-admin/src/main/java/org/apache/ranger/db/XXAuthSessionDao.java
@@ -71,6 +71,23 @@ public class XXAuthSessionDao extends BaseDao<XXAuthSession> {
 		}
 	}
 
+    public XXAuthSession getLastSuccessLoginAuthSessionByUserId(String loginId) {
+        if (loginId == null) {
+            return null;
+        }
+        try {
+            List<XXAuthSession> sessions = getEntityManager()
+                    .createNamedQuery("XXAuthSession.getSuccessAuthSessionsByUserId", tClass)
+                    .setParameter("loginId", loginId)
+                    .setParameter("authStatus", XXAuthSession.AUTH_STATUS_SUCCESS)
+                    .setMaxResults(2)
+                    .getResultList();
+            return sessions.size() >= 2 ? sessions.get(1) : null;
+        } catch (NoResultException ignoreNoResultFound) {
+            return null;
+        }
+    }
+
 	public long getRecentAuthFailureCountByLoginId(String loginId, int timeRangezSecond){
 		Date authWindowStartTime = new Date(DateUtil.getUTCDate().getTime() - timeRangezSecond * 1000);
 

--- a/security-admin/src/main/java/org/apache/ranger/view/VXPortalUser.java
+++ b/security-admin/src/main/java/org/apache/ranger/view/VXPortalUser.java
@@ -20,14 +20,17 @@
  package org.apache.ranger.view;
 
 import java.util.Collection;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
 import org.apache.ranger.common.AppConstants;
+import org.apache.ranger.json.JsonDateSerializer;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 @JsonAutoDetect(getterVisibility=Visibility.NONE, setterVisibility=Visibility.NONE, fieldVisibility=Visibility.ANY)
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -94,6 +97,9 @@ public class VXPortalUser extends VXDataObject implements java.io.Serializable {
 	 *
 	 */
 	protected String syncSource;
+
+	@JsonSerialize(using = JsonDateSerializer.class)
+	protected Date lastLoginTime;
 
 	/**
 	 * Configuration properties.
@@ -348,6 +354,14 @@ public class VXPortalUser extends VXDataObject implements java.io.Serializable {
 		this.syncSource = syncSource;
 	}
 
+    public Date getLastLoginTime() {
+        return lastLoginTime;
+    }
+
+    public void setLastLoginTime(Date lastLoginTime) {
+        this.lastLoginTime = lastLoginTime;
+    }
+
 	/**
 	 * This return the bean content in string format
 	 * @return formatedStr
@@ -366,6 +380,7 @@ public class VXPortalUser extends VXDataObject implements java.io.Serializable {
 		str += "userRoleList={" + userRoleList + "} ";
 		str += "otherAttributes={" + otherAttributes + "} ";
 		str += "syncSource={" + syncSource + "} ";
+		str += "lastLoginTime={" + lastLoginTime + "} ";
 		str += "}";
 		return str;
 	}

--- a/security-admin/src/main/resources/META-INF/jpa_named_queries.xml
+++ b/security-admin/src/main/resources/META-INF/jpa_named_queries.xml
@@ -48,6 +48,11 @@
 		<query>DELETE FROM XXAuthSession obj WHERE obj.id in :ids
 		</query>
 	</named-query>
+	<named-query name="XXAuthSession.getSuccessAuthSessionsByUserId">
+		<query>SELECT obj FROM XXAuthSession obj WHERE obj.loginId = :loginId and obj.authStatus = :authStatus order by obj.id DESC
+		</query>
+	</named-query>
+
 
 	<!-- XXPortalUser -->
 	<named-query name="XXPortalUser.findByEmailAddress">

--- a/security-admin/src/main/webapp/react-webapp/src/styles/style.css
+++ b/security-admin/src/main/webapp/react-webapp/src/styles/style.css
@@ -1309,7 +1309,7 @@ header {
 }
 
 .top-scroll {
-  bottom: 3px;
+  bottom: 10px;
   right: 5px;
 }
 

--- a/security-admin/src/main/webapp/react-webapp/src/views/Layout.jsx
+++ b/security-admin/src/main/webapp/react-webapp/src/views/Layout.jsx
@@ -40,6 +40,7 @@ import { Loader } from "../components/CommonComponents";
 import { Suspense } from "react";
 import { PathAssociateWithModule } from "../utils/XAEnums";
 import { flatMap, values } from "lodash";
+import dateFormat from "dateformat";
 
 const Layout = () => {
   let location = useLocation();
@@ -93,6 +94,13 @@ const Layout = () => {
     setOpen(false);
     activate();
   };
+
+  const lastLoginInformation = userProfile?.lastLoginTime
+    ? `You last logged in on, ${dateFormat(
+        new Date(userProfile.lastLoginTime),
+        "dddd, mmm dd, yyyy, hh:MM:ss TT"
+      )}`
+    : "";
 
   useEffect(() => {
     const interval = setInterval(() => {
@@ -170,6 +178,9 @@ const Layout = () => {
                 >
                   Licensed under the Apache License, Version 2.0
                 </a>
+                <span className="float-end mb-2 me-4" style={{ color: "#999" }}>
+                  {lastLoginInformation}
+                </span>
               </p>
             </div>
           </footer>

--- a/security-admin/src/main/webapp/react-webapp/src/views/SideBar/SideBar.jsx
+++ b/security-admin/src/main/webapp/react-webapp/src/views/SideBar/SideBar.jsx
@@ -125,7 +125,7 @@ export const SideBar = () => {
 
   const userProps = getUserProfile();
   const loginId = (
-    <span className="login-id user-name">{userProps?.loginId}</span>
+    <span className="login-id user-name p-0">{userProps?.loginId}</span>
   );
 
   let location = useLocation();


### PR DESCRIPTION
## What changes were proposed in this pull request?
The Ranger UI should display the logged in user's last login date and time. This information is currently available under Ranger > Audits > Login Sessions, but it would be more convenient for security audits if it were available on the homepage.


## How was this patch tested?

1. Applied the patch locally and verified that the build completed successfully.
2. Started the development server and confirmed there were no errors.
3. Logged in with different users and verified that the last login date and time is displayed correctly on the homepage.
4. Cross-checked the displayed value with the data shown in Ranger > Audits > Login Sessions to ensure accuracy.
5. Performed sanity testing across other homepage components to confirm no regressions.
