### PR TITLE
RANGER-5259: Add REST API to delete stale entries of Plugin info

### DIFF
--- a/security-admin/src/main/java/org/apache/ranger/biz/AssetMgr.java
+++ b/security-admin/src/main/java/org/apache/ranger/biz/AssetMgr.java
@@ -1506,6 +1506,13 @@ public class AssetMgr extends AssetMgrBase {
         }
     }
 
+    public void doDeleteXXPluginInfo(Long id) {
+        XXPluginInfo xObj = rangerDaoManager.getXXPluginInfo().getById(id);
+        if (xObj != null) {
+            rangerDaoManager.getXXPluginInfo().remove(xObj.getId());
+        }
+    }
+
     private String getRemoteAddress(final HttpServletRequest request) {
         String ret = null;
 

--- a/security-admin/src/main/java/org/apache/ranger/rest/ServiceREST.java
+++ b/security-admin/src/main/java/org/apache/ranger/rest/ServiceREST.java
@@ -2852,6 +2852,48 @@ public class ServiceREST {
         return ret;
     }
 
+    @DELETE
+    @Path("/plugins/info")
+    @Produces("application/json")
+    @PreAuthorize("hasRole('ROLE_SYS_ADMIN')")
+    public void deletePluginsInfo(@Context HttpServletRequest request) {
+        LOG.debug("==> ServiceREST.deletePluginsInfo()");
+
+        RangerPluginInfoList ret    = null;
+        SearchFilter         filter = searchUtil.getSearchFilter(request, pluginInfoService.getSortFields());
+
+        try {
+            PList<RangerPluginInfo> paginatedPluginsInfo = pluginInfoService.searchRangerPluginInfo(filter);
+            if (paginatedPluginsInfo != null) {
+                for (RangerPluginInfo rangerPluginInfo : paginatedPluginsInfo.getList()) {
+                    if (rangerPluginInfo != null) {
+                        deletePluginsInfo(rangerPluginInfo.getId());
+                        LOG.debug("Deleted rangerPluginInfo:[{}]", rangerPluginInfo);
+                    }
+                }
+            }
+        } catch (WebApplicationException excp) {
+            throw excp;
+        } catch (Throwable excp) {
+            LOG.error("deletePluginsInfo() failed", excp);
+
+            throw restErrorUtil.createRESTException(excp.getMessage());
+        }
+
+        LOG.debug("<== ServiceREST.deletePluginsInfo()");
+    }
+
+    @DELETE
+    @Path("/plugins/info/{id}")
+    @PreAuthorize("hasRole('ROLE_SYS_ADMIN')")
+    public void deletePluginsInfo(@PathParam("id") Long id) {
+        LOG.debug("==> ServiceREST.deletePluginsInfo({})", id);
+
+        assetMgr.doDeleteXXPluginInfo(id);
+
+        LOG.debug("<== ServiceREST.deletePluginsInfo() - [id={}]", id);
+    }
+
     public void blockIfGdsService(String serviceName) {
         String serviceType = daoManager.getXXServiceDef().findServiceDefTypeByServiceName(serviceName);
 

--- a/security-admin/src/main/java/org/apache/ranger/security/context/RangerAPIList.java
+++ b/security-admin/src/main/java/org/apache/ranger/security/context/RangerAPIList.java
@@ -87,6 +87,7 @@ public class RangerAPIList {
     public static final String GET_POLICY_VERSION_LIST         = "ServiceREST.getPolicyVersionList";
     public static final String GET_POLICY_FOR_VERSION_NO       = "ServiceREST.getPolicyForVersionNumber";
     public static final String GET_PLUGINS_INFO                = "ServiceREST.getPluginsInfo";
+    public static final String DELETE_PLUGINS_INFO             = "ServiceREST.deletePluginsInfo";
     public static final String GET_METRICS_BY_TYPE             = "ServiceREST.getMetricByType";
     public static final String DELETE_CLUSTER_SERVICES         = "ServiceREST.deleteClusterServices";
 

--- a/security-admin/src/main/java/org/apache/ranger/security/context/RangerAPIMapping.java
+++ b/security-admin/src/main/java/org/apache/ranger/security/context/RangerAPIMapping.java
@@ -376,6 +376,7 @@ public class RangerAPIMapping {
         apiAssociatedWithAudit.add(RangerAPIList.GET_POLICY_FROM_EVENT_TIME);
         apiAssociatedWithAudit.add(RangerAPIList.GET_POLICY_VERSION_LIST);
         apiAssociatedWithAudit.add(RangerAPIList.GET_PLUGINS_INFO);
+        apiAssociatedWithAudit.add(RangerAPIList.DELETE_PLUGINS_INFO);
         apiAssociatedWithAudit.add(RangerAPIList.GET_SERVICE);
         apiAssociatedWithAudit.add(RangerAPIList.GET_SERVICE_BY_NAME);
         apiAssociatedWithAudit.add(RangerAPIList.GET_SERVICE_DEF);


### PR DESCRIPTION
## What changes were proposed in this pull request?

We are adding two REST APIs in ranger-admin to delete stale plugin info entries:

Delete based on plugin info entry id : plugins/plugins/info/{id}

Example: if the plugin info entry id is 9 which need to be deleted then below REST shall work. 

` curl -ivk -u admin:Admin123 -H "Accept: application/json" -H "Content-Type: application/json" -X DELETE https://<ranger_host>:6182/service/plugins/plugins/info/9`

Delete based on plugin info entry attributes : plugins/plugins/info

Case-1: if you want to delete all plugin info entries of a ranger service.

`curl -ivk -u admin:Admin123 -H "Accept: application/json" -H "Content-Type: application/json" -X DELETE "https://<ranger_host>:6182/service/plugins/plugins/info?serviceName=${SERVICE_NAME}"`

Case-2: if you want to delete all plugin info entries of a ranger service and host name.

`curl -ivk -u admin:Admin123 -H "Accept: application/json" -H "Content-Type: application/json" -X DELETE "https://<ranger_host>:6182/service/plugins/plugins/info?serviceName=${SERVICE_NAME}&pluginHostName=${HOST_NAME}"`

Case-3: if you want to delete all plugin info entries of a ranger service, host and application name/type.

`curl -ivk -u admin:Admin123 -H "Accept: application/json" -H "Content-Type: application/json" -X DELETE "https://<ranger_host>:6182/service/plugins/plugins/info?serviceName=${SERVICE_NAME}&pluginHostName=${HOST_NAME}&pluginAppType=${APPLICATION_NAME}"`


## How was this patch tested?
 Manually: via calling the above given REST point
