### PR TITLE
RANGER-5363: Filtering users by userRoleList parameter does not work in /xusers/users API

### DIFF
--- a/security-admin/src/main/java/org/apache/ranger/rest/XUserREST.java
+++ b/security-admin/src/main/java/org/apache/ranger/rest/XUserREST.java
@@ -110,6 +110,8 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -406,13 +408,7 @@ public class XUserREST {
     @Produces("application/json")
     @PreAuthorize("@rangerPreAuthSecurityHandler.isAPIAccessible(\"" + RangerAPIList.SEARCH_X_USERS + "\")")
     public VXUserList searchXUsers(@Context HttpServletRequest request, @QueryParam("syncSource") String syncSource, @QueryParam("userRole") String userRole) {
-        String         userRoleParamName = RangerConstants.ROLE_USER;
         SearchCriteria searchCriteria    = searchUtil.extractCommonCriterias(request, xUserService.sortFields);
-        String         userName          = null;
-
-        if (request.getUserPrincipal() != null) {
-            userName = request.getUserPrincipal().getName();
-        }
 
         searchUtil.extractString(request, searchCriteria, "name", "User name", null);
         searchUtil.extractString(request, searchCriteria, "emailAddress", "Email Address", null);
@@ -425,40 +421,48 @@ public class XUserREST {
         searchUtil.extractRoleString(request, searchCriteria, "userRole", "Role", null);
         searchUtil.extractString(request, searchCriteria, "syncSource", "Sync Source", null);
 
-        if (CollectionUtils.isNotEmpty(userRolesList) && CollectionUtils.size(userRolesList) == 1 && userRolesList.get(0).equalsIgnoreCase(userRoleParamName)) {
-            if (!(searchCriteria.getParamList().containsKey("name"))) {
-                searchCriteria.addParam("name", userName);
-            } else if ((searchCriteria.getParamList().containsKey("name")) && userName != null && userName.contains((String) searchCriteria.getParamList().get("name"))) {
-                searchCriteria.addParam("name", userName);
-            }
-        }
-
         UserSessionBase userSession = ContextUtil.getCurrentUserSession();
 
         if (userSession != null && userSession.getLoginId() != null) {
             VXUser loggedInVXUser = xUserService.getXUserByUserName(userSession.getLoginId());
 
             if (loggedInVXUser != null && loggedInVXUser.getUserRoleList().size() == 1) {
-                if (loggedInVXUser.getUserRoleList().contains(RangerConstants.ROLE_SYS_ADMIN) || loggedInVXUser.getUserRoleList().contains(RangerConstants.ROLE_ADMIN_AUDITOR)) {
-                    boolean hasRole = false;
+                Collection<String> roles   = loggedInVXUser.getUserRoleList();
+                List<String> allowedSysAdminRoles = Arrays.asList(RangerConstants.ROLE_SYS_ADMIN, RangerConstants.ROLE_ADMIN_AUDITOR, RangerConstants.ROLE_USER);
+                List<String> allowedKeyAdminRoles = Arrays.asList(RangerConstants.ROLE_KEY_ADMIN, RangerConstants.ROLE_KEY_ADMIN_AUDITOR, RangerConstants.ROLE_USER);
 
-                    hasRole = !userRolesList.contains(RangerConstants.ROLE_SYS_ADMIN) ? userRolesList.add(RangerConstants.ROLE_SYS_ADMIN) : hasRole;
-                    hasRole = !userRolesList.contains(RangerConstants.ROLE_ADMIN_AUDITOR) ? userRolesList.add(RangerConstants.ROLE_ADMIN_AUDITOR) : hasRole;
-                    hasRole = !userRolesList.contains(RangerConstants.ROLE_USER) ? userRolesList.add(RangerConstants.ROLE_USER) : hasRole;
+                if (roles.contains(RangerConstants.ROLE_SYS_ADMIN) || roles.contains(RangerConstants.ROLE_ADMIN_AUDITOR)) {
+                    boolean isSysAdmin         = roles.contains(RangerConstants.ROLE_SYS_ADMIN);
+                    boolean isRangerUserSync   = "rangerusersync".equalsIgnoreCase(userSession.getLoginId());
 
-                    if (loggedInVXUser.getUserRoleList().contains(RangerConstants.ROLE_SYS_ADMIN) && "rangerusersync".equalsIgnoreCase(userSession.getLoginId())) {
-                        hasRole = !userRolesList.contains(RangerConstants.ROLE_KEY_ADMIN) ? userRolesList.add(RangerConstants.ROLE_KEY_ADMIN) : hasRole;
-                        hasRole = !userRolesList.contains(RangerConstants.ROLE_KEY_ADMIN_AUDITOR) ? userRolesList.add(RangerConstants.ROLE_KEY_ADMIN_AUDITOR) : hasRole;
+                    if (CollectionUtils.isNotEmpty(userRolesList)) {
+                        boolean hasDisallowedRole  = userRolesList.stream().anyMatch(role -> !allowedSysAdminRoles.contains(role));
+                        if (isSysAdmin && !isRangerUserSync && hasDisallowedRole) {
+                            logger.warn("Access denied: SYS_ADMIN [{}] tried to access KEY_ADMIN users: {}", userSession.getLoginId(), userRolesList);
+                            throw restErrorUtil.create403RESTException("Logged-In user is not allowed to access requested user data.");
+                        }
+                    } else {
+                        userRolesList.addAll(allowedSysAdminRoles);
+                        if (isSysAdmin && isRangerUserSync) {
+                            userRolesList.addAll(allowedKeyAdminRoles);
+                        }
                     }
-                } else if (loggedInVXUser.getUserRoleList().contains(RangerConstants.ROLE_KEY_ADMIN) || loggedInVXUser.getUserRoleList().contains(RangerConstants.ROLE_KEY_ADMIN_AUDITOR)) {
-                    boolean hasRole = false;
-
-                    hasRole = !userRolesList.contains(RangerConstants.ROLE_KEY_ADMIN) ? userRolesList.add(RangerConstants.ROLE_KEY_ADMIN) : hasRole;
-                    hasRole = !userRolesList.contains(RangerConstants.ROLE_KEY_ADMIN_AUDITOR) ? userRolesList.add(RangerConstants.ROLE_KEY_ADMIN_AUDITOR) : hasRole;
-                    hasRole = !userRolesList.contains(RangerConstants.ROLE_USER) ? userRolesList.add(RangerConstants.ROLE_USER) : hasRole;
+                } else if (roles.contains(RangerConstants.ROLE_KEY_ADMIN) || roles.contains(RangerConstants.ROLE_KEY_ADMIN_AUDITOR)) {
+                    if (CollectionUtils.isNotEmpty(userRolesList)) {
+                        boolean hasDisallowedRole = userRolesList.stream().anyMatch(role -> !allowedKeyAdminRoles.contains(role));
+                        if (hasDisallowedRole) {
+                            logger.warn("Access denied: KEY_ADMIN [{}] tried to access SYS_ADMIN users: {}", userSession.getLoginId(), userRolesList);
+                            throw restErrorUtil.create403RESTException("Logged-In user is not allowed to access requested user data.");
+                        }
+                    } else {
+                        userRolesList.addAll(allowedKeyAdminRoles);
+                    }
                 } else if (userSession.isSingleRoleUserSession()) {
                     // Plain ROLE_USER self-search only; config super-users use full search below.
-                    if ((CollectionUtils.isNotEmpty(userRolesList) && !userRolesList.contains(RangerConstants.ROLE_USER)) || (userRole != null && !RangerConstants.ROLE_USER.equals(userRole))) {
+                    boolean invalidRoles = CollectionUtils.isNotEmpty(userRolesList) && !userRolesList.contains(RangerConstants.ROLE_USER);
+                    boolean invalidUserRole = userRole != null && !RangerConstants.ROLE_USER.equals(userRole);
+
+                    if (invalidRoles || invalidUserRole) {
                         throw restErrorUtil.create403RESTException("Logged-In user is not allowed to access requested user data.");
                     }
 
@@ -468,7 +472,7 @@ public class XUserREST {
                         throw restErrorUtil.create403RESTException("Logged-In user is not allowed to access requested user data.");
                     }
 
-                    if (loggedInVXUser != null && !xUserMgr.hasAccessToModule(RangerConstants.MODULE_USER_GROUPS)) {
+                    if (!xUserMgr.hasAccessToModule(RangerConstants.MODULE_USER_GROUPS)) {
                         loggedInVXUser = xUserMgr.getMaskedVXUser(loggedInVXUser);
                     }
 

--- a/security-admin/src/test/java/org/apache/ranger/rest/TestXUserREST.java
+++ b/security-admin/src/test/java/org/apache/ranger/rest/TestXUserREST.java
@@ -2388,6 +2388,98 @@ public class TestXUserREST {
         Mockito.verify(xUserMgr).modifyUserVisibility(visibilityMap);
     }
 
+    @Test
+    public void test165AdminUserWillHaveAdminAuditorAndUserRoles() {
+        destroySession();
+        String adminLoginId = "adminuser";
+        Long adminUserId = 10L;
+        RangerSecurityContext context = new RangerSecurityContext();
+        context.setUserSession(new UserSessionBase());
+        RangerContextHolder.setSecurityContext(context);
+        UserSessionBase currentUserSession = ContextUtil.getCurrentUserSession();
+        currentUserSession.setUserAdmin(false);
+        XXPortalUser xXPortalUser = new XXPortalUser();
+        xXPortalUser.setLoginId(adminLoginId);
+        xXPortalUser.setId(adminUserId);
+        currentUserSession.setXXPortalUser(xXPortalUser);
+
+        VXUser loggedInUser = new VXUser();
+        List<String> roles = new ArrayList<String>();
+        roles.add(RangerConstants.ROLE_SYS_ADMIN);
+        loggedInUser.setId(adminUserId);
+        loggedInUser.setName(adminLoginId);
+        loggedInUser.setUserRoleList(roles);
+
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        SearchCriteria     testSearchCriteria = createsearchCriteria();
+        Mockito.when(searchUtil.extractCommonCriterias(Mockito.any(), Mockito.any())).thenReturn(testSearchCriteria);
+        Mockito.when(searchUtil.extractString(request, testSearchCriteria, "name", "User name", null)).thenReturn("");
+        Mockito.when(searchUtil.extractString(request, testSearchCriteria, "emailAddress", "Email Address", null)).thenReturn("");
+        Mockito.when(searchUtil.extractInt(request, testSearchCriteria, "userSource", "User Source")).thenReturn(1);
+        Mockito.when(searchUtil.extractInt(request, testSearchCriteria, "isVisible", "User Visibility")).thenReturn(1);
+        Mockito.when(searchUtil.extractInt(request, testSearchCriteria, "status", "User Status")).thenReturn(1);
+        List<String> userRoleListParam = new ArrayList<String>();
+        Mockito.when(searchUtil.extractStringList(request, testSearchCriteria, "userRoleList", "User Role List", "userRoleList", null, null)).thenReturn(userRoleListParam);
+        Mockito.when(searchUtil.extractRoleString(request, testSearchCriteria, "userRole", "Role", null)).thenReturn("");
+        Mockito.when(searchUtil.extractString(request, testSearchCriteria, "syncSource", "Sync Source", null)).thenReturn(null);
+
+        Mockito.when(xUserService.getXUserByUserName(adminLoginId)).thenReturn(loggedInUser);
+        Mockito.when(xUserMgr.searchXUsers(testSearchCriteria)).thenReturn(new VXUserList());
+
+        VXUserList result = xUserRest.searchXUsers(request, null, null);
+        Assertions.assertNotNull(result);
+        // verify roles augmented for admin
+        Assertions.assertTrue(userRoleListParam.contains(RangerConstants.ROLE_SYS_ADMIN));
+        Assertions.assertTrue(userRoleListParam.contains(RangerConstants.ROLE_ADMIN_AUDITOR));
+        Assertions.assertTrue(userRoleListParam.contains(RangerConstants.ROLE_USER));
+    }
+
+    @Test
+    public void test166KeyAdminUserWillHaveKeyAdminAuditorAndUserRoles() {
+        destroySession();
+        String keyAdminLoginId = "keyadminuser";
+        Long keyAdminUserId = 11L;
+        RangerSecurityContext context = new RangerSecurityContext();
+        context.setUserSession(new UserSessionBase());
+        RangerContextHolder.setSecurityContext(context);
+        UserSessionBase currentUserSession = ContextUtil.getCurrentUserSession();
+        currentUserSession.setUserAdmin(false);
+        XXPortalUser xXPortalUser = new XXPortalUser();
+        xXPortalUser.setLoginId(keyAdminLoginId);
+        xXPortalUser.setId(keyAdminUserId);
+        currentUserSession.setXXPortalUser(xXPortalUser);
+
+        VXUser loggedInUser = new VXUser();
+        List<String> roles = new ArrayList<String>();
+        roles.add(RangerConstants.ROLE_KEY_ADMIN);
+        loggedInUser.setId(keyAdminUserId);
+        loggedInUser.setName(keyAdminLoginId);
+        loggedInUser.setUserRoleList(roles);
+
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        SearchCriteria     testSearchCriteria = createsearchCriteria();
+        Mockito.when(searchUtil.extractCommonCriterias(Mockito.any(), Mockito.any())).thenReturn(testSearchCriteria);
+        Mockito.when(searchUtil.extractString(request, testSearchCriteria, "name", "User name", null)).thenReturn("");
+        Mockito.when(searchUtil.extractString(request, testSearchCriteria, "emailAddress", "Email Address", null)).thenReturn("");
+        Mockito.when(searchUtil.extractInt(request, testSearchCriteria, "userSource", "User Source")).thenReturn(1);
+        Mockito.when(searchUtil.extractInt(request, testSearchCriteria, "isVisible", "User Visibility")).thenReturn(1);
+        Mockito.when(searchUtil.extractInt(request, testSearchCriteria, "status", "User Status")).thenReturn(1);
+        List<String> userRoleListParam = new ArrayList<String>();
+        Mockito.when(searchUtil.extractStringList(request, testSearchCriteria, "userRoleList", "User Role List", "userRoleList", null, null)).thenReturn(userRoleListParam);
+        Mockito.when(searchUtil.extractRoleString(request, testSearchCriteria, "userRole", "Role", null)).thenReturn("");
+        Mockito.when(searchUtil.extractString(request, testSearchCriteria, "syncSource", "Sync Source", null)).thenReturn(null);
+
+        Mockito.when(xUserService.getXUserByUserName(keyAdminLoginId)).thenReturn(loggedInUser);
+        Mockito.when(xUserMgr.searchXUsers(testSearchCriteria)).thenReturn(new VXUserList());
+
+        VXUserList result = xUserRest.searchXUsers(request, null, null);
+        Assertions.assertNotNull(result);
+        // verify roles augmented for keyadmin
+        Assertions.assertTrue(userRoleListParam.contains(RangerConstants.ROLE_KEY_ADMIN));
+        Assertions.assertTrue(userRoleListParam.contains(RangerConstants.ROLE_KEY_ADMIN_AUDITOR));
+        Assertions.assertTrue(userRoleListParam.contains(RangerConstants.ROLE_USER));
+    }
+
     @AfterEach
     public void destroySession() {
         RangerSecurityContext context = new RangerSecurityContext();


### PR DESCRIPTION

## What changes were proposed in this pull request?

When invoking the REST API

GET /service/xusers/users?userRoleList=ROLE_SYS_ADMIN

The userRoleList search filter is not applied as expected. The API returns users of all roles instead of filtering by the specified role, even when tested using an admin user.

Steps to Reproduce:
1) Log in as an admin user.
2) Call the API with a specific role filter, for example:
GET /service/xusers/users?userRoleList=ROLE_SYS_ADMIN
3) Observe that the response includes users of all roles instead of only those with the ROLE_SYS_ADMIN role.

Expected Behavior:
The API should return only users matching the specified userRoleList value.

Actual Behavior:
The API ignores the userRoleList parameter and returns all users.

## How was this patch tested?

Verified the userRoleList filter correctly restricts results.

Steps:

Call GET /service/xusers/users?userRoleList=ROLE_SYS_ADMIN.

**Expected Result**: The response list is correctly filtered and contains only users possessing the ROLE_SYS_ADMIN role.
