### PR TITLE
RANGER-5315: Enhance Audit Log Filters to Support Resource Name Exclusions

### DIFF
--- a/security-admin/src/main/java/org/apache/ranger/AccessAuditsService.java
+++ b/security-admin/src/main/java/org/apache/ranger/AccessAuditsService.java
@@ -71,6 +71,7 @@ public class AccessAuditsService {
          */
         searchFields.add(new SearchField("-repoType", "-repoType", SearchField.DATA_TYPE.INTEGER, SearchField.SEARCH_TYPE.FULL));
         searchFields.add(new SearchField("-requestUser", "-reqUser", SearchField.DATA_TYPE.STRING, SearchField.SEARCH_TYPE.FULL));
+        searchFields.add(new SearchField("excludeResourceName", "-resource", SearchField.DATA_TYPE.STRING, SearchField.SEARCH_TYPE.PARTIAL));
         searchFields.add(new SearchField("resourceType", "resType", SearchField.DATA_TYPE.STRING, SearchField.SEARCH_TYPE.FULL));
         searchFields.add(new SearchField("reason", "reason", SearchField.DATA_TYPE.STRING, SearchField.SEARCH_TYPE.FULL));
         searchFields.add(new SearchField("action", "action", SearchField.DATA_TYPE.STRING, SearchField.SEARCH_TYPE.FULL));

--- a/security-admin/src/main/java/org/apache/ranger/rest/AssetREST.java
+++ b/security-admin/src/main/java/org/apache/ranger/rest/AssetREST.java
@@ -552,6 +552,7 @@ public class AssetREST {
         searchUtil.extractStringList(request, searchCriteria, "excludeUser", "Exclude Users", "-requestUser", null, StringUtil.VALIDATION_TEXT);
         searchUtil.extractString(request, searchCriteria, "requestData", "Request Data", StringUtil.VALIDATION_TEXT);
         searchUtil.extractString(request, searchCriteria, "resourcePath", "Resource Name", StringUtil.VALIDATION_TEXT);
+        searchUtil.extractString(request, searchCriteria, "excludeResourceName", "Exclude Resource Name", StringUtil.VALIDATION_TEXT);
         searchUtil.extractString(request, searchCriteria, "clientIP", "Client IP", StringUtil.VALIDATION_TEXT);
         searchUtil.extractString(request, searchCriteria, "resourceType", "Resource Type", StringUtil.VALIDATION_TEXT);
         searchUtil.extractString(request, searchCriteria, "excludeServiceUser", "Exclude Service User", StringUtil.VALIDATION_TEXT);

--- a/security-admin/src/main/webapp/react-webapp/src/views/AuditEvent/AccessLogs.jsx
+++ b/security-admin/src/main/webapp/react-webapp/src/views/AuditEvent/AccessLogs.jsx
@@ -1009,6 +1009,12 @@ function Access() {
       urlLabel: "zoneName",
       type: "textoptions",
       options: getZones
+    },
+    {
+      category: "excludeResourceName",
+      label: "Exclude Resource Name",
+      urlLabel: "excludeResourceName",
+      type: "text"
     }
   ];
 

--- a/security-admin/src/test/java/org/apache/ranger/rest/TestAssetREST.java
+++ b/security-admin/src/test/java/org/apache/ranger/rest/TestAssetREST.java
@@ -569,7 +569,7 @@ public class TestAssetREST {
         Mockito.verify(msBizUtil).isKeyAdmin();
         Mockito.verify(assetMgr).getAccessLogs(searchCriteria);
         Mockito.verify(daoManager).getXXServiceDef();
-        Mockito.verify(searchUtil, Mockito.times(15)).extractString(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString(), Mockito.nullable(String.class));
+        Mockito.verify(searchUtil, Mockito.times(16)).extractString(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString(), Mockito.nullable(String.class));
         Mockito.verify(searchUtil, Mockito.times(4)).extractInt(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
         Mockito.verify(searchUtil, Mockito.times(2)).extractDate(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
         Mockito.verify(searchUtil).extractLong(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
@@ -604,7 +604,7 @@ public class TestAssetREST {
         Mockito.verify(msBizUtil).isKeyAdmin();
         Mockito.verify(assetMgr).getAccessLogs(searchCriteria);
         Mockito.verify(daoManager).getXXServiceDef();
-        Mockito.verify(searchUtil, Mockito.times(15)).extractString(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString(), Mockito.nullable(String.class));
+        Mockito.verify(searchUtil, Mockito.times(16)).extractString(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString(), Mockito.nullable(String.class));
         Mockito.verify(searchUtil, Mockito.times(4)).extractInt(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
         Mockito.verify(searchUtil, Mockito.times(2)).extractDate(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
         Mockito.verify(searchUtil).extractLong(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());


### PR DESCRIPTION
## What changes were proposed in this pull request?

Enhance Ranger's audit search functionality to support exclusion filters based on resource names.

## How was this patch tested?

Tested /assets/accessAudit?excludeResourceName=<resourcename> — confirmed that Ranger access audit logs correctly exclude entries for the specified resource name. Verification was performed via both the API and the Ranger UI. Currently tested and validated for Solr only.