### PR TITLE
RANGER-5230: add configuration to force policy engine to update its p…

### DIFF
--- a/agents-common/src/main/java/org/apache/ranger/plugin/service/RangerBasePlugin.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/service/RangerBasePlugin.java
@@ -77,7 +77,7 @@ public class RangerBasePlugin {
 	private final boolean                     dedupStrings;
 	private       boolean                     isUserStoreEnricherAddedImplcitly = false;
 	private       Map<String, String>         serviceConfigs;
-
+	private       boolean                     synchronousPolicyRefresh;
 
 	public RangerBasePlugin(String serviceType, String appId) {
 		this(new RangerPluginConfig(serviceType, null, appId, null, null, null));
@@ -362,6 +362,12 @@ public class RangerBasePlugin {
 			}
 		}
 
+		String isSyncPolicyRefresh = this.pluginConfig == null ? null : this.serviceConfigs.get(this.pluginConfig.getPropertyPrefix() + ".policy.refresh.synchronous");
+		this.synchronousPolicyRefresh = Boolean.parseBoolean(isSyncPolicyRefresh);
+		if (this.synchronousPolicyRefresh) {
+			LOG.info("synchronousPolicyRefresh = {}", this.synchronousPolicyRefresh);
+		}
+
 		// guard against catastrophic failure during policy engine Initialization or
 		try {
 			RangerPolicyEngine oldPolicyEngine = this.policyEngine;
@@ -558,6 +564,9 @@ public class RangerBasePlugin {
 	}
 
 	public RangerAccessResult isAccessAllowed(RangerAccessRequest request, RangerAccessResultProcessor resultProcessor) {
+		if (this.synchronousPolicyRefresh) {
+			refreshPoliciesAndTags();
+		}
 		RangerAccessResult ret          = null;
 		RangerPolicyEngine policyEngine = this.policyEngine;
 
@@ -603,6 +612,9 @@ public class RangerBasePlugin {
 	}
 
 	public Collection<RangerAccessResult> isAccessAllowed(Collection<RangerAccessRequest> requests, RangerAccessResultProcessor resultProcessor) {
+		if (this.synchronousPolicyRefresh) {
+			refreshPoliciesAndTags();
+		}
 		Collection<RangerAccessResult> ret          = null;
 		RangerPolicyEngine             policyEngine = this.policyEngine;
 
@@ -644,6 +656,9 @@ public class RangerBasePlugin {
 	}
 
 	public RangerAccessResult evalDataMaskPolicies(RangerAccessRequest request, RangerAccessResultProcessor resultProcessor) {
+		if (this.synchronousPolicyRefresh) {
+			refreshPoliciesAndTags();
+		}
 		RangerPolicyEngine policyEngine = this.policyEngine;
 		RangerAccessResult ret          = null;
 
@@ -680,6 +695,9 @@ public class RangerBasePlugin {
 	}
 
 	public RangerAccessResult evalRowFilterPolicies(RangerAccessRequest request, RangerAccessResultProcessor resultProcessor) {
+		if (this.synchronousPolicyRefresh) {
+			refreshPoliciesAndTags();
+		}
 		RangerPolicyEngine policyEngine = this.policyEngine;
 		RangerAccessResult ret          = null;
 
@@ -716,6 +734,9 @@ public class RangerBasePlugin {
 	}
 
 	public void evalAuditPolicies(RangerAccessResult result) {
+		if (this.synchronousPolicyRefresh) {
+			refreshPoliciesAndTags();
+		}
 		RangerPolicyEngine policyEngine = this.policyEngine;
 
 		if (policyEngine != null) {
@@ -738,6 +759,9 @@ public class RangerBasePlugin {
 	}
 
 	public RangerResourceACLs getResourceACLs(RangerAccessRequest request, Integer policyType) {
+		if (this.synchronousPolicyRefresh) {
+			refreshPoliciesAndTags();
+		}
 		RangerResourceACLs ret          = null;
 		RangerPolicyEngine policyEngine = this.policyEngine;
 
@@ -1037,7 +1061,7 @@ public class RangerBasePlugin {
 
 	public void refreshPoliciesAndTags() {
 		if (LOG.isDebugEnabled()) {
-			LOG.debug("==> refreshPoliciesAndTags()");
+			LOG.debug("==> refreshPoliciesAndTags(): synchronousPolicyRefresh={}", synchronousPolicyRefresh);
 		}
 
 		try {
@@ -1224,7 +1248,7 @@ public class RangerBasePlugin {
 	}
 
 	public Map<String, String> getServiceConfigs() {
-		return serviceConfigs;
+		return (serviceConfigs == null) ? Collections.emptyMap() : serviceConfigs;
 	}
 
 	protected RangerPolicyEngine getPolicyEngine() {

--- a/dev-support/ranger-docker/scripts/create-ranger-services.py
+++ b/dev-support/ranger-docker/scripts/create-ranger-services.py
@@ -17,24 +17,29 @@ hdfs = RangerService({'name': 'dev_hdfs', 'type': 'hdfs',
                       'configs': {'username': 'hdfs', 'password': 'hdfs',
                                   'fs.default.name': 'hdfs://ranger-hadoop:9000',
                                   'hadoop.security.authentication': 'simple',
-                                  'hadoop.security.authorization': 'true'}})
+                                  'hadoop.security.authorization': 'true',
+                                  'ranger.plugin.hdfs.policy.refresh.synchronous':'true'}})
 
 hive = RangerService({'name': 'dev_hive', 'type': 'hive',
                       'configs': {'username': 'hive', 'password': 'hive',
                                   'jdbc.driverClassName': 'org.apache.hive.jdbc.HiveDriver',
                                   'jdbc.url': 'jdbc:hive2://ranger-hive:10000',
-                                  'hadoop.security.authorization': 'true'}})
+                                  'hadoop.security.authorization': 'true',
+                                  'ranger.plugin.hive.policy.refresh.synchronous':'true'}})
 
 kafka = RangerService({'name': 'dev_kafka', 'type': 'kafka',
                        'configs': {'username': 'kafka', 'password': 'kafka',
-                                   'zookeeper.connect': 'ranger-zk.example.com:2181'}})
+                                   'zookeeper.connect': 'ranger-zk.example.com:2181',
+                                   'ranger.plugin.kafka.policy.refresh.synchronous':'true'}})
 
 knox = RangerService({'name': 'dev_knox', 'type': 'knox',
-                      'configs': {'username': 'knox', 'password': 'knox', 'knox.url': 'https://ranger-knox:8443'}})
+                      'configs': {'username': 'knox', 'password': 'knox', 'knox.url': 'https://ranger-knox:8443',
+                      'ranger.plugin.knox.policy.refresh.synchronous':'true'}})
 
 yarn = RangerService({'name': 'dev_yarn', 'type': 'yarn',
                       'configs': {'username': 'yarn', 'password': 'yarn',
-                                  'yarn.url': 'http://ranger-hadoop:8088'}})
+                                  'yarn.url': 'http://ranger-hadoop:8088',
+                                  'ranger.plugin.yarn.policy.refresh.synchronous':'true'}})
 
 hbase = RangerService({'name': 'dev_hbase', 'type': 'hbase',
                        'configs': {'username': 'hbase', 'password': 'hbase',
@@ -43,11 +48,13 @@ hbase = RangerService({'name': 'dev_hbase', 'type': 'hbase',
                                    'hadoop.security.authorization': 'true',
                                    'hbase.zookeeper.property.clientPort': '2181',
                                    'hbase.zookeeper.quorum': 'ranger-zk',
-                                   'zookeeper.znode.parent': '/hbase'}})
+                                   'zookeeper.znode.parent': '/hbase',
+                                   'ranger.plugin.hbase.policy.refresh.synchronous':'true'}})
 
 kms = RangerService({'name': 'dev_kms', 'type': 'kms',
                      'configs': {'username': 'keyadmin', 'password': 'rangerR0cks!',
-                                 'provider': 'http://ranger-kms:9292'}})
+                                 'provider': 'http://ranger-kms:9292',
+                                 'ranger.plugin.kms.policy.refresh.synchronous':'true'}})
 
 trino = RangerService({'name': 'dev_trino',
                        'type': 'trino',
@@ -56,6 +63,7 @@ trino = RangerService({'name': 'dev_trino',
                            'password': 'trino',
                            'jdbc.driverClassName': 'io.trino.jdbc.TrinoDriver',
                            'jdbc.url': 'jdbc:trino://ranger-trino:8080',
+                           'ranger.plugin.trino.policy.refresh.synchronous':'true'
                        }})
 
 ozone = RangerService({'name': 'dev_ozone',
@@ -63,7 +71,8 @@ ozone = RangerService({'name': 'dev_ozone',
                        'displayName': 'dev_ozone',
                        'configs': {'username': 'hdfs', 'password': 'hdfs',
                                    'ozone.om.http-address': 'http://om:9874',
-                                   'hadoop.security.authentication': 'simple'}})
+                                   'hadoop.security.authentication': 'simple',
+                                   'ranger.plugin.ozone.policy.refresh.synchronous':'true'}})
 
 services = [hdfs, yarn, hive, hbase, kafka, knox, kms, trino, ozone]
 for service in services:


### PR DESCRIPTION
…olicy cache synchronously

## What changes were proposed in this pull request?

Cherry-pick of https://github.com/apache/ranger/commit/6a812eb0e42768119b93c3e3b2417e947211c9a9  from master branch with the required code changes to account for code divergence between the two branches

Proposes new config set via service plugin configs (repo configs) ranger.plugin.<service_name>.policy.refresh.synchronous=true that can be used to synchronously download policies during policy evaluation to reduce time waiting for plugin tests to download latest policies


## How was this patch tested?

Manually tested. 
Docker containers come up
Policies are evaluated synchronously
