### PR TITLE
RANGER-5340: fix incorrect isFinal flag in RangerResourceACLs for GDS…

### DIFF
--- a/agents-common/src/main/java/org/apache/ranger/plugin/policyengine/RangerResourceACLs.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/policyengine/RangerResourceACLs.java
@@ -117,46 +117,73 @@ public class RangerResourceACLs {
 
     public void setUserAccessInfo(String userName, String accessType, Integer access, RangerPolicy policy) {
         Map<String, AccessResult> userAccessInfo = userACLs.computeIfAbsent(userName, k -> new HashMap<>());
+        AccessResult              existingResult = userAccessInfo.get(accessType);
 
-        AccessResult accessResult = userAccessInfo.get(accessType);
-
-        if (accessResult == null) {
-            accessResult = new AccessResult(access, policy);
-
-            userAccessInfo.put(accessType, accessResult);
+        if (existingResult == null) {
+            userAccessInfo.put(accessType, new AccessResult(access, policy));
         } else if (!ACCESS_CONDITIONAL.equals(access)) {
-            accessResult.setResult(access);
-            accessResult.setPolicy(policy);
+            existingResult.setResult(access);
+            existingResult.setPolicy(policy);
         }
     }
 
     public void setGroupAccessInfo(String groupName, String accessType, Integer access, RangerPolicy policy) {
         Map<String, AccessResult> groupAccessInfo = groupACLs.computeIfAbsent(groupName, k -> new HashMap<>());
+        AccessResult              existingResult  = groupAccessInfo.get(accessType);
 
-        AccessResult accessResult = groupAccessInfo.get(accessType);
-
-        if (accessResult == null) {
-            accessResult = new AccessResult(access, policy);
-
-            groupAccessInfo.put(accessType, accessResult);
+        if (existingResult == null) {
+            groupAccessInfo.put(accessType, new AccessResult(access, policy));
         } else if (!ACCESS_CONDITIONAL.equals(access)) {
-            accessResult.setResult(access);
-            accessResult.setPolicy(policy);
+            existingResult.setResult(access);
+            existingResult.setPolicy(policy);
         }
     }
 
     public void setRoleAccessInfo(String roleName, String accessType, Integer access, RangerPolicy policy) {
         Map<String, AccessResult> roleAccessInfo = roleACLs.computeIfAbsent(roleName, k -> new HashMap<>());
+        AccessResult              existingResult = roleAccessInfo.get(accessType);
 
-        AccessResult accessResult = roleAccessInfo.get(accessType);
-
-        if (accessResult == null) {
-            accessResult = new AccessResult(access, policy);
-
-            roleAccessInfo.put(accessType, accessResult);
+        if (existingResult == null) {
+            roleAccessInfo.put(accessType, new AccessResult(access, policy));
         } else if (!ACCESS_CONDITIONAL.equals(access)) {
-            accessResult.setResult(access);
-            accessResult.setPolicy(policy);
+            existingResult.setResult(access);
+            existingResult.setPolicy(policy);
+        }
+    }
+
+    public void setUserAccessInfo(String userName, String accessType, AccessResult accessResult) {
+        Map<String, AccessResult> userAccessInfo = userACLs.computeIfAbsent(userName, k -> new HashMap<>());
+        AccessResult              existingResult = userAccessInfo.get(accessType);
+
+        if (existingResult == null) {
+            userAccessInfo.put(accessType, accessResult);
+        } else if (!ACCESS_CONDITIONAL.equals(accessResult.getResult())) {
+            existingResult.setResult(accessResult.getResult());
+            existingResult.setPolicy(accessResult.getPolicy());
+        }
+    }
+
+    public void setGroupAccessInfo(String userName, String accessType, AccessResult accessResult) {
+        Map<String, AccessResult> groupAccessInfo = groupACLs.computeIfAbsent(userName, k -> new HashMap<>());
+        AccessResult              existingResult  = groupAccessInfo.get(accessType);
+
+        if (existingResult == null) {
+            groupAccessInfo.put(accessType, accessResult);
+        } else if (!ACCESS_CONDITIONAL.equals(accessResult.getResult())) {
+            existingResult.setResult(accessResult.getResult());
+            existingResult.setPolicy(accessResult.getPolicy());
+        }
+    }
+
+    public void setRoleAccessInfo(String userName, String accessType, AccessResult accessResult) {
+        Map<String, AccessResult> roleAccessInfo = roleACLs.computeIfAbsent(userName, k -> new HashMap<>());
+        AccessResult              existingResult = roleAccessInfo.get(accessType);
+
+        if (existingResult == null) {
+            roleAccessInfo.put(accessType, accessResult);
+        } else if (!ACCESS_CONDITIONAL.equals(accessResult.getResult())) {
+            existingResult.setResult(accessResult.getResult());
+            existingResult.setPolicy(accessResult.getPolicy());
         }
     }
 

--- a/agents-common/src/main/java/org/apache/ranger/plugin/policyengine/RangerResourceACLs.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/policyengine/RangerResourceACLs.java
@@ -163,8 +163,8 @@ public class RangerResourceACLs {
         }
     }
 
-    public void setGroupAccessInfo(String userName, String accessType, AccessResult accessResult) {
-        Map<String, AccessResult> groupAccessInfo = groupACLs.computeIfAbsent(userName, k -> new HashMap<>());
+    public void setGroupAccessInfo(String groupName, String accessType, AccessResult accessResult) {
+        Map<String, AccessResult> groupAccessInfo = groupACLs.computeIfAbsent(groupName, k -> new HashMap<>());
         AccessResult              existingResult  = groupAccessInfo.get(accessType);
 
         if (existingResult == null) {
@@ -175,8 +175,8 @@ public class RangerResourceACLs {
         }
     }
 
-    public void setRoleAccessInfo(String userName, String accessType, AccessResult accessResult) {
-        Map<String, AccessResult> roleAccessInfo = roleACLs.computeIfAbsent(userName, k -> new HashMap<>());
+    public void setRoleAccessInfo(String roleName, String accessType, AccessResult accessResult) {
+        Map<String, AccessResult> roleAccessInfo = roleACLs.computeIfAbsent(roleName, k -> new HashMap<>());
         AccessResult              existingResult = roleAccessInfo.get(accessType);
 
         if (existingResult == null) {

--- a/agents-common/src/main/java/org/apache/ranger/plugin/policyevaluator/RangerPolicyEvaluator.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/policyevaluator/RangerPolicyEvaluator.java
@@ -606,6 +606,17 @@ public interface RangerPolicyEvaluator {
             }
         }
 
+        @Override
+        public String toString() {
+            return "PolicyACLSummary{" +
+                    "usersAccessInfo=" + usersAccessInfo +
+                    ", groupsAccessInfo=" + groupsAccessInfo +
+                    ", rolesAccessInfo=" + rolesAccessInfo +
+                    ", rowFilters=" + rowFilters +
+                    ", dataMasks=" + dataMasks +
+                    '}';
+        }
+
         private void addAccess(String accessorName, AccessorType accessorType, String accessType, Integer access, int policyItemType) {
             final Map<String, Map<String, AccessResult>> accessorsAccessInfo;
 

--- a/agents-common/src/main/java/org/apache/ranger/plugin/service/RangerBasePlugin.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/service/RangerBasePlugin.java
@@ -1447,13 +1447,13 @@ public class RangerBasePlugin {
 
                 switch (userType) {
                     case USER:
-                        baseResourceACLs.setUserAccessInfo(name, chainedAccessType, finalAccessResult.getResult(), finalAccessResult.getPolicy());
+                        baseResourceACLs.setUserAccessInfo(name, chainedAccessType, finalAccessResult);
                         break;
                     case GROUP:
-                        baseResourceACLs.setGroupAccessInfo(name, chainedAccessType, finalAccessResult.getResult(), finalAccessResult.getPolicy());
+                        baseResourceACLs.setGroupAccessInfo(name, chainedAccessType, finalAccessResult);
                         break;
                     case ROLE:
-                        baseResourceACLs.setRoleAccessInfo(name, chainedAccessType, finalAccessResult.getResult(), finalAccessResult.getPolicy());
+                        baseResourceACLs.setRoleAccessInfo(name, chainedAccessType, finalAccessResult);
                         break;
                     default:
                         break;

--- a/agents-common/src/test/resources/plugin/test_base_plugin_hive.json
+++ b/agents-common/src/test/resources/plugin/test_base_plugin_hive.json
@@ -390,10 +390,10 @@
         "userACLs": {
           "res-user":   { "select": { "result": 1, "isFinal": true, "policy": { "id": 100 } } },
           "tag-user":   { "select": { "result": 1, "isFinal": true, "policy": { "id": 200 } } },
-          "ds-user":    { "select": { "result": 1, "isFinal": false, "policy": { "id": 2001 } } },
-          "ds1-user":   { "select": { "result": 1, "isFinal": false, "policy": { "id": 2001 } } },
-          "proj-user":  { "select": { "result": 1, "isFinal": false, "policy": { "id": 3001 } } },
-          "proj1-user": { "select": { "result": 1, "isFinal": false, "policy": { "id": 3001 } } }
+          "ds-user":    { "select": { "result": 1, "isFinal": true, "policy": { "id": 2001 } } },
+          "ds1-user":   { "select": { "result": 1, "isFinal": true, "policy": { "id": 2001 } } },
+          "proj-user":  { "select": { "result": 1, "isFinal": true, "policy": { "id": 3001 } } },
+          "proj1-user": { "select": { "result": 1, "isFinal": true, "policy": { "id": 3001 } } }
         },
         "datasets": [ "dataset-1" ],
         "projects": [ "project-1" ]
@@ -408,11 +408,11 @@
         "userACLs": {
           "res-user":   { "select": { "result": 1, "isFinal": true, "policy": { "id": 100 } } },
           "tag-user":   { "select": { "result": 1, "isFinal": true, "policy": { "id": 200 } } },
-          "ds-user":    { "select": { "result": 1, "isFinal": false, "policy": { "id": 2001 } } },
-          "ds1-user":   { "select": { "result": 1, "isFinal": false, "policy": { "id": 2001 } } },
-          "ds2-user":   { "select": { "result": 1, "isFinal": false, "policy": { "id": 2002 } } },
-          "proj-user":  { "select": { "result": 1, "isFinal": false, "policy": { "id": 3001 } } },
-          "proj1-user": { "select": { "result": 1, "isFinal": false, "policy": { "id": 3001 } } }
+          "ds-user":    { "select": { "result": 1, "isFinal": true, "policy": { "id": 2001 } } },
+          "ds1-user":   { "select": { "result": 1, "isFinal": true, "policy": { "id": 2001 } } },
+          "ds2-user":   { "select": { "result": 1, "isFinal": true, "policy": { "id": 2002 } } },
+          "proj-user":  { "select": { "result": 1, "isFinal": true, "policy": { "id": 3001 } } },
+          "proj1-user": { "select": { "result": 1, "isFinal": true, "policy": { "id": 3001 } } }
         },
         "datasets": [ "dataset-1", "dataset-2" ],
         "projects": [ "project-1" ]
@@ -427,10 +427,10 @@
         "userACLs": {
           "res-user":   { "select": { "result": 1, "isFinal": true, "policy": { "id": 100 } } },
           "tag-user":   { "select": { "result": 1, "isFinal": true, "policy": { "id": 200 } } },
-          "ds-user":    { "select": { "result": 1, "isFinal": false, "policy": { "id": 2002 } } },
-          "ds2-user":   { "select": { "result": 1, "isFinal": false, "policy": { "id": 2002 } } },
-          "proj-user":  { "select": { "result": 1, "isFinal": false, "policy": { "id": 3001 } } },
-          "proj1-user": { "select": { "result": 1, "isFinal": false, "policy": { "id": 3001 } } }
+          "ds-user":    { "select": { "result": 1, "isFinal": true, "policy": { "id": 2002 } } },
+          "ds2-user":   { "select": { "result": 1, "isFinal": true, "policy": { "id": 2002 } } },
+          "proj-user":  { "select": { "result": 1, "isFinal": true, "policy": { "id": 3001 } } },
+          "proj1-user": { "select": { "result": 1, "isFinal": true, "policy": { "id": 3001 } } }
         },
         "datasets": [ "dataset-2" ],
         "projects": [ "project-1" ]
@@ -445,12 +445,12 @@
         "userACLs": {
           "res-user":   { "select": { "result": 1, "isFinal": true, "policy": { "id": 131 } } },
           "tag-user":   { "select": { "result": 1, "isFinal": true, "policy": { "id": 203 } } },
-          "ds-user":    { "select": { "result": 1, "isFinal": false, "policy": { "id": 2003 } } },
-          "ds3-user":   { "select": { "result": 1, "isFinal": false, "policy": { "id": 2003 } } },
-          "ds6-user":   { "select": { "result": 1, "isFinal": false, "policy": { "id": 2006 } } },
-          "proj-user":  { "select": { "result": 1, "isFinal": false, "policy": { "id": 3002 } } },
-          "proj2-user": { "select": { "result": 1, "isFinal": false, "policy": { "id": 3002 } } },
-          "proj4-user": { "select": { "result": 1, "isFinal": false, "policy": { "id": 3004 } } }
+          "ds-user":    { "select": { "result": 1, "isFinal": true, "policy": { "id": 2003 } } },
+          "ds3-user":   { "select": { "result": 1, "isFinal": true, "policy": { "id": 2003 } } },
+          "ds6-user":   { "select": { "result": 1, "isFinal": true, "policy": { "id": 2006 } } },
+          "proj-user":  { "select": { "result": 1, "isFinal": true, "policy": { "id": 3002 } } },
+          "proj2-user": { "select": { "result": 1, "isFinal": true, "policy": { "id": 3002 } } },
+          "proj4-user": { "select": { "result": 1, "isFinal": true, "policy": { "id": 3004 } } }
         },
         "datasets": [ "dataset-3", "dataset-6" ],
         "projects": [ "project-2", "project-4" ]
@@ -465,8 +465,8 @@
         "userACLs": {
           "res-user":  { "select": { "result": 1, "isFinal": true, "policy": { "id": 141 } } },
           "tag-user":  { "select": { "result": 1, "isFinal": true, "policy": { "id": 204 } } },
-          "ds-user":   { "select": { "result": 1, "isFinal": false, "policy": { "id": 2004 } } },
-          "ds4-user":  { "select": { "result": 1, "isFinal": false, "policy": { "id": 2004 } } }
+          "ds-user":   { "select": { "result": 1, "isFinal": true, "policy": { "id": 2004 } } },
+          "ds4-user":  { "select": { "result": 1, "isFinal": true, "policy": { "id": 2004 } } }
         },
         "datasets": [ "dataset-4" ]
       }

--- a/agents-common/src/test/resources/policyengine/test_aclprovider_default.json
+++ b/agents-common/src/test/resources/policyengine/test_aclprovider_default.json
@@ -583,11 +583,13 @@
       "tests": [
         { "name": "{USER} macro in database name",
           "resource": { "elements": { "database": "user_madhan", "table": "test_tbl1" } },
-          "groupPermissions": { "public":  { "select":  { "result": 2, "isFinal": true }, "update": { "result": 2, "isFinal": true } } }
+          "groupPermissions": { "public":  { "select":  { "result": 2, "isFinal": true }, "update": { "result": 2, "isFinal": true } } },
+          "userPermissions": {}, "rolePermissions": {}, "dataMasks": [], "rowFilters": []
         },
         { "name": "${{USER.dept}} macro in database name",
           "resource": { "elements": { "database": "dept_engg", "table": "test_tbl1" } },
-          "groupPermissions": { "public":  { "select":  { "result": 2, "isFinal": true } }, "engg":  { "select":  { "result": 1, "isFinal": true } } }
+          "groupPermissions": { "public":  { "select":  { "result": 2, "isFinal": true } }, "engg":  { "select":  { "result": 1, "isFinal": true } } },
+          "userPermissions": {}, "rolePermissions": {}, "dataMasks": [], "rowFilters": []
         },
       {
         "name": "denyAllElse-test",
@@ -597,74 +599,83 @@
             "user2": {"select": {"result": -1, "isFinal": true}, "update": {"result": -1, "isFinal": true},"create": {"result": -1, "isFinal": true},"drop": {"result": -1, "isFinal": true},"alter": {"result": -1, "isFinal": true},"index": {"result": -1, "isFinal": true},"lock": {"result": -1, "isFinal": true}},
             "user3": {"select": {"result": 1, "isFinal": true}, "update": {"result": 1, "isFinal": true},"create": {"result": 1, "isFinal": true},"drop": {"result": 1, "isFinal": true},"alter": {"result": 1, "isFinal": true},"index": {"result": 1, "isFinal": true},"lock": {"result": -1, "isFinal": true}}},
         "groupPermissions": {"public": {"select": {"result": 2, "isFinal": true}, "update": {"result": 2, "isFinal": true},"create": {"result": 2, "isFinal": true},"drop": {"result": 2, "isFinal": true},"alter": {"result": 2, "isFinal": true},"index": {"result": 2, "isFinal": true},"lock": {"result": -1, "isFinal": true}}},
-        "rolePermissions": {}
+        "rolePermissions": {}, "dataMasks": [], "rowFilters": []
       },
         {
           "name": "all-deny-test",
           "resource": {"elements":{"database":"hr", "udf":"udf" }},
           "userPermissions": {},
-          "groupPermissions": {"public": {"select":{"result":-1, "isFinal":true},"create":{"result":-1, "isFinal":true}}}
+          "groupPermissions": {"public": {"select":{"result":-1, "isFinal":true},"create":{"result":-1, "isFinal":true},"_admin":{"result":-1, "isFinal":true}}},
+          "rolePermissions": {}, "dataMasks": [], "rowFilters": []
         },
         {
           "name": "no-deny-test",
           "resource": {"elements":{"database":"default", "table":"test1", "column":"column2"}},
-          "userPermissions": {"user1":{"select":{"result":1, "isFinal":true}}, "user2":{"select":{"result":1, "isFinal":true}}, "admin":{"create":{"result":1, "isFinal":true},"drop":{"result":1, "isFinal":true}}},
-          "groupPermissions": {"group1": {"select":{"result":1, "isFinal":true}}, "group2": {"select":{"result":1, "isFinal":true}},"cluster-admin": {"create":{"result":1, "isFinal":true},"drop":{"result":1, "isFinal":true}}}
+          "userPermissions": {"user1":{"select":{"result":1, "isFinal":true}}, "user2":{"select":{"result":1, "isFinal":true}}, "admin":{"create":{"result":1, "isFinal":true},"drop":{"result":1, "isFinal":true},"_admin":{"result":1, "isFinal":true}}},
+          "groupPermissions": {"group1": {"select":{"result":1, "isFinal":true}}, "group2": {"select":{"result":1, "isFinal":true}},"cluster-admin": {"create":{"result":1, "isFinal":true},"drop":{"result":1, "isFinal":true}, "_admin":{"result":1, "isFinal":true}}},
+          "rolePermissions": {}, "dataMasks": [], "rowFilters": []
         },
         {
           "name": "partial-deny-test",
           "resource": {"elements":{"database":"default", "table":"test2", "column":"column2"}},
-          "userPermissions": {"user1":{"select":{"result":1, "isFinal":true}}, "user2":{"select":{"result":-1, "isFinal":true},"create":{"result":-1, "isFinal":true}}, "user3":{"select":{"result":1, "isFinal":true},"create":{"result":-1, "isFinal":true}},"user4":{"select":{"result":-1, "isFinal":true},"create":{"result":-1, "isFinal":true}},"admin":{"create":{"result":1, "isFinal":true},"drop":{"result":1, "isFinal":true}}},
-          "groupPermissions": {"group1": {"select":{"result":1, "isFinal":true}}, "group2": {"select":{"result":1, "isFinal":true}},"group3": {"select":{"result":-1, "isFinal":true},"create":{"result":-1, "isFinal":true}},"cluster-admin": {"create":{"result":1, "isFinal":true},"drop":{"result":1, "isFinal":true}}}
+          "userPermissions": {"user1":{"select":{"result":1, "isFinal":true}}, "user2":{"select":{"result":-1, "isFinal":true},"create":{"result":-1, "isFinal":true}}, "user3":{"select":{"result":1, "isFinal":true},"create":{"result":-1, "isFinal":true}},"user4":{"select":{"result":-1, "isFinal":true},"create":{"result":-1, "isFinal":true}},"admin":{"create":{"result":1, "isFinal":true},"drop":{"result":1, "isFinal":true},"_admin":{"result":1, "isFinal":true}}},
+          "groupPermissions": {"group1": {"select":{"result":1, "isFinal":true}}, "group2": {"select":{"result":1, "isFinal":true}},"group3": {"select":{"result":-1, "isFinal":true},"create":{"result":-1, "isFinal":true}},"cluster-admin": {"create":{"result":1, "isFinal":true},"drop":{"result":1, "isFinal":true},"_admin":{"result":1, "isFinal":true}}},
+          "rolePermissions": {}, "dataMasks": [], "rowFilters": []
         },
         {
           "name": "conditional-deny-test",
           "resource": {"elements":{"database":"finance", "table":"fin_1", "column":"salary"}},
-          "userPermissions": {"user1":{"select":{"result":1, "isFinal":true}}, "user2":{"select":{"result":1, "isFinal":true}}, "user3":{"select":{"result":2, "isFinal":true}} },
-          "groupPermissions": {"finance-controller": {"select":{"result":1, "isFinal":true}}, "cluster-admin": {"select":{"result":2, "isFinal":true}}}
+          "userPermissions": {"user1":{"select":{"result":1, "isFinal":true},"_admin":{"result":1, "isFinal":true}}, "user2":{"select":{"result":1, "isFinal":true},"_admin":{"result":1, "isFinal":true}}, "user3":{"select":{"result":2, "isFinal":true},"_admin":{"result":2, "isFinal":true}} },
+          "groupPermissions": {"finance-controller": {"select":{"result":1, "isFinal":true},"_admin":{"result":1, "isFinal":true}}, "cluster-admin": {"select":{"result":2, "isFinal":true},"_admin":{"result":2, "isFinal":true}}},
+          "rolePermissions": {}, "dataMasks": [], "rowFilters": []
         },
         {
           "name": "conditional-tag-only-test-descendant",
           "resource": {"elements":{"database":"finance", "table":"sales"}},
           "resourceMatchingScope": "SELF_OR_DESCENDANTS",
-          "userPermissions": {"hive":{"select":{"result":-1, "isFinal":true},"create":{"result":1, "isFinal":true}, "drop":{"result":-1, "isFinal":true}}, "admin":{"select":{"result":-1, "isFinal":true}} },
-          "groupPermissions": {"public": {"index":{"result":2, "isFinal":true}}}
+          "userPermissions": {"hive":{"select":{"result":-1, "isFinal":true},"create":{"result":1, "isFinal":true}}, "admin":{"select":{"result":-1, "isFinal":true}} },
+          "groupPermissions": {"public": {"index":{"result":2, "isFinal":true}}},
+          "rolePermissions": {}, "dataMasks": [], "rowFilters": []
         },
         {
           "name": "all-types-of-policy-items",
           "resource": {"elements":{"database":"default", "table":"table", "column":"column"}},
-          "userPermissions": {"user1":{"select":{"result":2, "isFinal":true}}, "user2":{"select":{"result":2, "isFinal":true}}, "user3":{"select":{"result":2, "isFinal":true}}, "user4":{"select":{"result":2, "isFinal":true}} },
-          "groupPermissions": {"public": {"select":{"result":2, "isFinal":true}}, "cluster-admin": {"select":{"result":2, "isFinal":true}}}
+          "userPermissions": {"user1":{"select":{"result":2, "isFinal":true}, "_admin":{"result":2, "isFinal":true}}, "user2":{"select":{"result":2, "isFinal":true}, "_admin":{"result":2, "isFinal":true}}, "user3":{"select":{"result":2, "isFinal":true}, "_admin":{"result":2, "isFinal":true}}, "user4":{"select":{"result":2, "isFinal":true}, "_admin":{"result":2, "isFinal":true}} },
+          "groupPermissions": {"public": {"select":{"result":2, "isFinal":true}, "_admin":{"result":2, "isFinal":true}}, "cluster-admin": {"select":{"result":2, "isFinal":true}, "_admin":{"result":2, "isFinal":true}}},
+          "rolePermissions": {}, "dataMasks": [], "rowFilters": []
         },
         {
           "name": "public-allow-test",
           "resource": {"elements":{"database":"finance", "table":"accounts", "column": "status" }},
-          "userPermissions": {"john":{"select":{"result":2, "isFinal":true}, "update":{"result":2, "isFinal":true}}, "jane":{"select":{"result":2, "isFinal":true},"update":{"result":2, "isFinal":true}}},
-          "groupPermissions": {"public": {"select":{"result":2, "isFinal":true}}, "accounting": {"select":{"result":2, "isFinal":true},"update":{"result":2, "isFinal":true}}, "admin": {"select":{"result":2, "isFinal":true},"update":{"result":2, "isFinal":true}}, "housekeeping":{"select":{"result":-1, "isFinal":true}}}
+          "userPermissions": {"john":{"select":{"result":2, "isFinal":true}, "update":{"result":2, "isFinal":true}, "_admin":{"result": 2, "isFinal": true}}, "jane":{"select":{"result":2, "isFinal":true},"update":{"result":2, "isFinal":true}, "_admin":{"result": 2, "isFinal": true}}},
+          "groupPermissions": {"public": {"select":{"result":2, "isFinal":true}}, "accounting": {"select":{"result":2, "isFinal":true},"update":{"result":2, "isFinal":true},"_admin":{"result":2, "isFinal":true}}, "admin": {"select":{"result":2, "isFinal":true},"update":{"result":2, "isFinal":true},"_admin":{"result":2, "isFinal":true}}, "housekeeping":{"select":{"result":-1, "isFinal":true}}},
+          "rolePermissions": {}, "dataMasks": [], "rowFilters": []
         },
         {
           "name": "public-allow-test-next",
           "resource": {"elements":{"database":"finance", "table":"accounts", "column": "amount" }},
-          "userPermissions": {"john":{"select":{"result":2, "isFinal":true}, "update":{"result":2, "isFinal":true}}, "jane":{"select":{"result":2, "isFinal":true},"update":{"result":2, "isFinal":true}}},
-          "groupPermissions": {"public": {"select":{"result":2, "isFinal":true}}, "accounting": {"select":{"result":2, "isFinal":true},"update":{"result":2, "isFinal":true}}, "admin": {"select":{"result":2, "isFinal":true},"update":{"result":2, "isFinal":true}}, "housekeeping":{"drop":{"result":-1, "isFinal":true}}}
+          "userPermissions": {"john":{"select":{"result":2, "isFinal":true}, "update":{"result":2, "isFinal":true}, "_admin":{"result":2, "isFinal":true}}, "jane":{"select":{"result":2, "isFinal":true},"update":{"result":2, "isFinal":true}, "_admin":{"result":2, "isFinal":true}}},
+          "groupPermissions": {"public": {"select":{"result":2, "isFinal":true}}, "accounting": {"select":{"result":2, "isFinal":true},"update":{"result":2, "isFinal":true},"_admin":{"result":2, "isFinal":true}}, "admin": {"select":{"result":2, "isFinal":true},"update":{"result":2, "isFinal":true},"_admin":{"result":2, "isFinal":true}}, "housekeeping":{"drop":{"result":-1, "isFinal":true}}},
+          "rolePermissions": {}, "dataMasks": [], "rowFilters": []
         },
         {
           "name": "conditions-in-exceptions-test",
           "resource": {"elements":{"database":"db1", "table":"tbl1", "column": "col1" }},
           "userPermissions": {"john":{"select":{"result":2, "isFinal":true}, "update":{"result":2, "isFinal":true}}, "jane":{"select":{"result":2, "isFinal":true},"update":{"result":2, "isFinal":true}}, "adam":{"drop":{"result":2, "isFinal":true}}, "eve":{"drop":{"result":2, "isFinal":true}}},
-          "groupPermissions": {}
+          "groupPermissions": {}, "rolePermissions": {}, "dataMasks": [], "rowFilters": []
         },
         {
           "name": "conditions-in-some-exceptions-test",
           "resource": {"elements":{"database":"db2", "table":"tbl2", "column": "col2" }},
           "userPermissions": {"john":{"select":{"result":1, "isFinal":true}, "update":{"result":-1, "isFinal":true}}, "jane":{"select":{"result":1, "isFinal":true},"update":{"result":1, "isFinal":true}}, "adam":{"drop":{"result":2, "isFinal":true}}, "eve":{"drop":{"result":2, "isFinal":true}}},
-          "groupPermissions": {}
+          "groupPermissions": {}, "rolePermissions": {}, "dataMasks": [], "rowFilters": []
         },
         {
           "name": "roles-test",
           "resource": {"elements":{"database":"db3", "table":"tbl3", "column": "col3" }},
           "userPermissions": {"john":{"select":{"result":1, "isFinal":true}, "update":{"result":1, "isFinal":true}}, "jane":{"select":{"result":1, "isFinal":true},"update":{"result":1, "isFinal":true}}, "adam":{"drop":{"result":-1, "isFinal":true}}, "eve":{"drop":{"result":-1, "isFinal":true}}},
-          "rolePermissions": {"tarzan":{"select":{"result":1, "isFinal":true}, "update":{"result":1, "isFinal":true}}, "eden":{"drop":{"result":-1, "isFinal":true}}}
+          "rolePermissions": {"tarzan":{"select":{"result":1, "isFinal":true}, "update":{"result":1, "isFinal":true}}, "eden":{"drop":{"result":-1, "isFinal":true}}},
+          "groupPermissions": {}, "dataMasks": [], "rowFilters": []
         }
       ]
     }

--- a/agents-common/src/test/resources/policyengine/test_aclprovider_hdfs.json
+++ b/agents-common/src/test/resources/policyengine/test_aclprovider_hdfs.json
@@ -107,23 +107,20 @@
         {
           "name": "test-finance-restricted",
           "resource": {"elements":{"path":"/finance/restricted"}},
-          "userPermissions": {},
           "groupPermissions": {"finance": {"read": {"result": 1, "isFinal": true}}},
-          "rolePermissions": {}
+          "userPermissions": {}, "rolePermissions": {}, "rowFilters": [], "dataMasks": []
         },
         {
           "name": "test-finance-limited",
           "resource": {"elements":{"path":"/finance/limited"}},
-          "userPermissions": {},
           "groupPermissions": {"stewards": {"read": {"result": 1, "isFinal": true}}},
-          "rolePermissions": {}
+          "userPermissions": {}, "rolePermissions": {}, "rowFilters": [], "dataMasks": []
         },
         {
           "name": "test-anything-under-public",
           "resource": {"elements":{"path":"/public/anything"}},
-          "userPermissions": {},
           "groupPermissions": {"public": {"read": {"result": 1, "isFinal": true}, "execute": {"result": 1, "isFinal": true}}},
-          "rolePermissions": {}
+          "userPermissions": {}, "rolePermissions": {}, "rowFilters": [], "dataMasks": []
         }
       ]
     }

--- a/agents-common/src/test/resources/policyengine/test_aclprovider_mask_filter.json
+++ b/agents-common/src/test/resources/policyengine/test_aclprovider_mask_filter.json
@@ -326,7 +326,8 @@
             {"users":["user2"], "groups":[], "roles":[], "accessTypes":["select"], "maskInfo":{"dataMaskType":"SHUFFLE"}},
             {"users":["user1"], "groups":[], "roles":[], "accessTypes":["select"], "maskInfo":{"dataMaskType":"HASH"}},
             {"users":["user2"], "groups":[], "roles":[], "accessTypes":["select"], "maskInfo":{"dataMaskType":"MASK"}}
-          ]
+          ],
+          "userPermissions": {}, "groupPermissions": {}, "rolePermissions": {}, "rowFilters": []
         },
         {"name":"mask: hr.employee.date_of_birth",
           "resource":{"elements":{"database":"hr", "table":"employee", "column":"date_of_birth"}},
@@ -334,56 +335,64 @@
             {"users":["user1"], "groups":[], "roles":[], "accessTypes":["select"], "maskInfo":{"dataMaskType":"MASK"}},
             {"users":["user2"], "groups":[], "roles":[], "accessTypes":["select"], "maskInfo":{"dataMaskType":"SHUFFLE"}},
             {"users":["user3"], "groups":[], "roles":[], "accessTypes":["select"], "maskInfo":{"dataMaskType":"LAST_4"}, "isConditional":  true}
-          ]
+          ],
+          "userPermissions": {}, "groupPermissions": {}, "rolePermissions": {}, "rowFilters": []
         },
         {"name":"mask: hr.employee.project - conditional: validity-schedule",
           "resource":{"elements":{"database":"hr", "table":"employee", "column":"project"}},
           "dataMasks": [
             {"users":["user1"], "groups":[], "roles":[], "accessTypes":["select"], "maskInfo":{"dataMaskType":"MASK"}, "isConditional": true},
             {"users":["user2"], "groups":[], "roles":[], "accessTypes":["select"], "maskInfo":{"dataMaskType":"HASH"}, "isConditional": true}
-          ]
+          ],
+          "userPermissions": {}, "groupPermissions": {}, "rolePermissions": {}, "rowFilters": []
         },
         {"name":"mask: employee.personal.city - tag-based: RESTRICTED",
           "resource":{"elements":{"database":"employee", "table":"personal", "column":"city"}},
           "dataMasks": [
             {"users":["user1"], "groups":[], "roles":[], "accessTypes":["select"], "maskInfo":{"dataMaskType":"MASK"}},
             {"users":["user2"], "groups":[], "roles":[], "accessTypes":["select"], "maskInfo":{"dataMaskType":"HASH"}}
-          ]
+          ],
+          "userPermissions": {}, "groupPermissions": {}, "rolePermissions": {}, "rowFilters": []
         },
         {"name":"mask: employee.personal.mrn - tag-based: DATA_QUALITY; conditional",
           "resource":{"elements":{"database":"employee", "table":"personal", "column":"mrn"}},
           "dataMasks": [
             {"users":["user1"], "groups":[], "roles":[], "accessTypes":["select"], "maskInfo":{"dataMaskType":"MASK"}, "isConditional": true},
             {"users":["user2"], "groups":[], "roles":[], "accessTypes":["select"], "maskInfo":{"dataMaskType":"HASH"}, "isConditional": true}
-          ]
+          ],
+          "userPermissions": {}, "groupPermissions": {}, "rolePermissions": {}, "rowFilters": []
         },
         {"name":"mask: employee.personal.address - tag-based: RESTRICTED-FINAL; conditional: validity-schedule",
           "resource":{"elements":{"database":"employee", "table":"personal", "column":"address"}},
           "dataMasks": [
             {"users":["user1"], "groups":[], "roles":[], "accessTypes":["select"], "maskInfo":{"dataMaskType":"MASK"}, "isConditional": true},
             {"users":["user2"], "groups":[], "roles":[], "accessTypes":["select"], "maskInfo":{"dataMaskType":"HASH"}, "isConditional": true}
-          ]
+          ],
+          "userPermissions": {}, "groupPermissions": {}, "rolePermissions": {}, "rowFilters": []
         },
         {"name":"mask: finance.forecast.revenue - tag-based: RESTRICTED; conditional: tag-validity-period",
           "resource":{"elements":{"database":"finance", "table":"forecast", "column":"revenue"}},
           "dataMasks": [
             {"users":["user1"], "groups":[], "roles":[], "accessTypes":["select"], "maskInfo":{"dataMaskType":"MASK"}, "isConditional": true},
             {"users":["user2"], "groups":[], "roles":[], "accessTypes":["select"], "maskInfo":{"dataMaskType":"HASH"}, "isConditional": true}
-          ]
+          ],
+          "userPermissions": {}, "groupPermissions": {}, "rolePermissions": {}, "rowFilters": []
         },
         { "name": "mask: test_db.dept_hr.col1: conditional",
           "resource": { "elements": { "database": "test_db", "table":"dept_hr", "column":"col1" } },
           "dataMasks": [
             { "users": [ ], "groups": [ "public" ], "roles": [], "accessTypes": [ "select" ], "maskInfo": { "dataMaskType": "MASK_NONE" }, "isConditional": true },
             { "users": [ ], "groups": [ "public" ], "roles": [], "accessTypes": [ "select" ], "maskInfo": { "dataMaskType": "MASK_HASH" }, "isConditional": false }
-          ]
+          ],
+          "userPermissions": {}, "groupPermissions": {}, "rolePermissions": {}, "rowFilters": []
         },
         {"name":"row-filter: employee.personal",
           "resource":{"elements":{"database":"employee", "table":"personal"}},
           "rowFilters":[
             {"users":["user1"], "groups":[], "roles":[], "accessTypes":["select"], "filterInfo":{"filterExpr":"location='US'"}},
             {"users":["user2"], "groups":[], "roles":[], "accessTypes":["select"], "filterInfo":{"filterExpr":"location='CA'"}}
-          ]
+          ],
+          "userPermissions": {}, "groupPermissions": {}, "rolePermissions": {}, "dataMasks": []
         },
         {"name":"row-filter: hr.employee",
           "resource":{"elements":{"database":"hr", "table":"employee"}},
@@ -391,21 +400,24 @@
             {"users":["user1"], "groups":[], "roles":[], "accessTypes":["select"], "filterInfo":{"filterExpr":"dept='production'"}},
             {"users":["user2"], "groups":[], "roles":[], "accessTypes":["select"], "filterInfo":{"filterExpr":"dept='purchase'"}},
             {"users":["user3"], "groups":[], "roles":[], "accessTypes":["select"], "filterInfo":{"filterExpr":"location='GR'"}, "isConditional":  true}
-          ]
+          ],
+          "userPermissions": {}, "groupPermissions": {}, "rolePermissions": {}, "dataMasks": []
         },
         {"name":"row-filter: hr.employee2 - conditional: validity-schedule",
           "resource":{"elements":{"database":"hr", "table":"employee2"}},
           "rowFilters":[
             {"users":["user1"], "groups":[], "roles":[], "accessTypes":["select"], "filterInfo":{"filterExpr":"dept='production'"}, "isConditional": true},
             {"users":["user2"], "groups":[], "roles":[], "accessTypes":["select"], "filterInfo":{"filterExpr":"dept='purchase'"}, "isConditional": true}
-          ]
+          ],
+          "userPermissions": {}, "groupPermissions": {}, "rolePermissions": {}, "dataMasks": []
         },
         { "name": "row-filter: test_db.dept_hr: conditional",
           "resource": { "elements": { "database": "test_db", "table":"dept_hr" } },
           "rowFilters": [
             { "users": [], "groups": [ "public" ], "roles": [], "accessTypes": [ "select" ], "filterInfo": { "filterExpr": "1 = 1" },        "isConditional": true },
             { "users": [], "groups": [ "public" ], "roles": [], "accessTypes": [ "select" ], "filterInfo": { "filterExpr": "dept != 'hr'" }, "isConditional": false }
-          ]
+          ],
+          "userPermissions": {}, "groupPermissions": {}, "rolePermissions": {}, "dataMasks": []
         }
       ]
     }

