### PR TITLE
docs: fix typo ("deleteing" → "deleting") in docs/README.txt

### DIFF
--- a/docs/README.txt
+++ b/docs/README.txt
@@ -54,7 +54,7 @@ svn status
 # For adding any new files, use the following command
 # svn add PATH
 
-# For deleteing any existing file, use the following command
+# For deleting any existing file, use the following command
 # svn delete PATH
 
 #


### PR DESCRIPTION
This PR fixes a misspelling in the docs build instructions:
“deleteing” → “deleting” in docs/README.txt. No behavioral changes—docs only.
