### PR TITLE
RANGER-5552: Remove ozone-2.1.0-rc repository from pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -768,11 +768,6 @@
             <name>jetbrains-intellij-dependencies</name>
             <url>https://packages.jetbrains.team/maven/p/ij/intellij-dependencies</url>
         </repository>
-        <repository>
-            <id>ozone-2.1.0-rc</id>
-            <name>ozone-2.1.0-rc</name>
-            <url>https://repository.apache.org/content/repositories/orgapacheozone-1061</url>
-        </repository>
     </repositories>
     <distributionManagement>
         <repository>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Apache Ozone 2.1.0 has released, clean up maven repo reference in pom.xml

## How was this patch tested?

Existing unit tests with CI
