### PR TITLE
RANGER-5309: add authz-api module

### DIFF
--- a/authz-api/README.txt
+++ b/authz-api/README.txt
@@ -1,0 +1,177 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+1. Introduction
+   Authorization APIs introduced in this module make it simpler for applications to use Apache Ranger to authorize
+   access to their resources. This document includes few examples of authorization requests and corresponding
+   responses. Libraries in Java and Python will be made available for easier integration in applications using
+   these languages. Support for other languages will be added later as needed.
+
+2. Terminology
+   2.1. User
+        An actor who performs actions on resources. Each user is identified by an unique name. A user can belong
+        to multiple groups and can have multiple roles. A user can also have multiple attributes, like department
+        name, work location. Apache Ranger policies can be setup to grant access to resources based on any of the
+        following: user name, groups the user belongs to, roles the user is assigned to and user attributes.
+
+   2.2. Resource
+        Any object on which actions can be performed. Few examples of resources and actions performed on them:
+         - file: create, delete, write, read
+         - table: create, alter, drop, insert, select, delete
+         - topic: create, alter, delete, produce, consume
+
+        Resources are identified by their name, in format: "resource-type:resource-value". Few examples of resource
+        names:
+         - path:/warehouse/hive/mktg/visitors
+         - table:db1.tbl1
+         - object:s3a://mybucket/p1/p2/data.parquet
+
+        Resources can have attributes, like owner, createTime. Access to resources can be granted based on resource
+        attributes, like: owner of a resource should be allowed all actions.
+
+        Resources can have sub-resources, like columns of a table. This is useful in optimizing authorization for
+        access to a resource and several of its sub-resources in a single request.
+
+   2.3. Action
+        An action performed on a resource. Examples of actions include: query, list, read, write, delete. In the
+        context of authorization, the action given in the request is used only to record in audit log and does not
+        affect the authorization decision. The authorization decision is based on the permissions requested for the
+        resource.
+
+   2.4. Permission
+        A privilege necessary to perform an action on a resources. Apache Ranger policies are used to grant or deny
+        permissions to users. An action might require one or more permissions. Examples of permissions include:
+        select, insert, read, write, delete.
+
+   2.5. Context
+        Additional information about the request that can be used to make authorization decisions. Examples of
+        context information include: access time, client IP address, cluster name, cluster type.
+
+   2.6. Decision
+        The result of the authorization request. The decision can be either "ALLOWED" or "DENIED". The decision is
+        based on the policies defined in Apache Ranger and the user, resource, permissions and context information
+        provided in the request.
+
+   2.7. Row Filter
+        For resources that support rows, like tables, Apache Ranger policies can be setup to filter rows that a user
+        can access. Response from authorization request for such resources can include a row filter that should be
+        applied by the caller, to ensure that the user only accesses rows they are allowed to. For example, a row
+        filter can be defined to restrict access to rows in a table based on the department the user belongs to.
+
+   2.8. Data Mask
+        For resources that support data masking, like columns of a table, Apache Ranger policies can be setup to
+        mask (or transformation) values of columns having sensitive data. Response from authorization request for
+        such resources can include a data mask that should be applied by the caller, to ensure that the user only
+        has accesses to masked value of sensitive data. For example, a data mask can be defined on a column having
+        phone number, credit card number or social security number.
+
+3. Examples
+   This section includes few examples of authorization requests and corresponding responses. The examples include
+   authorizing access to a single resource, authorizing access to a resource and sub-resources, authorizing access
+   to multiple resources in a single request, row-filter and data-mask information in the response.
+
+   3.1 Authorize access to a single resource - a path
+    request:
+    {
+      "requestId": "9198b532-a386-4464-9770-d61a8e8bc206",
+      "user":      { "name": "gary.adams", "groups": [ "fte", "mktg" ], "roles": [ "analyst" ] }
+      "access":    { "resource": "path:/warehouse/hive/mktg/visitors", "action": "LIST", "permissions": [ "list" ], "attributes": { "OWNER": "nancy.boxer" } }
+      "context":   { "accessTime": 1755543894, "clientIpAddress": "12.051.242", "forwardedIpAddresses": [], "additionalInfo": { "clientType": "CLI", "clusterName": "cl1", "clusterType": "onprem" } }
+    }
+
+    result:
+    {
+      "requestId": "9198b532-a386-4464-9770-d61a8e8bc206",
+      "decision":  "ALLOWED",
+      "permissions": {
+        "list": { "access": { "result": "ALLOWED", "policy": { "id": 1, "version": 1 } }
+        }
+      }
+    }
+
+   3.2 Authorize access to a single resource and its sub-resources - a table and 3 columns
+    request:
+    {
+      "requestId": "0a4134c1-44af-42e1-8a27-f15f18e60850",
+      "user":      { "name": "gary.adams", "groups": [ "fte", "mktg" ], "roles": [ "analyst" ] }
+      "access":    { "resource": "table:db1.tbl1", "subResources: [ "column:col1", "column:col2", "column:col3" ], "action": "QUERY", "permissions": [ "select" ], "attributes": { "OWNER": "nancy.boxer" } }
+      "context":   { "accessTime": 1755543894, "clientIpAddress": "12.051.242", "forwardedIpAddresses": [], "additionalInfo": { "clientType": "CLI", "clusterName": "cl1", "clusterType": "onprem" } }
+    }
+
+    result:
+    {
+      "requestId": "0a4134c1-44af-42e1-8a27-f15f18e60850",
+      "decision":  "ALLOWED",
+      "permissions": {
+        "select": {
+          "rowFilter": { "filterExpression": "dept = 'mktg'", "policy": { "id": 11, "version": 3 } }
+          "subResources": {
+            "column:col1": { "access":   { "decision": "ALLOWED", "policy": { "id": 5, "version": 1 } },
+	                         "dataMask": { "maskType": "MASK_SHOW_LAST_4", "maskedValue": "mask_show_last_n({col}, 4, 'x', 'x', 'x', -1, '1')", "policy": { "id": 26, "version": 2 } } },
+            "column:col2": { "access":   { "decision": "ALLOWED", "policy": { "id": 2, "version": 1 } },
+	                          "dataMask": { "maskType": "MASK_HASH", "maskedValue": "mask_hash({col})", "policy": { "id": 27, "version": 4 } } },
+            "column:col3": { "access":   { "decision": "ALLOWED", "policy": { "id": 3, "version": 1 } },
+	                         "dataMask": { "maskType": "MASK_HASH", "maskedValue": "mask_hash({col})", "policy": { "id": 27, "version": 4 } } }
+          }
+        }
+      }
+    }
+
+   3.3: Authorize access to multiple resources - select on 2 tables and create on a table
+    request:
+    {
+      "requestId": "4aa68265-34f1-4115-b026-d88dff292669",
+      "user":      { "name": "gary.adams", "groups": [ "fte", "mktg" ], "roles": [ "analyst" ] }
+      "accesses": [
+        { "resource": "table:db1.tbl1", "action": "QUERY", "permissions": [ "select" ], "attributes": { "OWNER": "nancy.boxer" } },
+        { "resource": "table:db1.tbl2", "action": "QUERY", "permissions": [ "select" ], "attributes": { "OWNER": "nancy.boxer" } },
+        { "resource": "table:db1.vw1",  "action": "CREATE", "permissions": [ "create" ] }
+      ],
+      "context": { "accessTime": 1755543894, "clientIpAddress": "12.051.242", "forwardedIpAddresses": [], "additionalInfo": { "clientType": "CLI", "clusterName": "cl1", "clusterType": "onprem" } }
+    }
+
+    result:
+    {
+      "requestId": "4aa68265-34f1-4115-b026-d88dff292669",
+      "decision":  "DENIED",
+      "accesses": [
+        {
+          "decision": "ALLOWED",
+          "permissions": {
+            "select": {
+              "access":    { "decision": "ALLOWED", "policy": { "id": 1, "version": 1 } },
+              "rowFilter": { "filterExpression": "dept = 'mktg'", "policy": { "id": 11, "version": 3 } }
+            }
+          }
+        },
+        {
+          "decision": "DENIED",
+          "permissions": {
+            "select": {
+              "access": { "decision": "DENIED", "policy": { "id": 21, "version": 1 } }
+            }
+          }
+        },
+        {
+          "decision": "ALLOWED",
+          "permissions": {
+            "create": {
+              "access": { "decision": "ALLOWED", "policy": { "id": 23, "version": 3 } }
+            }
+          }
+        }
+      ]
+    }

--- a/authz-api/pom.xml
+++ b/authz-api/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.ranger</groupId>
+        <artifactId>ranger</artifactId>
+        <version>3.0.0-SNAPSHOT</version>
+        <relativePath>..</relativePath>
+    </parent>
+
+    <artifactId>ranger-authz-api</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Ranger Authorization API</name>
+    <description>Ranger Authorization API</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>${fasterxml.jackson.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>2.0.17</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/authz-api/src/main/java/org/apache/ranger/authz/api/RangerAuthorizer.java
+++ b/authz-api/src/main/java/org/apache/ranger/authz/api/RangerAuthorizer.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.authz.api;
+
+import org.apache.ranger.authz.model.RangerAuthzRequest;
+import org.apache.ranger.authz.model.RangerAuthzResult;
+import org.apache.ranger.authz.model.RangerMultiAuthzRequest;
+import org.apache.ranger.authz.model.RangerMultiAuthzResult;
+
+import java.util.Properties;
+
+public abstract class RangerAuthorizer implements AutoCloseable {
+    protected final Properties properties;
+
+    protected RangerAuthorizer(Properties properties) {
+        this.properties = properties;
+    }
+
+    public abstract RangerAuthzResult authorize(RangerAuthzRequest request) throws RangerAuthzException;
+
+    public abstract RangerMultiAuthzResult authorize(RangerMultiAuthzRequest request) throws RangerAuthzException;
+}

--- a/authz-api/src/main/java/org/apache/ranger/authz/api/RangerAuthorizerFactory.java
+++ b/authz-api/src/main/java/org/apache/ranger/authz/api/RangerAuthorizerFactory.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.authz.api;
+
+import java.util.Properties;
+
+import static org.apache.ranger.authz.api.RangerAuthzApiErrorCode.AUTHZ_FACTORY_INITIALIZATION_FAILED;
+import static org.apache.ranger.authz.api.RangerAuthzApiErrorCode.AUTHZ_FACTORY_NOT_INITIALIZED;
+
+public class RangerAuthorizerFactory {
+    public static final String PROPERTY_RANGER_AUTHORIZER_IMPL_CLASS = "ranger.authorizer.impl.class";
+    public static final String DEFAULT_RANGER_AUTHORIZER_IMPL_CLASS  = "org.apache.ranger.authz.embedded.RangerEmbeddedAuthorizer";
+
+    private static RangerAuthorizerFactory instance;
+
+    private final Properties       properties;
+    private final RangerAuthorizer authorizer;
+
+    public static RangerAuthorizerFactory getOrCreateInstance(Properties properties) throws RangerAuthzException {
+        RangerAuthorizerFactory instance = RangerAuthorizerFactory.instance;
+
+        if (instance == null) {
+            synchronized (RangerAuthorizerFactory.class) {
+                instance = RangerAuthorizerFactory.instance;
+
+                if (instance == null) {
+                    instance = new RangerAuthorizerFactory(properties);
+
+                    RangerAuthorizerFactory.instance = instance;
+                }
+            }
+        }
+
+        return instance;
+    }
+
+    public static RangerAuthorizerFactory getInstance() throws RangerAuthzException {
+        RangerAuthorizerFactory ret = instance;
+
+        if (ret == null) {
+            throw new RangerAuthzException(AUTHZ_FACTORY_NOT_INITIALIZED);
+        }
+
+        return ret;
+    }
+
+    private RangerAuthorizerFactory(Properties properties) throws RangerAuthzException {
+        this.properties = properties;
+
+        String implClass = this.properties.getProperty(PROPERTY_RANGER_AUTHORIZER_IMPL_CLASS, DEFAULT_RANGER_AUTHORIZER_IMPL_CLASS);
+
+        try {
+            authorizer = (RangerAuthorizer) Class.forName(implClass).getDeclaredConstructor(Properties.class).newInstance(properties);
+        } catch (Exception e) {
+            throw new RangerAuthzException(AUTHZ_FACTORY_INITIALIZATION_FAILED, e);
+        }
+    }
+
+    public RangerAuthorizer getAuthorizer() {
+        return authorizer;
+    }
+}

--- a/authz-api/src/main/java/org/apache/ranger/authz/api/RangerAuthzApiErrorCode.java
+++ b/authz-api/src/main/java/org/apache/ranger/authz/api/RangerAuthzApiErrorCode.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.authz.api;
+
+public enum RangerAuthzApiErrorCode implements RangerAuthzErrorCode {
+    AUTHZ_FACTORY_NOT_INITIALIZED(500, "00-001", "RangerAuthorizerFactory not initialized"),
+    AUTHZ_FACTORY_INITIALIZATION_FAILED(500, "00-002", "Initialization of authorizer factory failed"),
+
+    INVALID_REQUEST_SERVICE_NOT_FOUND(400, "00-001", "{0}: service not found"),
+    INVALID_REQUEST_SERVICE_TYPE_NOT_FOUND(400, "00-002", "{0}: service type not found"),
+    INVALID_REQUEST_RESOURCE_TYPE_NOT_FOUND(400, "00-003", "{0}: resource type not found"),
+    INVALID_REQUEST_PERMISSION_NOT_FOUND(400, "00-004", "{0}: permission not found"),
+    INVALID_REQUEST_SERVICE_NAME_OR_TYPE_MANDATORY(400, "00-005", "Service name or service type is mandatory"),
+    INVALID_RESOURCE_TEMPLATE_UNEXPECTED_MARKER_AT(400, "00-006", "Invalid resource template: {0}. Unexpected marker '{1}' at position {2}");
+
+    private static final String ERROR_CODE_MODULE_PREFIX = "AUTHZ";
+
+    private final int    httpStatusCode;
+    private final String code;
+    private final String message;
+
+    RangerAuthzApiErrorCode(int httpStatusCode, String code, String message) {
+        this.httpStatusCode = httpStatusCode;
+        this.code           = String.format("%s-%3d-%s", ERROR_CODE_MODULE_PREFIX, String.valueOf(httpStatusCode), code);
+        this.message        = message;
+    }
+
+    public int getHttpStatusCode() {
+        return httpStatusCode;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public String toString() {
+        return "RangerAuthzBaseErrorCode{" +
+                "httpStatusCode=" + httpStatusCode +
+                ", code='" + code + '\'' +
+                ", message='" + message + '\'' +
+                '}';
+    }
+}

--- a/authz-api/src/main/java/org/apache/ranger/authz/api/RangerAuthzErrorCode.java
+++ b/authz-api/src/main/java/org/apache/ranger/authz/api/RangerAuthzErrorCode.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.authz.api;
+
+import java.text.MessageFormat;
+
+public interface RangerAuthzErrorCode {
+    int getHttpStatusCode();
+
+    String getCode();
+
+    String getMessage();
+
+    default String getFormattedMessage(Object... params) {
+        return new MessageFormat(getMessage()).format(params);
+    }
+}

--- a/authz-api/src/main/java/org/apache/ranger/authz/api/RangerAuthzException.java
+++ b/authz-api/src/main/java/org/apache/ranger/authz/api/RangerAuthzException.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.authz.api;
+
+public class RangerAuthzException extends Exception {
+    public RangerAuthzException(String message) {
+        super(message);
+    }
+
+    public RangerAuthzException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public RangerAuthzException(RangerAuthzErrorCode errorCode) {
+        super(errorCode.getMessage());
+    }
+
+    public RangerAuthzException(RangerAuthzErrorCode errorCode, Throwable cause) {
+        super(errorCode.getMessage(), cause);
+    }
+
+    public RangerAuthzException(RangerAuthzErrorCode errorCode, Object...params) {
+        super(errorCode.getFormattedMessage(params));
+    }
+
+    public RangerAuthzException(RangerAuthzErrorCode errorCode, Throwable cause, Object...params) {
+        super(errorCode.getFormattedMessage(params), cause);
+    }
+}

--- a/authz-api/src/main/java/org/apache/ranger/authz/model/RangerAccessContext.java
+++ b/authz-api/src/main/java/org/apache/ranger/authz/model/RangerAccessContext.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.authz.model;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.List;
+import java.util.Map;
+
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class RangerAccessContext {
+    public static final String CONTEXT_INFO_CLIENT_TYPE  = "clientType";
+    public static final String CONTEXT_INFO_CLUSTER_NAME = "clusterName";
+    public static final String CONTEXT_INFO_CLUSTER_TYPE = "clusterType";
+    public static final String CONTEXT_INFO_REQUEST_DATA = "requestData";
+
+    private long                accessTime;
+    private String              clientIpAddress;
+    private List<String>        forwardedIpAddresses;
+    private Map<String, Object> additionalInfo;
+
+    public long getAccessTime() {
+        return accessTime;
+    }
+
+    public void setAccessTime(long accessTime) {
+        this.accessTime = accessTime;
+    }
+
+    public String getClientIpAddress() {
+        return clientIpAddress;
+    }
+
+    public void setClientIpAddress(String clientIpAddress) {
+        this.clientIpAddress = clientIpAddress;
+    }
+
+    public List<String> getForwardedIpAddresses() {
+        return forwardedIpAddresses;
+    }
+
+    public void setForwardedIpAddresses(List<String> forwardedIpAddresses) {
+        this.forwardedIpAddresses = forwardedIpAddresses;
+    }
+
+    public Map<String, Object> getAdditionalInfo() {
+        return additionalInfo;
+    }
+
+    public void setAdditionalInfo(Map<String, Object> additionalInfo) {
+        this.additionalInfo = additionalInfo;
+    }
+
+    @Override
+    public String toString() {
+        return "RangerAccessContext{" +
+                "accessTime=" + accessTime +
+                ", clientIpAddress='" + clientIpAddress + '\'' +
+                ", forwardedIpAddresses=" + forwardedIpAddresses +
+                ", additionalInfo=" + additionalInfo +
+                '}';
+    }
+}

--- a/authz-api/src/main/java/org/apache/ranger/authz/model/RangerAccessInfo.java
+++ b/authz-api/src/main/java/org/apache/ranger/authz/model/RangerAccessInfo.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.authz.model;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.Map;
+import java.util.Set;
+
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class RangerAccessInfo {
+    private String              serviceType;
+    private String              serviceName;
+    private String              resource;
+    private Set<String>         subResources;
+    private String              action;
+    private Set<String>         permissions;
+    private Map<String, Object> attributes;
+
+    public String getServiceType() {
+        return serviceType;
+    }
+
+    public void setServiceType(String serviceType) {
+        this.serviceType = serviceType;
+    }
+
+    public String getServiceName() {
+        return serviceName;
+    }
+
+    public void setServiceName(String serviceName) {
+        this.serviceName = serviceName;
+    }
+
+    public String getResource() {
+        return resource;
+    }
+
+    public void setResource(String resource) {
+        this.resource = resource;
+    }
+
+    public Set<String> getSubResources() {
+        return subResources;
+    }
+
+    public void setSubResources(Set<String> subResources) {
+        this.subResources = subResources;
+    }
+
+    public String getAction() {
+        return action;
+    }
+
+    public void setAction(String action) {
+        this.action = action;
+    }
+
+    public Set<String> getPermissions() {
+        return permissions;
+    }
+
+    public void setPermissions(Set<String> permissions) {
+        this.permissions = permissions;
+    }
+
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    @Override
+    public String toString() {
+        return "RangerAccessInfo{" +
+                "serviceType=" + serviceType +
+                ", serviceName=" + serviceName +
+                ", resource='" + resource + '\'' +
+                ", subResources=" + subResources +
+                ", action=" + action +
+                ", permissions=" + permissions +
+                ", attributes=" + attributes +
+                '}';
+    }
+}

--- a/authz-api/src/main/java/org/apache/ranger/authz/model/RangerAuthzRequest.java
+++ b/authz-api/src/main/java/org/apache/ranger/authz/model/RangerAuthzRequest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.authz.model;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class RangerAuthzRequest {
+    private String              requestId;
+    private RangerUserInfo      user;
+    private RangerAccessInfo    access;
+    private RangerAccessContext context;
+
+    public RangerAuthzRequest() {
+    }
+
+    public RangerAuthzRequest(RangerUserInfo user, RangerAccessInfo access, RangerAccessContext context) {
+        this(null, user, access, context);
+    }
+
+    public RangerAuthzRequest(String requestId, RangerUserInfo user, RangerAccessInfo access, RangerAccessContext context) {
+        this.requestId = requestId;
+        this.user      = user;
+        this.access    = access;
+        this.context   = context;
+    }
+
+    public String getRequestId() {
+        return requestId;
+    }
+
+    public void setRequestId(String requestId) {
+        this.requestId = requestId;
+    }
+
+    public RangerUserInfo getUser() {
+        return user;
+    }
+
+    public void setUser(RangerUserInfo user) {
+        this.user = user;
+    }
+
+    public RangerAccessInfo getAccess() {
+        return access;
+    }
+
+    public void setAccess(RangerAccessInfo access) {
+        this.access = access;
+    }
+
+    public RangerAccessContext getContext() {
+        return context;
+    }
+
+    public void setContext(RangerAccessContext context) {
+        this.context = context;
+    }
+
+    @Override
+    public String toString() {
+        return "RangerAuthzRequest{" +
+                "requestId='" + requestId + '\'' +
+                ", user=" + user +
+                ", access=" + access +
+                ", context=" + context +
+                '}';
+    }
+}

--- a/authz-api/src/main/java/org/apache/ranger/authz/model/RangerAuthzResult.java
+++ b/authz-api/src/main/java/org/apache/ranger/authz/model/RangerAuthzResult.java
@@ -1,0 +1,351 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.authz.model;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class RangerAuthzResult {
+    public enum AccessDecision { ALLOW, DENY, NOT_DETERMINED, PARTIAL }
+
+    private String                        requestId;
+    private AccessDecision                decision;
+    private Map<String, PermissionResult> permissions;
+
+    public RangerAuthzResult() {
+    }
+
+    public RangerAuthzResult(String requestId) {
+        this(requestId, null);
+    }
+
+    public RangerAuthzResult(String requestId, Map<String, PermissionResult> permissions) {
+        this.requestId   = requestId;
+        this.permissions = permissions;
+    }
+
+    public String getRequestId() {
+        return requestId;
+    }
+
+    public void setRequestId(String requestId) {
+        this.requestId = requestId;
+    }
+
+    public AccessDecision getDecision() {
+        return decision;
+    }
+
+    public void setDecision(AccessDecision decision) {
+        this.decision = decision;
+    }
+
+    public Map<String, PermissionResult> getPermissions() {
+        return permissions;
+    }
+
+    public void setPermissions(Map<String, PermissionResult> permissions) {
+        this.permissions = permissions;
+    }
+
+    @Override
+    public String toString() {
+        return "RangerAuthzResult{" +
+                "requestId='" + requestId + '\'' +
+                ", decision=" + decision +
+                ", permissions=" + permissions +
+                '}';
+    }
+
+    @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class PermissionResult {
+        private String                        permission;
+        private AccessResult                  access;
+        private DataMaskResult                dataMask;
+        private RowFilterResult               rowFilter;
+        private Map<String, PermissionResult> subResources;
+        private Map<String, Object>           additionalInfo;
+
+        public PermissionResult(String permission, AccessResult access) {
+            this(permission, access, null);
+        }
+
+        public PermissionResult(String permission, AccessResult access, Map<String, Object> additionalInfo) {
+            this.permission     = permission;
+            this.access         = access;
+            this.additionalInfo = additionalInfo;
+        }
+
+        // Getters and Setters
+        public String getPermission() {
+            return permission;
+        }
+
+        public void setPermission(String permission) {
+            this.permission = permission;
+        }
+
+        public AccessResult getAccess() {
+            return access;
+        }
+
+        public void setAccess(AccessResult access) {
+            this.access = access;
+        }
+
+        public DataMaskResult getDataMask() {
+            return dataMask;
+        }
+
+        public void setDataMask(DataMaskResult dataMask) {
+            this.dataMask = dataMask;
+        }
+
+        public RowFilterResult getRowFilter() {
+            return rowFilter;
+        }
+
+        public void setRowFilter(RowFilterResult rowFilter) {
+            this.rowFilter = rowFilter;
+        }
+
+        public Map<String, PermissionResult> getSubResources() {
+            return subResources;
+        }
+
+        public void setSubResources(Map<String, PermissionResult> subResources) {
+            this.subResources = subResources;
+        }
+
+        public PermissionResult getdSubResourceResult(String resourceName) {
+            Map<String, PermissionResult> subResources = getSubResources();
+
+            return subResources != null ? subResources.get(resourceName) : null;
+        }
+
+        public void addSubResourceResult(String resourceName, PermissionResult result) {
+            if (subResources == null) {
+                subResources = new HashMap<>();
+            }
+
+            subResources.put(resourceName, result);
+        }
+
+        public Map<String, Object> getAdditionalInfo() {
+            return additionalInfo;
+        }
+
+        public void setAdditionalInfo(Map<String, Object> additionalInfo) {
+            this.additionalInfo = additionalInfo;
+        }
+
+        @Override
+        public String toString() {
+            return "PermissionResult{" +
+                    "permission='" + permission + '\'' +
+                    ", access=" + access +
+                    ", dataMask=" + dataMask +
+                    ", rowFilter=" + rowFilter +
+                    ", subResources=" + subResources +
+                    ", additionalInfo=" + additionalInfo +
+                    '}';
+        }
+    }
+
+    @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class AccessResult {
+        AccessDecision decision;
+        PolicyInfo     policy;
+
+        public AccessResult() {
+        }
+
+        public AccessResult(AccessDecision decision, PolicyInfo policy) {
+            this.decision = decision;
+            this.policy   = policy;
+        }
+
+        public AccessDecision getDecision() {
+            return decision;
+        }
+
+        public void setDecision(AccessDecision decision) {
+            this.decision = decision;
+        }
+
+        public PolicyInfo getPolicy() {
+            return policy;
+        }
+
+        public void setPolicyInfo(PolicyInfo policy) {
+            this.policy = policy;
+        }
+
+        @Override
+        public String toString() {
+            return "AccessResult{" +
+                    "decision=" + decision +
+                    ", policy=" + policy +
+                    '}';
+        }
+    }
+
+    @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class DataMaskResult {
+        private String     maskType;
+        private String     maskedValue;
+        private PolicyInfo policy;
+
+        public DataMaskResult() {
+        }
+
+        public DataMaskResult(String maskType, String maskedValue, PolicyInfo policy) {
+            this.maskType    = maskType;
+            this.maskedValue = maskedValue;
+            this.policy      = policy;
+        }
+
+        public String getMaskType() {
+            return maskType;
+        }
+
+        public void setMaskType(String maskType) {
+            this.maskType = maskType;
+        }
+
+        public String getMaskedValue() {
+            return maskedValue;
+        }
+
+        public void setMaskedValue(String maskedValue) {
+            this.maskedValue = maskedValue;
+        }
+
+        public PolicyInfo getPolicy() {
+            return policy;
+        }
+
+        public void setPolicy(PolicyInfo policy) {
+            this.policy = policy;
+        }
+
+        @Override
+        public String toString() {
+            return "DataMaskResult{" +
+                    "maskType='" + maskType + '\'' +
+                    ", maskedValue='" + maskedValue + '\'' +
+                    ", policy='" + policy + '\'' +
+                    '}';
+        }
+    }
+
+    @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class RowFilterResult {
+        private String     filterExpression;
+        private PolicyInfo policy;
+
+        public RowFilterResult() {
+        }
+
+        public RowFilterResult(String filterExpression, PolicyInfo policy) {
+            this.filterExpression = filterExpression;
+            this.policy           = policy;
+        }
+
+        public String getFilterExpression() {
+            return filterExpression;
+        }
+
+        public void setFilterExpression(String filterExpression) {
+            this.filterExpression = filterExpression;
+        }
+
+        public PolicyInfo getPolicy() {
+            return policy;
+        }
+
+        public void setPolicy(PolicyInfo policy) {
+            this.policy = policy;
+        }
+
+        @Override
+        public String toString() {
+            return "RowFilterResult{" +
+                    "filterExpression='" + filterExpression + '\'' +
+                    ", policy=" + policy +
+                    '}';
+        }
+    }
+
+    @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class PolicyInfo {
+        private Long id;
+        private Long version;
+
+        public PolicyInfo() {
+        }
+
+        public PolicyInfo(Long id, Long version) {
+            this.id      = id;
+            this.version = version;
+        }
+
+        public Long getId() {
+            return id;
+        }
+
+        public void setId(Long id) {
+            this.id = id;
+        }
+
+        public Long getVersion() {
+            return version;
+        }
+
+        public void setVersion(Long version) {
+            this.version = version;
+        }
+
+        @Override
+        public String toString() {
+            return "PolicyInfo{" +
+                    "id='" + id + '\'' +
+                    ", version=" + version +
+                    '}';
+        }
+    }
+}

--- a/authz-api/src/main/java/org/apache/ranger/authz/model/RangerMultiAuthzRequest.java
+++ b/authz-api/src/main/java/org/apache/ranger/authz/model/RangerMultiAuthzRequest.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.authz.model;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.List;
+
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class RangerMultiAuthzRequest {
+    private String                 requestId;
+    private RangerUserInfo         user;
+    private List<RangerAccessInfo> accesses;
+    private RangerAccessContext    context;
+
+    public RangerMultiAuthzRequest() {
+    }
+
+    public RangerMultiAuthzRequest(RangerUserInfo user, List<RangerAccessInfo> accesses, RangerAccessContext context) {
+        this(null, user, accesses, context);
+    }
+
+    public RangerMultiAuthzRequest(String requestId, RangerUserInfo user, List<RangerAccessInfo> accesses, RangerAccessContext context) {
+        this.requestId = requestId;
+        this.user      = user;
+        this.accesses  = accesses;
+        this.context   = context;
+    }
+
+    public String getRequestId() {
+        return requestId;
+    }
+
+    public void setRequestId(String requestId) {
+        this.requestId = requestId;
+    }
+
+    public RangerUserInfo getUser() {
+        return user;
+    }
+
+    public void setUser(RangerUserInfo user) {
+        this.user = user;
+    }
+
+    public List<RangerAccessInfo> getAccesses() {
+        return accesses;
+    }
+
+    public void setAccesses(List<RangerAccessInfo> accesses) {
+        this.accesses = accesses;
+    }
+
+    public RangerAccessContext getContext() {
+        return context;
+    }
+
+    public void setContext(RangerAccessContext context) {
+        this.context = context;
+    }
+
+    @Override
+    public String toString() {
+        return "RangerAuthzRequest{" +
+                "requestId='" + requestId + '\'' +
+                ", user=" + user +
+                ", accesses=" + accesses +
+                ", context=" + context +
+                '}';
+    }
+}

--- a/authz-api/src/main/java/org/apache/ranger/authz/model/RangerMultiAuthzResult.java
+++ b/authz-api/src/main/java/org/apache/ranger/authz/model/RangerMultiAuthzResult.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.authz.model;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import org.apache.ranger.authz.model.RangerAuthzResult.AccessDecision;
+
+import java.util.List;
+
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class RangerMultiAuthzResult {
+    private String                  requestId;
+    private AccessDecision          decision;
+    private List<RangerAuthzResult> accesses;
+
+    public RangerMultiAuthzResult() {
+    }
+
+    public RangerMultiAuthzResult(String requestId) {
+        this(requestId, null);
+    }
+
+    public RangerMultiAuthzResult(String requestId, List<RangerAuthzResult> accesses) {
+        this.requestId = requestId;
+        this.accesses  = accesses;
+    }
+
+    public String getRequestId() {
+        return requestId;
+    }
+
+    public void setRequestId(String requestId) {
+        this.requestId = requestId;
+    }
+
+    public AccessDecision getDecision() {
+        return decision;
+    }
+
+    public void setDecision(AccessDecision decision) {
+        this.decision = decision;
+    }
+
+    public List<RangerAuthzResult> getAccesses() {
+        return accesses;
+    }
+
+    public void setAccesses(List<RangerAuthzResult> accesses) {
+        this.accesses = accesses;
+    }
+
+    @Override
+    public String toString() {
+        return "RangerAuthzResult{" +
+                "requestId='" + requestId + '\'' +
+                ", decision=" + decision +
+                ", accesses=" + accesses +
+                '}';
+    }
+}

--- a/authz-api/src/main/java/org/apache/ranger/authz/model/RangerUserInfo.java
+++ b/authz-api/src/main/java/org/apache/ranger/authz/model/RangerUserInfo.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.authz.model;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.Map;
+import java.util.Set;
+
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class RangerUserInfo {
+    private String              name;
+    private Map<String, Object> attributes;
+    private Set<String>         groups;
+    private Set<String>         roles;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    public Set<String> getGroups() {
+        return groups;
+    }
+
+    public void setGroups(Set<String> groups) {
+        this.groups = groups;
+    }
+
+    public Set<String> getRoles() {
+        return roles;
+    }
+
+    public void setRoles(Set<String> roles) {
+        this.roles = roles;
+    }
+
+    @Override
+    public String toString() {
+        return "RangerUserInfo{" +
+                "name='" + name + '\'' +
+                ", attributes=" + attributes +
+                ", groups=" + groups +
+                ", roles=" + roles +
+                '}';
+    }
+}

--- a/authz-api/src/main/java/org/apache/ranger/authz/util/RangerResourceTemplate.java
+++ b/authz-api/src/main/java/org/apache/ranger/authz/util/RangerResourceTemplate.java
@@ -1,0 +1,184 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.authz.util;
+
+import org.apache.ranger.authz.api.RangerAuthzException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.ranger.authz.api.RangerAuthzApiErrorCode.INVALID_RESOURCE_TEMPLATE_UNEXPECTED_MARKER_AT;
+
+public class RangerResourceTemplate {
+    private static final Logger LOG = LoggerFactory.getLogger(RangerResourceTemplate.class);
+
+    private static final char RESOURCE_START_CHAR = '{';
+    private static final char RESOURCE_END_CHAR   = '}';
+    private static final char ESCAPE_CHAR         = '\\';
+
+    private final String   template;
+    private final String[] resources;
+    private final String   prefix;
+    private final String[] separators;
+    private final String   suffix;
+
+    public RangerResourceTemplate(String template) throws RangerAuthzException {
+        List<String>  resources    = new ArrayList<>();
+        List<String>  separators   = new ArrayList<>();
+        String        prefix       = null;
+        boolean       isInEscape   = false;
+        boolean       isInResource = false;
+        StringBuilder currentToken = new StringBuilder();
+
+        for (int i = 0; i < template.length(); i++) {
+            char c = template.charAt(i);
+
+            if (isInEscape) {
+                currentToken.append(c);
+
+                isInEscape = false;
+            } else if (c == ESCAPE_CHAR) {
+                isInEscape = true;
+            } else if (c == RESOURCE_START_CHAR) {
+                if (isInResource) {
+                    throw new RangerAuthzException(INVALID_RESOURCE_TEMPLATE_UNEXPECTED_MARKER_AT, template, RESOURCE_START_CHAR, i);
+                }
+
+                if (prefix == null) {
+                    prefix = currentToken.toString();
+                } else {
+                    separators.add(currentToken.toString());
+                }
+
+                isInResource = true;
+
+                currentToken.setLength(0);
+            } else if (c == RESOURCE_END_CHAR) {
+                if (!isInResource) {
+                    throw new RangerAuthzException(INVALID_RESOURCE_TEMPLATE_UNEXPECTED_MARKER_AT, template, RESOURCE_END_CHAR, i);
+                }
+
+                resources.add(currentToken.toString());
+
+                isInResource = false;
+
+                currentToken.setLength(0);
+            } else {
+                currentToken.append(c);
+            }
+        }
+
+        this.template   = template;
+        this.resources  = resources.toArray(new String[0]);
+        this.separators = separators.toArray(new String[0]);
+        this.prefix     = prefix;
+        this.suffix     = currentToken.toString();
+    }
+
+    public String getTemplate() {
+        return template;
+    }
+
+    public Map<String, String> parse(String resource) {
+        Map<String, String> ret = null;
+
+        if (resource == null || resource.isEmpty()) {
+            LOG.debug("parse(resource='{}', template='{}'): empty or null resource", resource, template);
+        } else if (!resource.startsWith(prefix)) {
+            LOG.debug("parse(resource='{}', template='{}'): resource does not start with prefix {}", resource, template, prefix);
+        } else if (!resource.endsWith(suffix)) {
+            LOG.debug("parse(resource='{}', template='{}'): resource does not end with suffix {}", resource, template, suffix);
+        } else {
+            ret = new HashMap<>();
+
+            int tokenStartPos = prefix.length();
+
+            for (int i = 0; i < this.separators.length; i++) {
+                String sep    = this.separators[i];
+                int    idxSep = resource.indexOf(sep, tokenStartPos);
+
+                LOG.debug("Separator '{}' found at {}: tokenStartPos={}", sep, idxSep, tokenStartPos);
+
+                if (idxSep == -1) {
+                    ret = null;
+
+                    break;
+                } else {
+                    String value = resource.substring(tokenStartPos, idxSep);
+
+                    ret.put(this.resources[i], value);
+                }
+
+                tokenStartPos = idxSep + sep.length();
+            }
+
+            if (ret != null && tokenStartPos != -1) {
+                String name  = this.resources[this.resources.length - 1];
+                String value = resource.substring(tokenStartPos, resource.length() - suffix.length());
+
+                ret.put(name, value);
+            }
+        }
+
+        LOG.debug("parse(resource='{}', template='{}'): ret={}", resource, template, ret);
+
+        return ret;
+    }
+
+    public String formatResource(Map<String, String> resourceMap) {
+        StringBuilder ret = new StringBuilder(prefix);
+
+        for (int i = 0; i < resources.length; i++) {
+            String name  = resources[i];
+            String value = resourceMap.get(name);
+
+            if (value == null) {
+                value = "";
+            }
+
+            ret.append(value);
+
+            if (i < separators.length) {
+                ret.append(separators[i]);
+            }
+        }
+
+        ret.append(suffix);
+
+        LOG.debug("createResource(resourceMap={}, template='{}'): ret='{}'", resourceMap, template, ret);
+
+        return ret.toString();
+    }
+
+    @Override
+    public String toString() {
+        return "ResourceParser{" +
+                "template=" + template +
+                ", resources='" + String.join(",", resources) + "'" +
+                ", prefix='" + prefix + "'" +
+                ", separators='" + String.join(",", separators) + "'" +
+                ", suffix='" + suffix + "'" +
+                "}";
+    }
+}

--- a/authz-api/src/test/java/org/apache/ranger/authz/util/TestRangerResourceTemplate.java
+++ b/authz-api/src/test/java/org/apache/ranger/authz/util/TestRangerResourceTemplate.java
@@ -1,0 +1,238 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.authz.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TestRangerResourceTemplate {
+    @Test
+    public void testHiveResources() throws Exception {
+        Map<String, List<RangerResourceTemplate>> templates = getHiveTemplates();
+
+        TestData[] tests = {
+                new TestData("database:db1", "database", "db1"),
+                new TestData("table:db1.tbl1", "database", "db1", "table", "tbl1"),
+                new TestData("column:db1.tbl1.col1", "database", "db1", "table", "tbl1", "column", "col1"),
+                new TestData("udf:db1.myUDF", "database", "db1", "udf", "myUDF"),
+                new TestData("url:s3a://mybucket/db1/tbl1", "url", "s3a://mybucket/db1/tbl1"),
+                new TestData("hiveservice:server1", "hiveservice", "server1"),
+                new TestData("global:*", "global", "*"),
+                // invalid values
+                new TestData("db1.tbl1.col1"),                     // no resource-type
+                new TestData(":db1.tbl1.col1"),                    // empty resource-type
+                new TestData("invalidResourceType:db1.tbl1.col1"), // unknown resource-type
+                new TestData("database:"),
+                new TestData("table:db1_tbl1"),
+                new TestData("column:db1_tbl1.col1"),
+                new TestData("udf:db1_myUDF"),
+        };
+
+        for (TestData test : tests) {
+            Map<String, String> actual = getResourceAsMap(test.resource, templates);
+
+            assertEquals(test.expected, actual, test.resource);
+        }
+    }
+
+    @Test
+    public void testS3Resources() throws Exception {
+        Map<String, List<RangerResourceTemplate>> templates = getS3Templates();
+
+        TestData[] tests = {
+                new TestData("bucket:s3a://mybucket", "bucket", "mybucket"),
+                new TestData("bucket:s3a://mybucket/", "bucket", "mybucket"),
+                new TestData("bucket:s3://mybucket", "bucket", "mybucket"),
+                new TestData("bucket:s3://mybucket/", "bucket", "mybucket"),
+                new TestData("bucket:mybucket", "bucket", "mybucket"),
+                new TestData("bucket:mybucket/", "bucket", "mybucket"),
+                new TestData("path:s3a://mybucket/myfolder/myfile.txt", "bucket", "mybucket", "path", "myfolder/myfile.txt"),
+                new TestData("path:s3://mybucket/myfolder/myfile.txt", "bucket", "mybucket", "path", "myfolder/myfile.txt"),
+                new TestData("path:mybucket/myfolder/myfile.txt", "bucket", "mybucket", "path", "myfolder/myfile.txt"),
+                new TestData("path:s3a://mybucket/", "bucket", "mybucket", "path", ""),
+                // invalid values
+                new TestData("mybucket/myfolder/myfile.txt"),                     // no resource-type
+                new TestData(":mybucket/myfolder/myfile.txt"),                    // empty resource-type
+                new TestData("invalidResourceType:mybucket/myfolder/myfile.txt"), // unknown resource-type
+                new TestData("bucket:"),
+                new TestData("path:mybucket_myfolder_myfile.txt"),
+        };
+
+        for (TestData test : tests) {
+            Map<String, String> actual = getResourceAsMap(test.resource, templates);
+
+            assertEquals(test.expected, actual, test.resource);
+        }
+    }
+
+    @Test
+    public void testAdlsGen2Resources() throws Exception {
+        Map<String, List<RangerResourceTemplate>> templates = getAdlsGen2Templates();
+
+        TestData[] tests = {
+                new TestData("container:abfss://mycontainer@myaccount.dfs.core.windows.net", "storageaccount", "myaccount", "container", "mycontainer"),
+                new TestData("container:abfs://mycontainer@myaccount.dfs.core.windows.net", "storageaccount", "myaccount", "container", "mycontainer"),
+                new TestData("container:mycontainer@myaccount.dfs.core.windows.net", "storageaccount", "myaccount", "container", "mycontainer"),
+                new TestData("container:mycontainer@myaccount", "storageaccount", "myaccount", "container", "mycontainer"),
+                new TestData("relativepath:abfss://mycontainer@myaccount.dfs.core.windows.net/p1/p2/f1.txt", "storageaccount", "myaccount", "container", "mycontainer", "relativepath", "p1/p2/f1.txt"),
+                new TestData("relativepath:abfs://mycontainer@myaccount.dfs.core.windows.net/p1/p2/f1.txt", "storageaccount", "myaccount", "container", "mycontainer", "relativepath", "p1/p2/f1.txt"),
+                new TestData("relativepath:mycontainer@myaccount.dfs.core.windows.net/p1/p2/f1.txt", "storageaccount", "myaccount", "container", "mycontainer", "relativepath", "p1/p2/f1.txt"),
+                new TestData("relativepath:mycontainer@myaccount/p1/p2/f1.txt", "storageaccount", "myaccount", "container", "mycontainer", "relativepath", "p1/p2/f1.txt"),
+        };
+
+        for (TestData test : tests) {
+            Map<String, String> actual = getResourceAsMap(test.resource, templates);
+
+            assertEquals(test.expected, actual, test.resource);
+        }
+    }
+
+    @Test
+    public void testTrinoResources() throws Exception {
+        Map<String, List<RangerResourceTemplate>> templates = getTrinoTemplates();
+        TestData[] tests = {
+                new TestData("catalog:mycatalog", "catalog", "mycatalog"),
+                new TestData("schema:mycatalog.myschema", "catalog", "mycatalog", "schema", "myschema"),
+                new TestData("table:mycatalog.myschema.mytable", "catalog", "mycatalog", "schema", "myschema", "table", "mytable"),
+                new TestData("column:mycatalog.myschema.mytable.mycolumn", "catalog", "mycatalog", "schema", "myschema", "table", "mytable", "column", "mycolumn"),
+                new TestData("trinouser:myuser", "trinouser", "myuser"),
+                new TestData("systemproperty:myproperty", "systemproperty", "myproperty"),
+                new TestData("sessionproperty:mycatalog.mysessionproperty", "catalog", "mycatalog", "sessionproperty", "mysessionproperty"),
+                new TestData("function:myfunction", "function", "myfunction"),
+                new TestData("procedure:mycatalog.myschema.myprocedure", "catalog", "mycatalog", "schema", "myschema", "procedure", "myprocedure"),
+                new TestData("schemafunction:mycatalog.myschema.myschemafunction", "catalog", "mycatalog", "schema", "myschema", "schemafunction", "myschemafunction"),
+                new TestData("queryid:12345-67890-abcdefg-hijklmnopqrs-tuvwxyz", "queryid", "12345-67890-abcdefg-hijklmnopqrs-tuvwxyz"),
+                new TestData("sysinfo:systeminfo", "sysinfo", "systeminfo"),
+                new TestData("role:myrole", "role", "myrole"),
+                // invalid values
+                new TestData("mycatalog.myschema.mytable.mycolumn"),                     // no resource-type
+                new TestData(":mycatalog.myschema.mytable.mycolumn"),                    // empty resource-type
+                new TestData("invalidResourceType:mycatalog.myschema.mytable.mycolumn"), // unknown resource-type
+                new TestData("catalog:"),
+                new TestData("schema:mycatalog_myschema"),
+                new TestData("table:mycatalog_myschema_mytable"),
+                new TestData("column:mycatalog_myschema_mytable_mycolumn"),
+                new TestData("trinouser:"),
+                new TestData("sessionproperty:mycatalog_mysessionproperty"),
+                new TestData("procedure:mycatalog_myschema_myprocedure"),
+        };
+
+        for (TestData test : tests) {
+            Map<String, String> actual = getResourceAsMap(test.resource, templates);
+
+            assertEquals(test.expected, actual, test.resource);
+        }
+    }
+
+    private static Map<String, List<RangerResourceTemplate>> getHiveTemplates() throws Exception {
+        Map<String, List<RangerResourceTemplate>> ret = new HashMap<>();
+
+        ret.put("database", Collections.singletonList(new RangerResourceTemplate("{database}")));
+        ret.put("table", Collections.singletonList(new RangerResourceTemplate("{database}.{table}")));
+        ret.put("column", Collections.singletonList(new RangerResourceTemplate("{database}.{table}.{column}")));
+        ret.put("udf", Collections.singletonList(new RangerResourceTemplate("{database}.{udf}")));
+        ret.put("url", Collections.singletonList(new RangerResourceTemplate("{url}")));
+        ret.put("hiveservice", Collections.singletonList(new RangerResourceTemplate("{hiveservice}")));
+        ret.put("global", Collections.singletonList(new RangerResourceTemplate("{global}")));
+
+        return ret;
+    }
+
+    private static Map<String, List<RangerResourceTemplate>> getS3Templates() throws Exception {
+        Map<String, List<RangerResourceTemplate>> ret = new HashMap<>();
+
+        ret.put("bucket", Arrays.asList(new RangerResourceTemplate("s3a://{bucket}/"), new RangerResourceTemplate("s3a://{bucket}"), new RangerResourceTemplate("s3://{bucket}/"), new RangerResourceTemplate("s3://{bucket}"), new RangerResourceTemplate("{bucket}/"), new RangerResourceTemplate("{bucket}")));
+        ret.put("path", Arrays.asList(new RangerResourceTemplate("s3a://{bucket}/{path}"), new RangerResourceTemplate("s3://{bucket}/{path}"), new RangerResourceTemplate("{bucket}/{path}")));
+
+        return ret;
+    }
+
+    private static Map<String, List<RangerResourceTemplate>> getAdlsGen2Templates() throws Exception {
+        Map<String, List<RangerResourceTemplate>> ret = new HashMap<>();
+
+        ret.put("container", Arrays.asList(new RangerResourceTemplate("abfss://{container}@{storageaccount}.dfs.core.windows.net"), new RangerResourceTemplate("abfs://{container}@{storageaccount}.dfs.core.windows.net"), new RangerResourceTemplate("{container}@{storageaccount}.dfs.core.windows.net"), new RangerResourceTemplate("{container}@{storageaccount}")));
+        ret.put("relativepath", Arrays.asList(new RangerResourceTemplate("abfss://{container}@{storageaccount}.dfs.core.windows.net/{relativepath}"), new RangerResourceTemplate("abfs://{container}@{storageaccount}.dfs.core.windows.net/{relativepath}"), new RangerResourceTemplate("{container}@{storageaccount}.dfs.core.windows.net/{relativepath}"), new RangerResourceTemplate("{container}@{storageaccount}/{relativepath}")));
+
+        return ret;
+    }
+
+    private static Map<String, List<RangerResourceTemplate>> getTrinoTemplates() throws Exception {
+        Map<String, List<RangerResourceTemplate>> ret = new HashMap<>();
+
+        ret.put("catalog", Collections.singletonList(new RangerResourceTemplate("{catalog}")));
+        ret.put("schema", Collections.singletonList(new RangerResourceTemplate("{catalog}.{schema}")));
+        ret.put("table", Collections.singletonList(new RangerResourceTemplate("{catalog}.{schema}.{table}")));
+        ret.put("column", Collections.singletonList(new RangerResourceTemplate("{catalog}.{schema}.{table}.{column}")));
+        ret.put("trinouser", Collections.singletonList(new RangerResourceTemplate("{trinouser}")));
+        ret.put("systemproperty", Collections.singletonList(new RangerResourceTemplate("{systemproperty}")));
+        ret.put("sessionproperty", Collections.singletonList(new RangerResourceTemplate("{catalog}.{sessionproperty}")));
+        ret.put("function", Collections.singletonList(new RangerResourceTemplate("{function}")));
+        ret.put("procedure", Collections.singletonList(new RangerResourceTemplate("{catalog}.{schema}.{procedure}")));
+        ret.put("schemafunction", Collections.singletonList(new RangerResourceTemplate("{catalog}.{schema}.{schemafunction}")));
+        ret.put("queryid", Collections.singletonList(new RangerResourceTemplate("{queryid}")));
+        ret.put("sysinfo", Collections.singletonList(new RangerResourceTemplate("{sysinfo}")));
+        ret.put("role", Collections.singletonList(new RangerResourceTemplate("{role}")));
+
+        return ret;
+    }
+
+    private Map<String, String> getResourceAsMap(String resource, Map<String, List<RangerResourceTemplate>> templates) {
+        String[]            resourceParts = resource.split(":", 2);
+        String              resourceType  = resourceParts.length > 0 ? resourceParts[0] : null;
+        String              resourceValue = resourceParts.length > 1 ? resourceParts[1] : null;
+        Map<String, String> ret           = null;
+
+        for (RangerResourceTemplate template : templates.getOrDefault(resourceType, Collections.emptyList())) {
+            ret = template.parse(resourceValue);
+
+            if (ret != null) {
+                break;
+            }
+        }
+
+        return ret;
+    }
+
+    private static class TestData {
+        public final String              resource;
+        public final Map<String, String> expected;
+
+        public TestData(String resource, String...values) {
+            this.resource = resource;
+
+            if (values.length > 1) {
+                this.expected = new HashMap<>();
+
+                for (int i = 1; i < values.length; i += 2) {
+                    expected.put(values[i - 1], values[i]);
+                }
+            } else {
+                this.expected = null;
+            }
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -812,6 +812,7 @@
                 <module>agents-common</module>
                 <module>agents-cred</module>
                 <module>agents-installer</module>
+                <module>authz-api</module>
                 <module>credentialbuilder</module>
                 <!--
                    'distro' should be the last module. If a module gets inserted after
@@ -1138,6 +1139,7 @@
                 <module>agents-common</module>
                 <module>agents-cred</module>
                 <module>agents-installer</module>
+                <module>authz-api</module>
                 <module>credentialbuilder</module>
                 <!--
                    'distro' should be the last module. If a module gets inserted after
@@ -1227,6 +1229,7 @@
                 <module>agents-common</module>
                 <module>agents-cred</module>
                 <module>agents-installer</module>
+                <module>authz-api</module>
                 <module>credentialbuilder</module>
                 <module>embeddedwebserver</module>
                 <module>hbase-agent</module>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Introduces authorization API for use by applications that wants to leverage Ranger policies to authorize access to their resources. The API will have at least 2 implementations: 1) embedded policy evaluation 2) remote policy evaluation in Ranger PDP server

## How was this patch tested?

Added unit tests.