### PR TITLE
RANGER-5463: Update userstore version after group-user mapping changes in createOrDeleteXGroupUserList

### DIFF
--- a/security-admin/src/main/java/org/apache/ranger/biz/XUserMgr.java
+++ b/security-admin/src/main/java/org/apache/ranger/biz/XUserMgr.java
@@ -2959,10 +2959,14 @@ public class XUserMgr extends XUserMgrBase {
                 }
 
                 for (GroupUserInfo groupUserInfo : groupUserInfoList) {
-                    xGroupUserService.createOrDeleteXGroupUsers(groupUserInfo, usersFromDB);
+                    if (xGroupUserService.createOrDeleteXGroupUsers(groupUserInfo, usersFromDB)) {
+                        updatedGroups++;
+                    }
+                    
                 }
-
-                updatedGroups = groupUserInfoList.size();
+                if (logger.isDebugEnabled()) {
+                    logger.debug("No. of groups actually updated = {}", updatedGroups);
+                }
             }
 			if (updatedGroups > 0) {
 				updateUserStoreVersion("createOrDeleteXGroupUserList(updatedGroups=" + updatedGroups + ")");

--- a/security-admin/src/main/java/org/apache/ranger/biz/XUserMgr.java
+++ b/security-admin/src/main/java/org/apache/ranger/biz/XUserMgr.java
@@ -2964,6 +2964,9 @@ public class XUserMgr extends XUserMgrBase {
 
                 updatedGroups = groupUserInfoList.size();
             }
+			if (updatedGroups > 0) {
+				updateUserStoreVersion("createOrDeleteXGroupUserList(updatedGroups=" + updatedGroups + ")");
+			}
         }
 
         if (logger.isDebugEnabled()) {

--- a/security-admin/src/main/java/org/apache/ranger/service/XGroupUserService.java
+++ b/security-admin/src/main/java/org/apache/ranger/service/XGroupUserService.java
@@ -84,7 +84,7 @@ public class XGroupUserService extends XGroupUserServiceBase<XXGroupUser, VXGrou
         return vxGroupUser;
     }
 
-    public void createOrDeleteXGroupUsers(GroupUserInfo groupUserInfo, Map<String, Long> usersFromDB) {
+    public boolean createOrDeleteXGroupUsers(GroupUserInfo groupUserInfo, Map<String, Long> usersFromDB) {
         if (logger.isDebugEnabled()) {
             logger.debug("==>> createOrDeleteXGroupUsers for {}", groupUserInfo.getGroupName());
 
@@ -98,7 +98,7 @@ public class XGroupUserService extends XGroupUserServiceBase<XXGroupUser, VXGrou
         if (CollectionUtils.isEmpty(groupUserInfo.getAddUsers()) && CollectionUtils.isEmpty(groupUserInfo.getDelUsers())) {
             logger.info("Group memberships for source are empty for {}", groupName);
 
-            return;
+            return false;
         }
 
         XXGroup xxGroup = daoManager.getXXGroup().findByGroupName(groupName);
@@ -106,7 +106,7 @@ public class XGroupUserService extends XGroupUserServiceBase<XXGroupUser, VXGrou
         if (xxGroup == null) {
             logger.debug("createOrDeleteXGroupUsers(): groupName =  {} doesn't exist in database. Hence ignoring group membership updates", groupName);
 
-            return;
+            return false;
         }
 
         /* findUsersByGroupName returns all the entries from x_group_users table for a given group name and corresponding usernames from x_user table.
@@ -148,6 +148,7 @@ public class XGroupUserService extends XGroupUserServiceBase<XXGroupUser, VXGrou
 
             logger.debug("<<== createOrDeleteXGroupUsers: Max memory = {} Free memory = {} Total memory = {}", Runtime.getRuntime().maxMemory() / mb, Runtime.getRuntime().freeMemory() / mb, Runtime.getRuntime().totalMemory() / mb);
         }
+        return true;
     }
 
     public VXGroupUser readResourceWithOutLogin(Long id) {

--- a/security-admin/src/test/java/org/apache/ranger/service/TestXGroupUserServiceGroupUserMappingUpdator.java
+++ b/security-admin/src/test/java/org/apache/ranger/service/TestXGroupUserServiceGroupUserMappingUpdator.java
@@ -40,6 +40,8 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -104,10 +106,42 @@ public class TestXGroupUserServiceGroupUserMappingUpdator {
             Map<String, Long> users = new HashMap<>();
             users.put("u1", 11L);
             users.put("u2", 22L);
-            svc.createOrDeleteXGroupUsers(info, users);
+            boolean result = svc.createOrDeleteXGroupUsers(info, users);
+            assertTrue(result);
             verify(entityDao).create(any(XXGroupUser.class));
         } finally {
             svc.entityDao = previousDao;
         }
+    }
+
+    @Test
+    public void testCreateOrDeleteXGroupUsers_EmptyUsers() {
+        GroupUserInfo info = new GroupUserInfo();
+        info.setGroupName("group1");
+        info.setAddUsers(new HashSet<>());
+        info.setDelUsers(new HashSet<>());
+
+        Map<String, Long> users = new HashMap<>();
+        users.put("u1", 11L);
+
+        boolean result = svc.createOrDeleteXGroupUsers(info, users);
+        assertFalse(result);
+    }
+
+    @Test
+    public void testCreateOrDeleteXGroupUsers_GroupNotFound() {
+        GroupUserInfo info = new GroupUserInfo();
+        info.setGroupName("nonExistentGroup");
+        info.setAddUsers(new HashSet<>(Collections.singletonList("u1")));
+
+        XXGroupDao xGroupDao = mock(XXGroupDao.class);
+        when(daoMgr.getXXGroup()).thenReturn(xGroupDao);
+        when(xGroupDao.findByGroupName("nonExistentGroup")).thenReturn(null);
+
+        Map<String, Long> users = new HashMap<>();
+        users.put("u1", 11L);
+
+        boolean result = svc.createOrDeleteXGroupUsers(info, users);
+        assertFalse(result);
     }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added missing updateUserStoreVersion() call in XUserMgr.createOrDeleteXGroupUserList().                                   
                                                                                                                            
Without this fix, when user-group membership changes in LDAP (e.g., a user is added to or removed from a group), the      
UserSync successfully updates the x_group_users table in Ranger Admin, but the RangerUserStore version remains unchanged. 

Other similar methods like createXGroupUserFromMap() and createOrUpdateXGroups() already call updateUserStoreVersion() after modifying user/group data.    

## How was this patch tested?
- Built locally and deployed to a test environment
- Configured UserSync with LDAP source / Added user to a group in LDAP / Verified userstore version increments after sync