### PR TITLE
RANGER-5342: USER-role users with names similar to admin or keyadmin …

### DIFF
--- a/security-admin/src/main/java/org/apache/ranger/rest/XUserREST.java
+++ b/security-admin/src/main/java/org/apache/ranger/rest/XUserREST.java
@@ -457,6 +457,11 @@ public class XUserREST {
                     hasRole = !userRolesList.contains(RangerConstants.ROLE_KEY_ADMIN_AUDITOR) ? userRolesList.add(RangerConstants.ROLE_KEY_ADMIN_AUDITOR) : hasRole;
                     hasRole = !userRolesList.contains(RangerConstants.ROLE_USER) ? userRolesList.add(RangerConstants.ROLE_USER) : hasRole;
                 } else if (loggedInVXUser.getUserRoleList().contains(RangerConstants.ROLE_USER)) {
+                    boolean hasOnlyUserRole = userRolesList.size() == 1 && userRolesList.contains(RangerConstants.ROLE_USER);
+                    if (!hasOnlyUserRole || !RangerConstants.ROLE_USER.equals(userRole)) {
+                        throw restErrorUtil.create403RESTException("Logged-In user is not allowed to access requested user data.");
+                    }
+
                     logger.info("Logged-In user having user role will be able to fetch his own user details.");
 
                     if (!searchCriteria.getParamList().containsKey("name")) {


### PR DESCRIPTION
…can query those admin/keyadmin users.

## What changes were proposed in this pull request?
This change will prevent users with the USER role from fetching details of roles other than USER.


## How was this patch tested?
-- build with mvn clean install 
-- tested below REST API working as expected

1. curl --insecure -k -v -u 'user:pass' -H 'Accept: application/json, text/plain, */*' '{hostname}:{port}/service/xusers/users?pageSize=10000&userRole=ROLE_SYS_ADMIN'
2. curl --insecure -k -u 'user:pass' -H 'Accept: application/json, text/plain, */*' '{hostname}:{port}/service/xusers/users?pageSize=10000&userRole=ROLE_KEY_ADMIN' 
3. curl --insecure -k -v -u 'user:pass' -H 'Accept: application/json, text/plain, */*' '{hostname}:{port}/service/xusers/users?pageSize=10000&userRoleList=ROLE_KEY_ADMIN&userRoleList=ROLE_SYS_ADMIN'


