### PR TITLE
RANGER-5549: replace use of com.kstruct.gethostname4j library

### DIFF
--- a/agents-common/pom.xml
+++ b/agents-common/pom.xml
@@ -63,11 +63,6 @@
             <version>${jsr305.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.kstruct</groupId>
-            <artifactId>gethostname4j</artifactId>
-            <version>${kstruct.gethostname4j.version}</version>
-        </dependency>
-        <dependency>
             <groupId>com.nimbusds</groupId>
             <artifactId>nimbus-jose-jwt</artifactId>
             <version>${nimbus-jose-jwt.version}</version>
@@ -86,16 +81,6 @@
             <groupId>javax.ws.rs</groupId>
             <artifactId>jsr311-api</artifactId>
             <version>${jsr311-api.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>net.java.dev.jna</groupId>
-            <artifactId>jna</artifactId>
-            <version>${jna.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>net.java.dev.jna</groupId>
-            <artifactId>jna-platform</artifactId>
-            <version>${jna-platform.version}</version>
         </dependency>
         <dependency>
             <groupId>net.minidev</groupId>

--- a/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerRESTUtils.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerRESTUtils.java
@@ -145,7 +145,7 @@ public class RangerRESTUtils {
     private static String getHostname() {
         String hostname = System.getenv("HOSTNAME");
 
-        if (StringUtils.isEmpty(hostname)) {
+        if (StringUtils.isBlank(hostname)) {
             hostname = System.getenv("COMPUTERNAME");
 
             if (StringUtils.isBlank(hostname)) {

--- a/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerRESTUtils.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerRESTUtils.java
@@ -162,12 +162,11 @@ public class RangerRESTUtils {
                 try {
                     hostname = InetAddress.getLocalHost().getHostName();
                 } catch (Exception e) {
-                    LOG.error("ERROR: Unable to find hostname for the agent ", e);
-                    hostname = "unknownHost";
+                    LOG.error("ERROR: unable to find hostname", e);
                 }
             }
         }
 
-        return hostname.trim();
+        return StringUtils.isBlank(hostname) ? "unknownHost" : hostname.trim();
     }
 }

--- a/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerRESTUtils.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerRESTUtils.java
@@ -158,6 +158,6 @@ public class RangerRESTUtils {
             }
         }
 
-        return hostname;
+        return hostname.trim();
     }
 }

--- a/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerRESTUtils.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerRESTUtils.java
@@ -143,10 +143,20 @@ public class RangerRESTUtils {
     }
 
     private static String getHostname() {
-        String hostname = System.getenv("HOSTNAME");
+        String hostname = null;
+
+        try {
+            hostname = System.getenv("HOSTNAME");
+        } catch (SecurityException excp) {
+            LOG.error("Error in getting environment HOSTNAME", excp);
+        }
 
         if (StringUtils.isBlank(hostname)) {
-            hostname = System.getenv("COMPUTERNAME");
+            try {
+                hostname = System.getenv("COMPUTERNAME");
+            } catch (SecurityException excp) {
+                LOG.error("Error in getting environment COMPUTERNAME", excp);
+            }
 
             if (StringUtils.isBlank(hostname)) {
                 try {

--- a/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerRESTUtils.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerRESTUtils.java
@@ -19,7 +19,6 @@
 
 package org.apache.ranger.plugin.util;
 
-import com.kstruct.gethostname4j.Hostname;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -73,7 +72,7 @@ public class RangerRESTUtils {
     private static final Logger LOG                                               = LoggerFactory.getLogger(RangerRESTUtils.class);
     private static final int    MAX_PLUGIN_ID_LEN                                 = 255;
 
-    public static        String hostname;
+    public static final String hostname = getHostname();
 
     public String getPluginId(String serviceName, String appId) {
         String hostName;
@@ -143,12 +142,22 @@ public class RangerRESTUtils {
         return ret;
     }
 
-    static {
-        try {
-            hostname = Hostname.getHostname();
-        } catch (Exception e) {
-            LOG.error("ERROR: Unable to find hostname for the agent ", e);
-            hostname = "unknownHost";
+    private static String getHostname() {
+        String hostname = System.getenv("HOSTNAME");
+
+        if (StringUtils.isEmpty(hostname)) {
+            hostname = System.getenv("COMPUTERNAME");
+
+            if (StringUtils.isBlank(hostname)) {
+                try {
+                    hostname = InetAddress.getLocalHost().getHostName();
+                } catch (Exception e) {
+                    LOG.error("ERROR: Unable to find hostname for the agent ", e);
+                    hostname = "unknownHost";
+                }
+            }
         }
+
+        return hostname;
     }
 }

--- a/agents-common/src/test/java/org/apache/ranger/plugin/audit/TestRangerDefaultAuditHandler.java
+++ b/agents-common/src/test/java/org/apache/ranger/plugin/audit/TestRangerDefaultAuditHandler.java
@@ -18,7 +18,6 @@
 
 package org.apache.ranger.plugin.audit;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.ranger.audit.model.AuthzAuditEvent;
 import org.apache.ranger.audit.provider.AuditHandler;
@@ -35,6 +34,7 @@ import org.apache.ranger.plugin.policyengine.gds.GdsAccessResult;
 import org.apache.ranger.plugin.policyresourcematcher.RangerPolicyResourceMatcher;
 import org.apache.ranger.plugin.service.RangerBasePlugin;
 import org.apache.ranger.plugin.util.RangerAccessRequestUtil;
+import org.apache.ranger.plugin.util.RangerRESTUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
@@ -168,7 +168,7 @@ public class TestRangerDefaultAuditHandler {
         Assertions.assertEquals("clusterA", event.getClusterName());
         Assertions.assertEquals("zone-1", event.getZoneName());
         Assertions.assertEquals(Long.valueOf(7L), event.getPolicyVersion());
-        Assertions.assertTrue(StringUtils.isNotBlank(event.getAgentHostname()));
+        Assertions.assertEquals(new RangerRESTUtils().getAgentHostname(), event.getAgentHostname());
         Assertions.assertNotNull(event.getEventId());
         Assertions.assertEquals(event.getEventId(), result.getAuditLogId());
         Assertions.assertEquals("RangerAudit", event.getLogType());

--- a/agents-common/src/test/java/org/apache/ranger/plugin/audit/TestRangerDefaultAuditHandler.java
+++ b/agents-common/src/test/java/org/apache/ranger/plugin/audit/TestRangerDefaultAuditHandler.java
@@ -18,6 +18,7 @@
 
 package org.apache.ranger.plugin.audit;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.ranger.audit.model.AuthzAuditEvent;
 import org.apache.ranger.audit.provider.AuditHandler;
@@ -34,7 +35,6 @@ import org.apache.ranger.plugin.policyengine.gds.GdsAccessResult;
 import org.apache.ranger.plugin.policyresourcematcher.RangerPolicyResourceMatcher;
 import org.apache.ranger.plugin.service.RangerBasePlugin;
 import org.apache.ranger.plugin.util.RangerAccessRequestUtil;
-import org.apache.ranger.plugin.util.RangerRESTUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
@@ -83,8 +83,6 @@ public class TestRangerDefaultAuditHandler {
 
     @Test
     public void test02_getAuthzEvents_populatesFieldsAndDefaults() {
-        RangerRESTUtils.hostname = "my-host";
-
         RangerServiceDef svcDef = new RangerServiceDef();
         svcDef.setId(5L);
         List<RangerResourceDef> resourceDefs = new ArrayList<>();
@@ -170,7 +168,7 @@ public class TestRangerDefaultAuditHandler {
         Assertions.assertEquals("clusterA", event.getClusterName());
         Assertions.assertEquals("zone-1", event.getZoneName());
         Assertions.assertEquals(Long.valueOf(7L), event.getPolicyVersion());
-        Assertions.assertEquals("my-host", event.getAgentHostname());
+        Assertions.assertTrue(StringUtils.isNotBlank(event.getAgentHostname()));
         Assertions.assertNotNull(event.getEventId());
         Assertions.assertEquals(event.getEventId(), result.getAuditLogId());
         Assertions.assertEquals("RangerAudit", event.getLogType());

--- a/distro/src/main/assembly/admin-web.xml
+++ b/distro/src/main/assembly/admin-web.xml
@@ -255,9 +255,6 @@
           <include>org.codehaus.woodstox:stax2-api:jar:${codehaus.woodstox.stax2api.version}</include>
           <include>org.apache.commons:commons-configuration2:jar:${commons.configuration.version}</include>
           <include>org.apache.commons:commons-lang3:jar:${commons.lang3.version}</include>
-          <include>com.kstruct:gethostname4j:jar:${kstruct.gethostname4j.version}</include>
-          <include>net.java.dev.jna:jna:jar:${jna.version}</include>
-          <include>net.java.dev.jna:jna-platform:jar:${jna-platform.version}</include>
           <include>org.apache.ranger:credentialbuilder</include>
           <include>org.elasticsearch.client:elasticsearch-rest-client</include>
           <include>org.elasticsearch.client:elasticsearch-rest-high-level-client</include>

--- a/distro/src/main/assembly/hbase-agent.xml
+++ b/distro/src/main/assembly/hbase-agent.xml
@@ -70,9 +70,6 @@
           <include>org.apache.httpcomponents:httpmime:jar:${httpcomponents.httpmime.version}</include>
           <include>org.noggit:noggit:jar:${noggit.version}</include>
           <include>org.apache.solr:solr-solrj:jar:${solr.version}</include>
-          <include>com.kstruct:gethostname4j:jar:${kstruct.gethostname4j.version}</include>
-          <include>net.java.dev.jna:jna:jar:${jna.version}</include>
-          <include>net.java.dev.jna:jna-platform:jar:${jna-platform.version}</include>
           <include>org.elasticsearch:elasticsearch</include>
           <include>org.elasticsearch:elasticsearch-core</include>
           <include>org.elasticsearch:elasticsearch-x-content</include>

--- a/distro/src/main/assembly/hdfs-agent.xml
+++ b/distro/src/main/assembly/hdfs-agent.xml
@@ -97,9 +97,6 @@
           <include>org.apache.httpcomponents:httpcore:jar:${httpcomponents.httpcore.version}</include>
           <include>org.noggit:noggit:jar:${noggit.version}</include>
           <include>org.apache.solr:solr-solrj:jar:${solr.version}</include>
-          <include>com.kstruct:gethostname4j:jar:${kstruct.gethostname4j.version}</include>
-          <include>net.java.dev.jna:jna:jar:${jna.version}</include>
-          <include>net.java.dev.jna:jna-platform:jar:${jna-platform.version}</include>
           <include>org.elasticsearch:elasticsearch</include>
           <include>org.elasticsearch:elasticsearch-core</include>
           <include>org.elasticsearch:elasticsearch-x-content</include>

--- a/distro/src/main/assembly/hive-agent.xml
+++ b/distro/src/main/assembly/hive-agent.xml
@@ -66,9 +66,6 @@
           <include>org.apache.httpcomponents:httpcore:jar:${httpcomponents.httpcore.version}</include>
           <include>org.noggit:noggit:jar:${noggit.version}</include>
           <include>org.apache.solr:solr-solrj:jar:${solr.version}</include>
-          <include>com.kstruct:gethostname4j:jar:${kstruct.gethostname4j.version}</include>
-          <include>net.java.dev.jna:jna:jar:${jna.version}</include>
-          <include>net.java.dev.jna:jna-platform:jar:${jna-platform.version}</include>
           <include>org.elasticsearch:elasticsearch</include>
           <include>org.elasticsearch:elasticsearch-core</include>
           <include>org.elasticsearch:elasticsearch-x-content</include>

--- a/distro/src/main/assembly/kms.xml
+++ b/distro/src/main/assembly/kms.xml
@@ -217,9 +217,6 @@
                     <include>org.apache.solr:solr-solrj:jar:${solr.version}</include>
                     <include>org.apache.ranger:ranger-common-utils</include>
                     <include>org.apache.ranger:ugsync-util</include>
-                    <include>com.kstruct:gethostname4j:jar:${kstruct.gethostname4j.version}</include>
-                    <include>net.java.dev.jna:jna:jar:${jna.version}</include>
-                    <include>net.java.dev.jna:jna-platform:jar:${jna-platform.version}</include>
                     <include>org.apache.ranger:credentialbuilder</include>
                     <include>org.apache.commons:commons-collections4:jar:${commons.collections4.version}</include>
                     <include>org.apache.commons:commons-compress:jar:${commons.compress.version}</include>
@@ -311,9 +308,6 @@
                             <include>org.noggit:noggit:jar:${noggit.version}</include>
                             <include>org.apache.zookeeper:zookeeper:jar:${zookeeper.version}</include>
                             <include>org.apache.solr:solr-solrj:jar:${solr.version}</include>
-                            <include>com.kstruct:gethostname4j:jar:${kstruct.gethostname4j.version}</include>
-                            <include>net.java.dev.jna:jna:jar:${jna.version}</include>
-                            <include>net.java.dev.jna:jna-platform:jar:${jna-platform.version}</include>
                             <include>org.elasticsearch:elasticsearch</include>
                             <include>org.elasticsearch:elasticsearch-core</include>
                             <include>org.elasticsearch:elasticsearch-x-content</include>

--- a/distro/src/main/assembly/knox-agent.xml
+++ b/distro/src/main/assembly/knox-agent.xml
@@ -75,9 +75,6 @@
           <include>com.fasterxml.jackson.core:jackson-core:jar:${fasterxml.jackson.version}</include>
           <include>com.fasterxml.jackson.core:jackson-databind:jar:${fasterxml.jackson.version}</include>
           <include>org.apache.solr:solr-solrj:jar:${solr.version}</include>
-          <include>com.kstruct:gethostname4j:jar:${kstruct.gethostname4j.version}</include>
-          <include>net.java.dev.jna:jna:jar:${jna.version}</include>
-          <include>net.java.dev.jna:jna-platform:jar:${jna-platform.version}</include>
           <include>org.elasticsearch:elasticsearch</include>
           <include>org.elasticsearch:elasticsearch-core</include>
           <include>org.elasticsearch:elasticsearch-x-content</include>

--- a/distro/src/main/assembly/pdp.xml
+++ b/distro/src/main/assembly/pdp.xml
@@ -126,11 +126,6 @@
                     <include>org.apache.zookeeper:zookeeper:jar:${zookeeper.version}</include>
                     <include>org.noggit:noggit</include>
 
-                    <!-- Native libs (hostname lookup) -->
-                    <include>com.kstruct:gethostname4j</include>
-                    <include>net.java.dev.jna:jna</include>
-                    <include>net.java.dev.jna:jna-platform</include>
-
                     <!-- Logging -->
                     <include>org.slf4j:slf4j-api:jar:${slf4j.version}</include>
                     <include>ch.qos.logback:logback-classic:jar:${logback.version}</include>

--- a/distro/src/main/assembly/plugin-atlas.xml
+++ b/distro/src/main/assembly/plugin-atlas.xml
@@ -72,9 +72,6 @@
           <include>org.apache.httpcomponents:httpclient:jar:${httpcomponents.httpclient.version}</include>
           <include>org.apache.httpcomponents:httpcore:jar:${httpcomponents.httpcore.version}</include>
           <include>org.apache.solr:solr-solrj:jar:${solr.version}</include>
-          <include>com.kstruct:gethostname4j:jar:${kstruct.gethostname4j.version}</include>
-          <include>net.java.dev.jna:jna:jar:${jna.version}</include>
-          <include>net.java.dev.jna:jna-platform:jar:${jna-platform.version}</include>
           <include>com.fasterxml.woodstox:woodstox-core:jar:${fasterxml.woodstox.version}</include>
           <include>org.codehaus.woodstox:stax2-api:jar:${codehaus.woodstox.stax2api.version}</include>
           <include>org.apache.commons:commons-configuration2:jar:${commons.configuration.version}</include>

--- a/distro/src/main/assembly/plugin-elasticsearch.xml
+++ b/distro/src/main/assembly/plugin-elasticsearch.xml
@@ -87,9 +87,6 @@
           <include>com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:jar:${fasterxml.jackson.version}</include>
           <include>org.apache.solr:solr-solrj:jar:${solr.version}</include>
           <include>commons-codec:commons-codec</include>
-          <include>com.kstruct:gethostname4j:jar:${kstruct.gethostname4j.version}</include>
-          <include>net.java.dev.jna:jna:jar:${jna.version}</include>
-          <include>net.java.dev.jna:jna-platform:jar:${jna-platform.version}</include>
           <include>org.elasticsearch:elasticsearch</include>
           <include>org.elasticsearch:elasticsearch-core</include>
           <include>org.elasticsearch:elasticsearch-x-content</include>

--- a/distro/src/main/assembly/plugin-kafka.xml
+++ b/distro/src/main/assembly/plugin-kafka.xml
@@ -82,9 +82,6 @@
 					<include>commons-codec:commons-codec</include>
 					<include>org.codehaus.woodstox:stax2-api</include>
 					<include>com.fasterxml.woodstox:woodstox-core</include>
-					<include>com.kstruct:gethostname4j:jar:${kstruct.gethostname4j.version}</include>
-					<include>net.java.dev.jna:jna:jar:${jna.version}</include>
-					<include>net.java.dev.jna:jna-platform:jar:${jna-platform.version}</include>
 					<include>org.elasticsearch:elasticsearch</include>
 					<include>org.elasticsearch:elasticsearch-core</include>
 					<include>org.elasticsearch:elasticsearch-x-content</include>

--- a/distro/src/main/assembly/plugin-kms.xml
+++ b/distro/src/main/assembly/plugin-kms.xml
@@ -70,9 +70,6 @@
           <include>org.noggit:noggit:jar:${noggit.version}</include>
           <include>org.apache.zookeeper:zookeeper:jar:${zookeeper.version}</include>
           <include>org.apache.solr:solr-solrj:jar:${solr.version}</include>
-          <include>com.kstruct:gethostname4j:jar:${kstruct.gethostname4j.version}</include>
-          <include>net.java.dev.jna:jna:jar:${jna.version}</include>
-          <include>net.java.dev.jna:jna-platform:jar:${jna-platform.version}</include>
           <include>org.apache.hive:hive-storage-api:jar:${hive.storage-api.version}</include>
           <include>org.apache.orc:orc-core:jar:${orc.version}</include>
           <include>org.apache.orc:orc-shims:jar:${orc.version}</include>

--- a/distro/src/main/assembly/plugin-kylin.xml
+++ b/distro/src/main/assembly/plugin-kylin.xml
@@ -69,9 +69,6 @@
               <include>org.apache.httpcomponents:httpcore:jar:${httpcomponents.httpcore.version}</include>
               <include>org.noggit:noggit:jar:${noggit.version}</include>
               <include>org.apache.solr:solr-solrj:jar:${solr.version}</include>
-              <include>com.kstruct:gethostname4j:jar:${kstruct.gethostname4j.version}</include>
-              <include>net.java.dev.jna:jna:jar:${jna.version}</include>
-              <include>net.java.dev.jna:jna-platform:jar:${jna-platform.version}</include>
               <include>org.elasticsearch:elasticsearch</include>
               <include>org.elasticsearch:elasticsearch-core</include>
               <include>org.elasticsearch:elasticsearch-x-content</include>

--- a/distro/src/main/assembly/plugin-ozone.xml
+++ b/distro/src/main/assembly/plugin-ozone.xml
@@ -50,7 +50,6 @@
                 <unpack>false</unpack>
                 <includes>
                     <include>com.fasterxml.woodstox:woodstox-core:jar:${fasterxml.woodstox.version}</include>
-                    <include>com.kstruct:gethostname4j</include>
                     <include>com.sun.jersey:jersey-client:jar:${jersey-bundle.version}</include>
                     <include>com.sun.jersey:jersey-core:jar:${jersey-bundle.version}</include>
                     <include>javax.ws.rs:jsr311-api:jar:${jsr311-api.version}</include>
@@ -59,8 +58,6 @@
                     <include>commons-configuration:commons-configuration:jar:${commons.configuration1.version}</include>
                     <include>commons-io:commons-io:jar:${commons.io.version}</include>
                     <include>commons-logging:commons-logging:jar:${commons.logging.version}</include>
-                    <include>net.java.dev.jna:jna</include>
-                    <include>net.java.dev.jna:jna-platform</include>
                     <include>org.apache.commons:commons-collections4:jar:${commons.collections4.version}</include>
                     <include>org.apache.commons:commons-compress:jar:${commons.compress.version}</include>
                     <include>org.apache.commons:commons-configuration2:jar:${commons.configuration.version}</include>
@@ -117,9 +114,6 @@
                     <include>com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:jar:${fasterxml.jackson.version}</include>
                     <include>com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:jar:${fasterxml.jackson.version}</include>
 		            <include>com.sun.xml.bind:jaxb-impl</include>
-                    <include>com.kstruct:gethostname4j</include>
-                    <include>net.java.dev.jna:jna</include>
-                    <include>net.java.dev.jna:jna-platform</include>
                     <include>org.elasticsearch:elasticsearch</include>
                     <include>org.elasticsearch:elasticsearch-core</include>
                     <include>org.elasticsearch:elasticsearch-x-content</include>

--- a/distro/src/main/assembly/plugin-presto.xml
+++ b/distro/src/main/assembly/plugin-presto.xml
@@ -103,9 +103,6 @@
                     <include>com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:jar:${fasterxml.jackson.version}</include>
                     <include>com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:jar:${fasterxml.jackson.version}</include>
                     <include>org.apache.zookeeper:zookeeper:jar:${zookeeper.version}</include>
-                    <include>net.java.dev.jna:jna</include>
-                    <include>net.java.dev.jna:jna-platform</include>
-                    <include>com.kstruct:gethostname4j</include>
                     <include>org.elasticsearch:elasticsearch</include>
                     <include>org.elasticsearch:elasticsearch-core</include>
                     <include>org.elasticsearch:elasticsearch-x-content</include>

--- a/distro/src/main/assembly/plugin-solr.xml
+++ b/distro/src/main/assembly/plugin-solr.xml
@@ -65,9 +65,6 @@
           <include>com.fasterxml.jackson.core:jackson-databind:jar:${fasterxml.jackson.version}</include>
           <include>com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:jar:${fasterxml.jackson.version}</include>
           <include>com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:jar:${fasterxml.jackson.version}</include>
-          <include>com.kstruct:gethostname4j:jar:${kstruct.gethostname4j.version}</include>
-          <include>net.java.dev.jna:jna:jar:${jna.version}</include>
-          <include>net.java.dev.jna:jna-platform:jar:${jna-platform.version}</include>
           <include>org.elasticsearch:elasticsearch</include>
           <include>org.elasticsearch:elasticsearch-core</include>
           <include>org.elasticsearch:elasticsearch-x-content</include>

--- a/distro/src/main/assembly/plugin-sqoop.xml
+++ b/distro/src/main/assembly/plugin-sqoop.xml
@@ -65,9 +65,6 @@
           <include>org.apache.httpcomponents:httpcore:jar:${httpcomponents.httpcore.version}</include>
           <include>org.noggit:noggit:jar:${noggit.version}</include>
           <include>org.apache.solr:solr-solrj:jar:${solr.version}</include>
-          <include>com.kstruct:gethostname4j:jar:${kstruct.gethostname4j.version}</include>
-          <include>net.java.dev.jna:jna:jar:${jna.version}</include>
-          <include>net.java.dev.jna:jna-platform:jar:${jna-platform.version}</include>
           <include>org.elasticsearch:elasticsearch</include>
           <include>org.elasticsearch:elasticsearch-core</include>
           <include>org.elasticsearch:elasticsearch-x-content</include>

--- a/distro/src/main/assembly/plugin-trino.xml
+++ b/distro/src/main/assembly/plugin-trino.xml
@@ -95,9 +95,6 @@
                     <include>com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:jar:${fasterxml.jackson.version}</include>
                     <include>com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:jar:${fasterxml.jackson.version}</include>
                     <include>org.apache.zookeeper:zookeeper:jar:${zookeeper.version}</include>
-                    <include>net.java.dev.jna:jna</include>
-                    <include>net.java.dev.jna:jna-platform</include>
-                    <include>com.kstruct:gethostname4j</include>
                     <include>org.elasticsearch:elasticsearch</include>
                     <include>org.elasticsearch:elasticsearch-core</include>
                     <include>org.elasticsearch:elasticsearch-x-content</include>

--- a/distro/src/main/assembly/plugin-yarn.xml
+++ b/distro/src/main/assembly/plugin-yarn.xml
@@ -65,9 +65,6 @@
           <include>org.apache.httpcomponents:httpcore:jar:${httpcomponents.httpcore.version}</include>
           <include>org.noggit:noggit:jar:${noggit.version}</include>
           <include>org.apache.solr:solr-solrj:jar:${solr.version}</include>
-          <include>com.kstruct:gethostname4j:jar:${kstruct.gethostname4j.version}</include>
-          <include>net.java.dev.jna:jna:jar:${jna.version}</include>
-          <include>net.java.dev.jna:jna-platform:jar:${jna-platform.version}</include>
           <include>org.elasticsearch:elasticsearch</include>
           <include>org.elasticsearch:elasticsearch-core</include>
           <include>org.elasticsearch:elasticsearch-x-content</include>

--- a/distro/src/main/assembly/ranger-tools.xml
+++ b/distro/src/main/assembly/ranger-tools.xml
@@ -71,9 +71,6 @@
               <include>org.apache.ranger:ranger-plugins-common</include>
               <include>org.apache.ranger:ugsync-util</include>
               <include>org.apache.ranger:ranger-plugins-audit</include>
-              <include>com.kstruct:gethostname4j:jar:${kstruct.gethostname4j.version}</include>
-              <include>net.java.dev.jna:jna:jar:${jna.version}</include>
-              <include>net.java.dev.jna:jna-platform:jar:${jna-platform.version}</include>
               <include>org.slf4j:slf4j-api</include>
               <include>org.apache.hadoop.thirdparty:hadoop-shaded-guava:jar:${hadoop-shaded-guava.version}</include>
               <include>org.slf4j:log4j-over-slf4j:jar:${slf4j.version}</include>

--- a/distro/src/main/assembly/sample-client.xml
+++ b/distro/src/main/assembly/sample-client.xml
@@ -68,9 +68,6 @@
                     <include>org.apache.ranger:ranger-audit-core</include>
                     <include>org.apache.ranger:ranger-audit-dest-hdfs</include>
                     <include>org.apache.ranger:ranger-audit-dest-solr</include>
-                    <include>com.kstruct:gethostname4j:jar:${kstruct.gethostname4j.version}</include>
-                    <include>net.java.dev.jna:jna:jar:${jna.version}</include>
-                    <include>net.java.dev.jna:jna-platform:jar:${jna-platform.version}</include>
                     <include>com.fasterxml.woodstox:woodstox-core:jar:${fasterxml.woodstox.version}</include>
                     <include>org.codehaus.woodstox:stax2-api:jar:${codehaus.woodstox.stax2api.version}</include>
                     <include>org.apache.hadoop.thirdparty:hadoop-shaded-guava:jar:${hadoop-shaded-guava.version}</include>

--- a/distro/src/main/assembly/storm-agent.xml
+++ b/distro/src/main/assembly/storm-agent.xml
@@ -89,9 +89,6 @@
               <include>com.fasterxml.jackson.core:jackson-core</include>
               <include>org.apache.solr:solr-solrj:jar:${solr.version}</include>
               <include>commons-codec:commons-codec</include>
-              <include>com.kstruct:gethostname4j:jar:${kstruct.gethostname4j.version}</include>
-              <include>net.java.dev.jna:jna:jar:${jna.version}</include>
-              <include>net.java.dev.jna:jna-platform:jar:${jna-platform.version}</include>
               <include>org.elasticsearch:elasticsearch</include>
               <include>org.elasticsearch:elasticsearch-core</include>
               <include>org.elasticsearch:elasticsearch-x-content</include>

--- a/distro/src/main/assembly/tagsync.xml
+++ b/distro/src/main/assembly/tagsync.xml
@@ -84,9 +84,6 @@
 							<include>joda-time:joda-time:jar:${joda-time.version}</include>
 							<include>org.codehaus.woodstox:stax2-api</include>
 							<include>com.fasterxml.woodstox:woodstox-core</include>
-							<include>com.kstruct:gethostname4j:jar:${kstruct.gethostname4j.version}</include>
-							<include>net.java.dev.jna:jna:jar:${jna.version}</include>
-							<include>net.java.dev.jna:jna-platform:jar:${jna-platform.version}</include>
 							<include>com.fasterxml.woodstox:woodstox-core:jar:${fasterxml.woodstox.version}</include>
 							<include>org.codehaus.woodstox:stax2-api:jar:${codehaus.woodstox.stax2api.version}</include>
 							<include>org.apache.commons:commons-collections4:jar:${commons.collections4.version}</include>

--- a/distro/src/main/assembly/usersync.xml
+++ b/distro/src/main/assembly/usersync.xml
@@ -66,9 +66,6 @@
 							<include>org.apache.zookeeper:zookeeper:jar:${zookeeper.version}</include>
 							<include>org.apache.zookeeper:zookeeper-jute:jar:${zookeeper.version}</include>
 							<include>org.apache.ranger:ugsync-util</include>
-							<include>com.kstruct:gethostname4j:jar:${kstruct.gethostname4j.version}</include>
-							<include>net.java.dev.jna:jna:jar:${jna.version}</include>
-							<include>net.java.dev.jna:jna-platform:jar:${jna-platform.version}</include>
 							<include>com.fasterxml.woodstox:woodstox-core:jar:${fasterxml.woodstox.version}</include>
 							<include>org.codehaus.woodstox:stax2-api:jar:${codehaus.woodstox.stax2api.version}</include>
 							<include>org.apache.commons:commons-collections4:jar:${commons.collections4.version}</include>

--- a/pom.xml
+++ b/pom.xml
@@ -146,8 +146,6 @@
         <jettison.version>1.5.4</jettison.version>
         <jetty-client.version>9.4.56.v20240826</jetty-client.version>
         <jline.version>0.9.94</jline.version>
-        <jna-platform.version>5.7.0</jna-platform.version>
-        <jna.version>5.7.0</jna.version>
         <joda.time.version>2.10.6</joda.time.version>
         <jopt-simple.version>3.2</jopt-simple.version>
         <json4s.version>3.2.11</json4s.version>
@@ -159,7 +157,6 @@
         <kafka.version>3.9.1</kafka.version>
         <kerby.version>2.0.3</kerby.version>
         <knox.gateway.version>2.0.0</knox.gateway.version>
-        <kstruct.gethostname4j.version>1.0.0</kstruct.gethostname4j.version>
         <kylin.version>4.0.4</kylin.version>
         <libpam4j.version>1.10</libpam4j.version>
         <libthrift.version>0.14.0</libthrift.version>

--- a/ranger-examples/distro/src/main/assembly/sample-client.xml
+++ b/ranger-examples/distro/src/main/assembly/sample-client.xml
@@ -57,9 +57,6 @@
                     <include>com.fasterxml.jackson.core:jackson-databind:jar:${fasterxml.jackson.version}</include>
                     <include>com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:jar:${fasterxml.jackson.version}</include>
                     <include>org.apache.ranger:ranger-audit-core</include>
-                    <include>com.kstruct:gethostname4j:jar:${kstruct.gethostname4j.version}</include>
-                    <include>net.java.dev.jna:jna:jar:${jna.version}</include>
-                    <include>net.java.dev.jna:jna-platform:jar:${jna-platform.version}</include>
                     <include>com.fasterxml.woodstox:woodstox-core:jar:${fasterxml.woodstox.version}</include>
                     <include>org.codehaus.woodstox:stax2-api:jar:${codehaus.woodstox.stax2api.version}</include>
                 </includes>

--- a/ranger-presto-plugin-shim/pom.xml
+++ b/ranger-presto-plugin-shim/pom.xml
@@ -46,12 +46,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.kstruct</groupId>
-            <artifactId>gethostname4j</artifactId>
-            <version>${kstruct.gethostname4j.version}</version>
-        </dependency>
-
-        <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
             <version>${commons.codec.version}</version>
@@ -89,18 +83,6 @@
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
             <version>${presto.validation-api.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>net.java.dev.jna</groupId>
-            <artifactId>jna</artifactId>
-            <version>${jna.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>net.java.dev.jna</groupId>
-            <artifactId>jna-platform</artifactId>
-            <version>${jna-platform.version}</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Replaced use of `com.kstruct.gethostname4j.Hostname.getHostname()` with env variable lookup `HOSTNAME` or `COMPUTERNAME`), with fallback to `InetAddress.getLocalHost().getHostName()`.

## How was this patch tested?

Using docker setup, verified that plugins report correct hostname in audit logs.