### PR TITLE
RANGER-5333:Configurable Master key name for Ranger KMS DB with Luna HSM

### DIFF
--- a/kms/config/kms-webapp/dbks-site.xml
+++ b/kms/config/kms-webapp/dbks-site.xml
@@ -405,6 +405,12 @@
   	<value>false</value>
   	<description></description>
   </property>
+
+  <property>
+        <name>ranger.ks.hsm.masterkey.alias</name>
+        <value></value>
+        <description>Custom alias for Luna HSM master key</description>
+  </property>
   
   <property>
   	<name>ranger.ks.hsm.partition.name</name>

--- a/kms/config/kms-webapp/dbks-site.xml
+++ b/kms/config/kms-webapp/dbks-site.xml
@@ -408,7 +408,7 @@
 
   <property>
         <name>ranger.ks.hsm.masterkey.alias</name>
-        <value></value>
+        <value>RangerKMSKey</value>
         <description>Custom alias for Luna HSM master key</description>
   </property>
   

--- a/kms/src/main/java/org/apache/hadoop/crypto/key/RangerHSM.java
+++ b/kms/src/main/java/org/apache/hadoop/crypto/key/RangerHSM.java
@@ -48,11 +48,14 @@ public class RangerHSM implements RangerKMSMKI {
     private static final String PARTITION_NAME          = "ranger.ks.hsm.partition.name";
     private static final String HSM_TYPE                = "ranger.ks.hsm.type";
     private static final String MK_KEY_SIZE             = "ranger.kms.hsm.masterkey.size";
-    private static final String ALIAS                   = "RangerKMSKey";
+    private static final String MK_ALIAS                = "ranger.ks.hsm.masterkey.alias";
+    private static final String DEFAULT_MK_ALIAS        = "RangerKMSKey";
 
     private KeyStore myStore;
     private String   hsmKeystore;
-    private int mkKeySize;
+    private String   mkAlias;
+    private int      mkKeySize;
+
 
     public RangerHSM() {
     }
@@ -65,6 +68,7 @@ public class RangerHSM implements RangerKMSMKI {
          */
         String passwd        = conf.get(PARTITION_PASSWORD);
         String partitionName = conf.get(PARTITION_NAME);
+        this.mkAlias         = conf.get(MK_ALIAS, DEFAULT_MK_ALIAS);
         this.mkKeySize       = conf.getInt(MK_KEY_SIZE, DEFAULT_MK_KEY_SIZE);
         String errorMsg      = StringUtils.EMPTY;
 
@@ -103,7 +107,7 @@ public class RangerHSM implements RangerKMSMKI {
 
         boolean isMKGenerated = false;
 
-        if (!this.myStore.containsAlias(ALIAS)) {
+        if (!this.myStore.containsAlias(mkAlias)) {
             try {
                 logger.info("Generating AES Master Key for '{}' HSM Provider and keySize is {}", hsmKeystore, this.mkKeySize);
 
@@ -113,14 +117,14 @@ public class RangerHSM implements RangerKMSMKI {
 
                 SecretKey aesKey = keyGen.generateKey();
 
-                myStore.setKeyEntry(ALIAS, aesKey, password.toCharArray(), (java.security.cert.Certificate[]) null);
+                myStore.setKeyEntry(mkAlias, aesKey, password.toCharArray(), (java.security.cert.Certificate[]) null);
 
                 isMKGenerated = true;
             } catch (Exception e) {
                 logger.error("generateMasterKey : Exception during Ranger Master Key Generation - {}", e.getMessage());
             }
         } else {
-            logger.info("Master key with alias - '{}' already exists!", ALIAS);
+            logger.info("Master key with alias - '{}' already exists!", mkAlias);
         }
 
         logger.debug("<== RangerHSM.generateMasterKey()");
@@ -136,12 +140,12 @@ public class RangerHSM implements RangerKMSMKI {
             try {
                 logger.debug("Searching for Ranger Master Key in Luna Keystore");
 
-                boolean result = myStore.containsAlias(ALIAS);
+                boolean result = myStore.containsAlias(mkAlias);
 
                 if (result) {
                     logger.debug("Ranger Master Key is present in Keystore");
 
-                    SecretKey key = (SecretKey) myStore.getKey(ALIAS, password.toCharArray());
+                    SecretKey key = (SecretKey) myStore.getKey(mkAlias, password.toCharArray());
 
                     return Base64.encode(key.getEncoded());
                 }
@@ -161,7 +165,7 @@ public class RangerHSM implements RangerKMSMKI {
             try {
                 Key aesKey = new SecretKeySpec(key, MK_CIPHER);
 
-                myStore.setKeyEntry(ALIAS, aesKey, password.toCharArray(), (java.security.cert.Certificate[]) null);
+                myStore.setKeyEntry(mkAlias, aesKey, password.toCharArray(), (java.security.cert.Certificate[]) null);
 
                 return true;
             } catch (KeyStoreException e) {

--- a/kms/src/main/java/org/apache/hadoop/crypto/key/RangerHSM.java
+++ b/kms/src/main/java/org/apache/hadoop/crypto/key/RangerHSM.java
@@ -56,7 +56,6 @@ public class RangerHSM implements RangerKMSMKI {
     private String   mkAlias;
     private int      mkKeySize;
 
-
     public RangerHSM() {
     }
 


### PR DESCRIPTION
Master Key name is hard coded for Ranger KMS DB integration with Luna HSM.
Refer : https://github.com/apache/ranger/blob/master/kms/src/main/java/org/apache/hadoop/crypto/key/RangerHSM.java#L50

It is made configurable so CU can provide customised name.

Test:
 Successful creation of new master key with configured name
 Noticed duplicate creation of key error if created with existing Master key name (as expected)
 Successful mvn build
