### PR TITLE
RANGER-5320:Handle unsupported cipher key creation

### DIFF
--- a/kms/src/main/java/org/apache/hadoop/crypto/key/RangerKeyStoreProvider.java
+++ b/kms/src/main/java/org/apache/hadoop/crypto/key/RangerKeyStoreProvider.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.crypto.key;
 import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.crypto.CipherSuite;
 import org.apache.hadoop.fs.Path;
 import org.apache.ranger.credentialapi.CredentialReader;
 import org.apache.ranger.kms.dao.DaoManager;
@@ -442,6 +443,7 @@ public class RangerKeyStoreProvider extends KeyProvider {
         logger.debug("==> createKey({})", name);
 
         KeyVersion ret;
+        validateKeyCiphers(options.getCipher());
 
         try (AutoClosableWriteLock ignored = new AutoClosableWriteLock(lock)) {
             reloadKeys();
@@ -595,6 +597,16 @@ public class RangerKeyStoreProvider extends KeyProvider {
         logger.debug("<== getConfiguration()");
 
         return conf;
+    }
+
+    private void validateKeyCiphers(String ciphers) throws IOException {
+        if (StringUtils.isNotEmpty(ciphers)) {
+            try {
+                CipherSuite.convert(ciphers);
+            }  catch (Exception e) {
+                throw new IOException("Invalid ciphers: " + ciphers, e);
+            }
+        }
     }
 
     private static void getFromJceks(Configuration conf, String path, String alias, String key) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Creation of key with cipher other than default supported value by KMS should fail but in actual Key was getting created successfully, So it is handled in this patch


## How was this patch tested?

local mvn build test
Brought up docker containers and tested key creations in Ranger UI
