### PR TITLE
RANGER-5338: Make XMLUtils's error message more informative

### DIFF
--- a/agents-common/src/main/java/org/apache/ranger/plugin/util/XMLUtils.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/util/XMLUtils.java
@@ -51,7 +51,7 @@ public class XMLUtils {
         try (InputStream input = getFileInputStream(configFileName)) {
             loadConfig(input, properties);
         } catch (Exception e) {
-            LOG.error("Error loading : ", e);
+            LOG.error("Error loading : {}", configFileName, e);
         }
     }
 
@@ -135,6 +135,9 @@ public class XMLUtils {
             }
         }
 
+        if (ret == null) {
+            throw new FileNotFoundException(path + " is not found");
+        }
         return ret;
     }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR would add more contexts to error logs when failing to load a configuration file, such as ranger-admin-site.xml.

https://issues.apache.org/jira/browse/RANGER-5338

## How was this patch tested?

I executed [this test case](https://github.com/apache/ranger/blob/c1528cd526a7c8dfcb8390b78dcaa25e43f4efbe/security-admin/src/test/java/org/apache/ranger/common/TestRangerProperties.java#L58-L63) and confirmed that the following error message showed up.

```
ERROR org.apache.ranger.plugin.util.XMLUtils -- Error loading : non-existent-file.xml
java.io.FileNotFoundException: non-existent-file.xml is not found
	at org.apache.ranger.plugin.util.XMLUtils.getFileInputStream(XMLUtils.java:139)
	at org.apache.ranger.plugin.util.XMLUtils.loadConfig(XMLUtils.java:51)
	at org.apache.ranger.common.TestRangerProperties.testXMLUtilsLoadConfigNoFileGraceful(TestRangerProperties.java:61)
```
