### PR TITLE
RANGER-5466 Avoid hardcoded delta sync and unnecessary LDAP filter when delta sync is disabled

### DIFF
--- a/ugsync/src/main/java/org/apache/ranger/ldapusersync/process/LdapUserGroupBuilder.java
+++ b/ugsync/src/main/java/org/apache/ranger/ldapusersync/process/LdapUserGroupBuilder.java
@@ -512,7 +512,11 @@ public class LdapUserGroupBuilder implements UserGroupSource {
                 deltaSyncUserTimeStamp = dateFormat.format(new Date(0));
             }
 
-            extendedUserSearchFilter = "(objectclass=" + userObjectClass + ")(|(uSNChanged>=" + deltaSyncUserTime + ")(modifyTimestamp>=" + deltaSyncUserTimeStamp + "Z))";
+            if (config.isDeltaSyncEnabled()) {
+                extendedUserSearchFilter = "(objectclass=" + userObjectClass + ")(|(uSNChanged>=" + deltaSyncUserTime + ")(modifyTimestamp>=" + deltaSyncUserTimeStamp + "Z))";
+            } else {
+                extendedUserSearchFilter = "(objectclass=" + userObjectClass + ")";
+            }
 
             if (userSearchFilter != null && !userSearchFilter.trim().isEmpty()) {
                 String customFilter = userSearchFilter.trim();
@@ -753,7 +757,11 @@ public class LdapUserGroupBuilder implements UserGroupSource {
                 deltaSyncGroupTimeStamp = dateFormat.format(new Date(0));
             }
 
-            extendedAllGroupsSearchFilter = "(&" + extendedGroupSearchFilter + "(|(uSNChanged>=" + deltaSyncGroupTime + ")(modifyTimestamp>=" + deltaSyncGroupTimeStamp + "Z)))";
+            if (config.isDeltaSyncEnabled()) {
+                extendedAllGroupsSearchFilter = "(&"  + extendedGroupSearchFilter + "(|(uSNChanged>=" + deltaSyncGroupTime + ")(modifyTimestamp>=" + deltaSyncGroupTimeStamp + "Z)))";
+            } else {
+                extendedAllGroupsSearchFilter = "(&"  + extendedGroupSearchFilter + ")";
+            }
 
             LOG.info("extendedAllGroupsSearchFilter = {}", extendedAllGroupsSearchFilter);
 

--- a/ugsync/src/main/java/org/apache/ranger/ldapusersync/process/LdapUserGroupBuilder.java
+++ b/ugsync/src/main/java/org/apache/ranger/ldapusersync/process/LdapUserGroupBuilder.java
@@ -506,8 +506,8 @@ public class LdapUserGroupBuilder implements UserGroupSource {
 
             DateFormat dateFormat = new SimpleDateFormat(DATE_FORMAT);
 
-            if (!groupUserTable.rowKeySet().isEmpty() || !config.isDeltaSyncEnabled() || (computeDeletes)) {
-                // Fix RANGER-1957: Perform full sync when there are updates to the groups or when incremental sync is not enabled
+            if (!groupUserTable.rowKeySet().isEmpty() || (config.isDeltaSyncEnabled() && (computeDeletes))) {
+                // Fix RANGER-1957: Perform full sync when there are updates to the groups or when computing deletes
                 deltaSyncUserTime      = 0;
                 deltaSyncUserTimeStamp = dateFormat.format(new Date(0));
             }
@@ -751,8 +751,8 @@ public class LdapUserGroupBuilder implements UserGroupSource {
                 extendedGroupSearchFilter = extendedGroupSearchFilter + customFilter;
             }
 
-            if (!config.isDeltaSyncEnabled() || (computeDeletes)) {
-                // Perform full sync when incremental sync is not enabled
+            if (config.isDeltaSyncEnabled() && (computeDeletes)) {
+                // Perform full sync when computing deletes
                 deltaSyncGroupTime      = 0;
                 deltaSyncGroupTimeStamp = dateFormat.format(new Date(0));
             }

--- a/ugsync/src/test/java/org/apache/ranger/ldapusersync/process/TestLdapUserGroupBuilder.java
+++ b/ugsync/src/test/java/org/apache/ranger/ldapusersync/process/TestLdapUserGroupBuilder.java
@@ -536,6 +536,8 @@ public class TestLdapUserGroupBuilder extends AbstractLdapTestUnit {
         UserGroupSyncConfig cfg = UserGroupSyncConfig.getInstance();
         cfg.setProperty("ranger.usersync.ldap.group.searchfilter", "cn=Group*");
         cfg.setProperty("ranger.usersync.ldap.largegroupsync", "true");
+        // Enable delta sync so that delta sync attributes are included in the search filters below
+        cfg.setProperty("ranger.usersync.ldap.deltasync", "true");
 
         LdapUserGroupBuilder b = new LdapUserGroupBuilder();
         b.init();
@@ -1127,6 +1129,84 @@ public class TestLdapUserGroupBuilder extends AbstractLdapTestUnit {
         assertTrue(srcUsers.containsKey("uid=user1,ou=people,dc=example,dc=com"));
         assertTrue(srcUsers.containsKey("uid=user2,ou=people,dc=example,dc=com"));
         assertTrue(srcUsers.containsKey("uid=user3,ou=people,dc=example,dc=com"));
+    }
+
+    @Test
+    void testZF_getUsers_and_getGroups_exclude_delta_filter_when_deltasync_disabled() throws Throwable {
+        resetConfig();
+        configureMinimalLdapConfig();
+        UserGroupSyncConfig cfg = UserGroupSyncConfig.getInstance();
+        cfg.setProperty("ranger.usersync.ldap.deltasync", "false");
+
+        LdapUserGroupBuilder b = new LdapUserGroupBuilder();
+        b.init();
+
+        // Prepare internal structures used by getUsers/getGroups
+        Field gutF           = LdapUserGroupBuilder.class.getDeclaredField("groupUserTable");
+        Field srcUsersF      = LdapUserGroupBuilder.class.getDeclaredField("sourceUsers");
+        Field srcGroupsF     = LdapUserGroupBuilder.class.getDeclaredField("sourceGroups");
+        Field srcGroupUsersF = LdapUserGroupBuilder.class.getDeclaredField("sourceGroupUsers");
+        gutF.setAccessible(true);
+        srcUsersF.setAccessible(true);
+        srcGroupsF.setAccessible(true);
+        srcGroupUsersF.setAccessible(true);
+        gutF.set(b, HashBasedTable.create());
+        srcUsersF.set(b, new HashMap<>());
+        srcGroupsF.set(b, new HashMap<>());
+        srcGroupUsersF.set(b, new HashMap<>());
+
+        class EmptyEnum implements NamingEnumeration<SearchResult> {
+            @Override
+            public SearchResult next() {
+                return null;
+            }
+
+            @Override
+            public boolean hasMore() {
+                return false;
+            }
+
+            @Override
+            public void close() {}
+
+            @Override
+            public boolean hasMoreElements() {
+                return false;
+            }
+
+            @Override
+            public SearchResult nextElement() {
+                return null;
+            }
+        }
+
+        try (MockedConstruction<InitialLdapContext> mocked = Mockito.mockConstruction(InitialLdapContext.class, (mock, ctx) -> {
+            Mockito.when(mock.search(Mockito.anyString(), Mockito.anyString(), Mockito.any(SearchControls.class)))
+                    .thenReturn(new EmptyEnum());
+            Mockito.when(mock.getResponseControls()).thenReturn(null);
+        })) {
+            Method getUsers = LdapUserGroupBuilder.class.getDeclaredMethod("getUsers", boolean.class);
+            getUsers.setAccessible(true);
+            getUsers.invoke(b, false);
+
+            Method getGroups = LdapUserGroupBuilder.class.getDeclaredMethod("getGroups", boolean.class);
+            getGroups.setAccessible(true);
+            getGroups.invoke(b, false);
+
+            // Search filters must not reference delta sync attributes when delta sync is disabled
+            Field extUserF = LdapUserGroupBuilder.class.getDeclaredField("extendedUserSearchFilter");
+            Field extAllF  = LdapUserGroupBuilder.class.getDeclaredField("extendedAllGroupsSearchFilter");
+            extUserF.setAccessible(true);
+            extAllF.setAccessible(true);
+            String extUser = (String) extUserF.get(b);
+            String extAll  = (String) extAllF.get(b);
+            assertTrue(extUser.startsWith("(&(objectclass="), () -> extUser + ": must start with '(&(objectclass='");
+            assertTrue(extAll.startsWith("(&(objectclass="), () -> extAll + ": must start with '(&(objectclass='");
+            assertFalse(extUser.contains("uSNChanged"), () -> extUser + ": must not contain 'uSNChanged'");
+            assertFalse(extUser.contains("modifyTimestamp"), () -> extUser + ": must not contain 'modifyTimestamp'");
+            assertFalse(extAll.contains("uSNChanged"), () -> extAll + ": must not contain 'uSNChanged'");
+            assertFalse(extAll.contains("modifyTimestamp"), () -> extAll + ": must not contain 'modifyTimestamp'");
+        }
     }
 
     private static void configureMinimalLdapConfig() throws Exception {

--- a/unixauthservice/scripts/setup.py
+++ b/unixauthservice/scripts/setup.py
@@ -256,7 +256,8 @@ def convertInstallPropsToXML(props):
             #	if (key.startswith("ranger.usersync.ldap") or key.startswith("ranger.usersync.group") or key.startswith("ranger.usersync.paged")):
             #		del ret[key]
         elif (syncSource == SYNC_SOURCE_LDAP):
-            ret['ranger.usersync.ldap.deltasync'] = "true"
+            if ('ranger.usersync.ldap.deltasync' not in ret or len(str(ret['ranger.usersync.ldap.deltasync'])) == 0):
+                ret['ranger.usersync.ldap.deltasync'] = "true"
             ldapPass = ret[SYNC_LDAP_BIND_PASSWORD_KEY]
             password_validation(ldapPass, SYNC_LDAP_BIND_PASSWORD_KEY)
             ret['ranger.usersync.source.impl.class'] = 'org.apache.ranger.ldapusersync.process.LdapUserGroupBuilder'


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. setup.py: Changed hardcoded `ranger.usersync.ldap.deltasync=true` to only set the default value when the property is not already configured in install.properties.

2. LdapUserGroupBuilder: Skip appending delta sync filter conditions (uSNChanged, modifyTimestamp) to LDAP search queries when delta sync is disabled. Applied to both getUsers() and getGroups()

Some LDAP services (e.g., Google Workspace Secure LDAP) do not support the attributes used for delta sync (uSNChanged, modifyTimestamp), which causes delta sync to not work properly. In such cases, users should be able to disable delta sync and run full sync without unnecessary filter conditions being included in the LDAP queries.

## How was this patch tested?

- Built locally and verified LDAP search filters with delta sync enabled and disabled
