### PR TITLE
RANGER-5341: Capture opCode in KMS access logs for EEK_OP operations

### DIFF
--- a/embeddedwebserver/src/main/java/org/apache/ranger/server/tomcat/EmbeddedServer.java
+++ b/embeddedwebserver/src/main/java/org/apache/ranger/server/tomcat/EmbeddedServer.java
@@ -226,7 +226,7 @@ public class EmbeddedServer {
         valve.setMaxDays(EmbeddedServerUtil.getIntConfig(ACCESS_LOG_ROTATE_MAX_DAYS, 15));
         valve.setRenameOnRotate(EmbeddedServerUtil.getBooleanConfig(ACCESS_LOG_ROTATE_RENAME_ON_ROTATE, false));
 
-        String defaultAccessLogPattern = servername.equalsIgnoreCase(KMS_SERVER_NAME) ? "%h %l %u %t \"%m %U\" %s %b %D" : "%h %l %u %t \"%r\" %s %b %D";
+        String defaultAccessLogPattern = servername.equalsIgnoreCase(KMS_SERVER_NAME) ? "%h %l %u %t \"%m %U\" %s %b %D %{eek_op}r" : "%h %l %u %t \"%r\" %s %b %D";
         String logPattern              = EmbeddedServerUtil.getConfig(ACCESS_LOG_PATTERN, defaultAccessLogPattern);
 
         valve.setPattern(logPattern);


### PR DESCRIPTION
Currently, when the handleEncryptedKeyOp() method in KMS.java is invoked via the API, there is no visibility into whether the request is performing a decryptKey or reEncryptKey operation as same path gets logged for both operations as it hits the same method.
So after this patch opCode will be included in AccessLog pattern.

e.g In access logs we can see opcode appended
<ip> - - [<DateTime>] "GET /kms/v1/keys/names" 200 3 50 -
<ip> - - [<DateTime>] "GET /kms/v1/key/key1/_eek" 500 288 29 generate
<ip> - - [<DateTime>] "POST /kms/v1/keyversion/test-2@1/_eek" 400 176 16 reencrypt
<ip> - - [<DateTime>] "POST /kms/v1/keyversion/test-2@1/_eek" 400 176 14 decrypt


## How was this patch tested?

Checked Access logs after hitting endpoints through Docker setup
Mvn local build
