### PR TITLE
RANGER-5546: Polaris service-def update to change label Root to Realm Identifier

### DIFF
--- a/agents-common/src/main/resources/service-defs/ranger-servicedef-polaris.json
+++ b/agents-common/src/main/resources/service-defs/ranger-servicedef-polaris.json
@@ -8,8 +8,8 @@
     {
       "itemId":      1,
       "name":        "root",
-      "label":       "Root",
-      "description": "Root",
+      "label":       "Realm Identifier",
+      "description": "Realm Identifier",
       "parent":      "",
       "level":       10,
       "isValidLeaf": true,


### PR DESCRIPTION
## What changes were proposed in this pull request?

Polaris service-def updated to change label `Root` to `Realm Identifier`

## How was this patch tested?

Verified that Ranger UI for Polaris policies show the updated label.