### PR TITLE
RANGER-5319: Add sleep for passive tagsync to avoid cpu usage

### DIFF
--- a/tagsync/src/main/java/org/apache/ranger/tagsync/process/TagSyncConfig.java
+++ b/tagsync/src/main/java/org/apache/ranger/tagsync/process/TagSyncConfig.java
@@ -80,6 +80,7 @@ public class TagSyncConfig extends Configuration {
     private static final long DEFAULT_TAGSYNC_ATLASREST_SOURCE_DOWNLOAD_INTERVAL   = 900000;
     private static final long DEFAULT_TAGSYNC_FILESOURCE_MOD_TIME_CHECK_INTERVAL   = 60000;
     private static final long DEFAULT_TAGSYNC_SOURCE_RETRY_INITIALIZATION_INTERVAL = 10000;
+    private static final long DEFAULT_TAGSYNC_HA_PASSIVE_SLEEP_INTERVAL            = 5000;
     private static final String AUTH_TYPE                 = "hadoop.security.authentication";
     private static final String NAME_RULES                = "hadoop.security.auth_to_local";
     private static final String TAGSYNC_KERBEROS_PRICIPAL = "ranger.tagsync.kerberos.principal";
@@ -192,6 +193,14 @@ public class TagSyncConfig extends Configuration {
 
     public static synchronized boolean isTagSyncServiceActive() {
         return TagSyncHAInitializerImpl.getInstance(TagSyncConfig.getInstance()).isActive();
+    }
+
+    public boolean isTagSyncHAEnabled() {
+        return this.getBoolean(TAGSYNC_SERVER_HA_ENABLED_PARAM, false);
+    }
+
+    public static long getTagSyncHAPassiveSleepInterval() {
+        return DEFAULT_TAGSYNC_HA_PASSIVE_SLEEP_INTERVAL;
     }
 
     public static String getTagsyncKeyStoreType(Properties prop) {

--- a/tagsync/src/main/java/org/apache/ranger/tagsync/sink/tagadmin/TagAdminRESTSink.java
+++ b/tagsync/src/main/java/org/apache/ranger/tagsync/sink/tagadmin/TagAdminRESTSink.java
@@ -180,6 +180,18 @@ public class TagAdminRESTSink implements TagSink, Runnable {
 
                     return;
                 }
+            } else {
+                // Only sleep when HA is enabled, similar to user sync
+                if (TagSyncConfig.getInstance().isTagSyncHAEnabled()) {
+                    try {
+                        long sleepInterval = TagSyncConfig.getTagSyncHAPassiveSleepInterval();
+                        LOG.debug("Sleeping for [{}] milliSeconds as this server is running in passive mode", sleepInterval);
+                        Thread.sleep(sleepInterval);
+                    } catch (InterruptedException interrupted) {
+                        LOG.error("Interrupted..: ", interrupted);
+                        return;
+                    }
+                }
             }
         }
     }

--- a/tagsync/src/main/java/org/apache/ranger/tagsync/source/atlas/AtlasTagSource.java
+++ b/tagsync/src/main/java/org/apache/ranger/tagsync/source/atlas/AtlasTagSource.java
@@ -231,6 +231,18 @@ public class AtlasTagSource extends AbstractTagSource {
                             return;
                         }
                     }
+                } else {
+                    // Only sleep when HA is enabled, similar to user sync
+                    if (TagSyncConfig.getInstance().isTagSyncHAEnabled()) {
+                        try {
+                            long sleepInterval = TagSyncConfig.getTagSyncHAPassiveSleepInterval();
+                            LOG.debug("Sleeping for [{}] milliSeconds as this server is running in passive mode", sleepInterval);
+                            Thread.sleep(sleepInterval);
+                        } catch (InterruptedException interrupted) {
+                            LOG.error("Interrupted: ", interrupted);
+                            return;
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently passive tagsync continuously checks whether it the active instance or not in an infinite loop (for quick failover) with 0 seconds delay which causes high CPU usage (150-200% i.e. 1.5 - 2 cores of CPU as noted from the top command).

This needs to be fixed by adding sleep similar to how passive usersync is doing currently


## How was this patch tested?

Manually tested. CPU usage goes down to 0% with periodic usage of 0.3% to check if it active instance or not every 5 seconds