--- a/agents-common/src/test/resources/policyengine/test_aclprovider_resource_hierarchy_tags.json
+++ b/agents-common/src/test/resources/policyengine/test_aclprovider_resource_hierarchy_tags.json
@@ -150,7 +150,8 @@
       "tests": [
         { "name":            "table: db1.tbl1",
           "resource":        { "elements": { "database": "db1", "table": "tbl1" } },
-          "userPermissions": { "test-user": { "select":  { "result": 1, "isFinal": true } } }
+          "userPermissions": { "test-user": { "select":  { "result": 1, "isFinal": true } } },
+          "groupPermissions": {}, "rolePermissions": {}, "rowFilters": [], "dataMasks": []
         },
         { "name":            "column: db1.tbl1.SSN",
           "resource":        { "elements": { "database": "db1", "table": "tbl1", "column": "SSN" } },
@@ -159,7 +160,8 @@
             {"users": [ "test-user" ], "groups": [], "roles": [], "accessTypes": [ "select" ], "maskInfo": { "dataMaskType": "SHUFFLE" },   "isConditional": true },
             {"users": [ "test-user" ], "groups": [], "roles": [], "accessTypes": [ "select" ], "maskInfo": { "dataMaskType": "MASK" },      "isConditional": true },
             {"users": [ "test-user" ], "groups": [], "roles": [], "accessTypes": [ "select" ], "maskInfo": { "dataMaskType": "MASK_HASH" }, "isConditional": true }
-          ]
+          ],
+          "groupPermissions": {}, "rolePermissions": {}, "rowFilters": []
         },
         { "name":            "column: db1.tbl1.Age",
           "resource":        { "elements": { "database": "db1", "table": "tbl1", "column": "Age" } },
@@ -168,7 +170,8 @@
             {"users": [ "test-user" ], "groups": [], "roles": [], "accessTypes": [ "select" ], "maskInfo": { "dataMaskType": "SHUFFLE" },   "isConditional": true },
             {"users": [ "test-user" ], "groups": [], "roles": [], "accessTypes": [ "select" ], "maskInfo": { "dataMaskType": "MASK" },      "isConditional": true },
             {"users": [ "test-user" ], "groups": [], "roles": [], "accessTypes": [ "select" ], "maskInfo": { "dataMaskType": "MASK_HASH" }, "isConditional": true }
-          ]
+          ],
+          "groupPermissions": {}, "rolePermissions": {}, "rowFilters": []
         },
         { "name":            "column: db1.tbl1.Name",
           "resource":        { "elements": { "database": "db1", "table": "tbl1", "column": "Name" } },
@@ -177,15 +180,18 @@
             {"users": [ "test-user" ], "groups": [], "roles": [], "accessTypes": [ "select" ], "maskInfo": { "dataMaskType": "SHUFFLE" },   "isConditional": true },
             {"users": [ "test-user" ], "groups": [], "roles": [], "accessTypes": [ "select" ], "maskInfo": { "dataMaskType": "MASK" },      "isConditional": true },
             {"users": [ "test-user" ], "groups": [], "roles": [], "accessTypes": [ "select" ], "maskInfo": { "dataMaskType": "MASK_HASH" }, "isConditional": true }
-          ]
+          ],
+          "groupPermissions": {}, "rolePermissions": {}, "rowFilters": []
         },
         { "name":            "database: db2",
           "resource":        { "elements": { "database": "db2" } },
-          "userPermissions": { "test-user": { "select":  { "result": 1, "isFinal": true } } }
+          "userPermissions": { "test-user": { "select":  { "result": 1, "isFinal": true } } },
+          "groupPermissions": {}, "rolePermissions": {}, "rowFilters": [], "dataMasks": []
         },
         { "name":            "table: db2.tbl1",
           "resource":        { "elements": { "database": "db2", "table": "tbl1" } },
-          "userPermissions": { "test-user": { "select":  { "result": 1, "isFinal": true } } }
+          "userPermissions": { "test-user": { "select":  { "result": 1, "isFinal": true } } },
+          "groupPermissions": {}, "rolePermissions": {}, "rowFilters": [], "dataMasks": []
         },
         { "name":            "column: db2.tbl1.Name",
           "resource":        { "elements": { "database": "db2", "table": "tbl1", "column": "Name" } },
@@ -194,18 +200,21 @@
             {"users": [ "test-user" ], "groups": [], "roles": [], "accessTypes": [ "select" ], "maskInfo": { "dataMaskType": "SHUFFLE" },   "isConditional": true },
             {"users": [ "test-user" ], "groups": [], "roles": [], "accessTypes": [ "select" ], "maskInfo": { "dataMaskType": "MASK" },      "isConditional": true },
             {"users": [ "test-user" ], "groups": [], "roles": [], "accessTypes": [ "select" ], "maskInfo": { "dataMaskType": "MASK_HASH" }, "isConditional": true }
-          ]
+          ],
+          "groupPermissions": {}, "rolePermissions": {}, "rowFilters": []
         },
         { "name":            "database: order",
           "resource":        { "elements": { "database": "order" } },
-          "userPermissions": { "dba": { "create": { "result":  1, "isFinal":  true } } }
+          "userPermissions": { "dba": { "create": { "result":  1, "isFinal":  true } } },
+          "groupPermissions": {}, "rolePermissions": {}, "rowFilters": [], "dataMasks": []
         },
         { "name":            "table: order.customer",
           "resource":        { "elements": { "database": "order", "table": "customer" } },
           "userPermissions": {
             "test-user": { "select":  { "result": 1, "isFinal": true } },
             "dba":       { "create":  { "result": 1, "isFinal": true } }
-          }
+          },
+          "groupPermissions": {}, "rolePermissions": {}, "rowFilters": [], "dataMasks": []
         },
         { "name":            "column: order.customer.address",
           "resource":        { "elements": { "database": "order", "table": "customer", "column": "address" } },
@@ -216,7 +225,8 @@
           "dataMasks": [
             { "users": [ "test-user" ], "groups": [], "roles": [], "accessTypes": [ "select" ], "maskInfo": { "dataMaskType": "MASK_NONE" }, "isConditional": false },
             { "users": [ "test-user" ], "groups": [], "roles": [], "accessTypes": [ "select" ], "maskInfo": { "dataMaskType": "MASK_HASH" }, "isConditional": false }
-          ]
+          ],
+          "groupPermissions": {}, "rolePermissions": {}, "rowFilters": []
         }
       ]
     }


### PR DESCRIPTION
… ACLs

## What changes were proposed in this pull request?

- updated `RangerBasePlugin.getMergedResourceACLs()` to initialize `isFinal` flag correctly.
- updated ACL validation in unit tests to use simple equals(), instead of hardcoded handling of special cases like `_admin` permission, null vs empty collection

## How was this patch tested?

- verified tests completed successfully