### PR TITLE
RANGER-5397: IllegalArgumentException in RangerRESTClient when no ranger.plugin.<service>.policy.rest.url is configured

### DIFF
--- a/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerRESTClient.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerRESTClient.java
@@ -110,9 +110,13 @@ public class RangerRESTClient {
         mUrl               = url;
         mSslConfigFileName = sslConfigFileName;
         configuredURLs     = StringUtil.getURLs(mUrl);
-
-        setLastKnownActiveUrlIndex((new Random()).nextInt(getConfiguredURLs().size()));
-
+        int size = getConfiguredURLs().size();
+        if (size == 0){
+            LOG.warn("No REST URL configured");
+            setLastKnownActiveUrlIndex(0);
+        } else {
+            setLastKnownActiveUrlIndex((new Random()).nextInt(size));
+        }
         init(config);
     }
 

--- a/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerRESTClient.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerRESTClient.java
@@ -111,7 +111,7 @@ public class RangerRESTClient {
         mSslConfigFileName = sslConfigFileName;
         configuredURLs     = StringUtil.getURLs(mUrl);
         int size = getConfiguredURLs().size();
-        if (size == 0){
+        if (size == 0) {
             LOG.warn("No REST URL configured");
             setLastKnownActiveUrlIndex(0);
         } else {

--- a/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerRESTClient.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerRESTClient.java
@@ -110,12 +110,10 @@ public class RangerRESTClient {
         mUrl               = url;
         mSslConfigFileName = sslConfigFileName;
         configuredURLs     = StringUtil.getURLs(mUrl);
-        int size = getConfiguredURLs().size();
-        if (size == 0) {
-            LOG.warn("No REST URL configured");
-            setLastKnownActiveUrlIndex(0);
+        if (StringUtil.isEmpty(url)) {
+            throw new IllegalArgumentException("Ranger URL is null or empty. Likely caused by incorrect configuration");
         } else {
-            setLastKnownActiveUrlIndex((new Random()).nextInt(size));
+            setLastKnownActiveUrlIndex((new Random()).nextInt(getConfiguredURLs().size()));
         }
         init(config);
     }

--- a/agents-common/src/test/java/org/apache/ranger/plugin/util/TestRangerRESTClient.java
+++ b/agents-common/src/test/java/org/apache/ranger/plugin/util/TestRangerRESTClient.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.plugin.util;
+import org.apache.ranger.plugin.service.RangerBasePlugin;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+
+public class TestRangerRESTClient {
+
+    private static final String SERVICE_TYPE = "hive";
+    private static final String SERVICE_NAME = "test-service";
+    private static final String APP_ID = "test-app";
+
+    @Test
+    public void testPluginInit_WithNoUrl_DoesNotCrash() {
+        RangerBasePlugin plugin = new RangerBasePlugin(SERVICE_TYPE, SERVICE_NAME, APP_ID);
+        plugin.init();
+        assertNotNull("RangerBasePlugin should be initialized successfully", plugin);
+    }
+}

--- a/agents-common/src/test/java/org/apache/ranger/plugin/util/TestRangerRESTClient.java
+++ b/agents-common/src/test/java/org/apache/ranger/plugin/util/TestRangerRESTClient.java
@@ -22,8 +22,11 @@ package org.apache.ranger.plugin.util;
 import org.apache.ranger.authorization.hadoop.config.RangerPluginConfig;
 import org.apache.ranger.plugin.policyengine.RangerPolicyEngineOptions;
 import org.apache.ranger.plugin.service.RangerBasePlugin;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestRangerRESTClient {
     private static final String SERVICE_TYPE = "hive";
@@ -34,8 +37,8 @@ public class TestRangerRESTClient {
     @Test
     public void testPluginInit_WithNoUrl_ThrowsException() {
         RangerBasePlugin plugin = new RangerBasePlugin(SERVICE_TYPE, SERVICE_NAME, APP_ID);
-        IllegalArgumentException exception = Assert.assertThrows(IllegalArgumentException.class, plugin::init);
-        Assert.assertTrue(exception.getMessage().contains(ERR_MESSAGE));
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, plugin::init);
+        assertTrue(exception.getMessage().contains(ERR_MESSAGE));
     }
 
     @Test
@@ -45,6 +48,6 @@ public class TestRangerRESTClient {
         pluginConfig.set("ranger.plugin.hive.policy.rest.url", "http://dummy:1234");
         RangerBasePlugin plugin = new RangerBasePlugin(pluginConfig);
         plugin.init();
-        Assert.assertNotNull("RangerBasePlugin should be initialized successfully", plugin);
+        assertNotNull(plugin, "RangerBasePlugin should be initialized successfully");
     }
 }

--- a/agents-common/src/test/java/org/apache/ranger/plugin/util/TestRangerRESTClient.java
+++ b/agents-common/src/test/java/org/apache/ranger/plugin/util/TestRangerRESTClient.java
@@ -18,13 +18,13 @@
  */
 
 package org.apache.ranger.plugin.util;
+
 import org.apache.ranger.plugin.service.RangerBasePlugin;
 import org.junit.Test;
 
 import static org.junit.Assert.assertNotNull;
 
 public class TestRangerRESTClient {
-
     private static final String SERVICE_TYPE = "hive";
     private static final String SERVICE_NAME = "test-service";
     private static final String APP_ID = "test-app";

--- a/agents-common/src/test/java/org/apache/ranger/plugin/util/TestRangerRESTClient.java
+++ b/agents-common/src/test/java/org/apache/ranger/plugin/util/TestRangerRESTClient.java
@@ -19,20 +19,32 @@
 
 package org.apache.ranger.plugin.util;
 
+import org.apache.ranger.authorization.hadoop.config.RangerPluginConfig;
+import org.apache.ranger.plugin.policyengine.RangerPolicyEngineOptions;
 import org.apache.ranger.plugin.service.RangerBasePlugin;
+import org.junit.Assert;
 import org.junit.Test;
-
-import static org.junit.Assert.assertNotNull;
 
 public class TestRangerRESTClient {
     private static final String SERVICE_TYPE = "hive";
     private static final String SERVICE_NAME = "test-service";
     private static final String APP_ID = "test-app";
+    private static final String ERR_MESSAGE = "Ranger URL is null or empty.";
 
     @Test
-    public void testPluginInit_WithNoUrl_DoesNotCrash() {
+    public void testPluginInit_WithNoUrl_ThrowsException() {
         RangerBasePlugin plugin = new RangerBasePlugin(SERVICE_TYPE, SERVICE_NAME, APP_ID);
+        IllegalArgumentException exception = Assert.assertThrows(IllegalArgumentException.class, plugin::init);
+        Assert.assertTrue(exception.getMessage().contains(ERR_MESSAGE));
+    }
+
+    @Test
+    public void testPluginInit_WithValidUrl_Succeeds() {
+        RangerPolicyEngineOptions peOptions = new RangerPolicyEngineOptions();
+        RangerPluginConfig pluginConfig = new RangerPluginConfig(SERVICE_TYPE, SERVICE_NAME, APP_ID, "cl1", "on-perm", peOptions);
+        pluginConfig.set("ranger.plugin.hive.policy.rest.url", "http://dummy:1234");
+        RangerBasePlugin plugin = new RangerBasePlugin(pluginConfig);
         plugin.init();
-        assertNotNull("RangerBasePlugin should be initialized successfully", plugin);
+        Assert.assertNotNull("RangerBasePlugin should be initialized successfully", plugin);
     }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

RangerBasePlugin initialization fails with an IllegalArgumentException when the ranger.plugin..policy.rest.url property is not set.
The issue occurs because getConfiguredURLs() returns an empty list, causing Random.nextInt(0) to throw an exception.

## How was this patch tested?

wrote a new test TestRangerRESTClient.testPluginInit_WithNoUrl_DoesNotCrash() this will fail without fix and pass with fix.
