### PR TITLE
RANGER-5583: Fix Ranger PDP startup and installation in docker

### DIFF
--- a/agents-audit/dest-solr/pom.xml
+++ b/agents-audit/dest-solr/pom.xml
@@ -33,6 +33,11 @@
     </properties>
     <dependencies>
         <dependency>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+            <version>${commons.logging.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpasyncclient</artifactId>
             <version>${httpcomponents.httpasyncclient.version}</version>

--- a/dev-support/ranger-docker/docker-compose.ranger-pdp.yml
+++ b/dev-support/ranger-docker/docker-compose.ranger-pdp.yml
@@ -58,4 +58,3 @@ services:
 networks:
   ranger:
     name: rangernw
-    external: true

--- a/distro/src/main/assembly/pdp.xml
+++ b/distro/src/main/assembly/pdp.xml
@@ -64,6 +64,8 @@
                     <include>org.glassfish.jersey.inject:jersey-hk2</include>
                     <include>org.glassfish.jersey.media:jersey-media-json-jackson</include>
                     <include>jakarta.ws.rs:jakarta.ws.rs-api</include>
+                    <include>jakarta.xml.bind:jakarta.xml.bind-api:jar:${jakarta.xml.bind-api.version}</include>
+                    <include>jakarta.activation:jakarta.activation-api:jar:${jakarta.activation-api.version}</include>
                     <include>javax.inject:javax.inject</include>
                     <include>javax.validation:validation-api</include>
 

--- a/pdp/pom.xml
+++ b/pdp/pom.xml
@@ -61,9 +61,19 @@
             <version>${commons.codec.version}</version>
         </dependency>
         <dependency>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
+            <version>${jakarta.activation-api.version}</version>
+        </dependency>
+        <dependency>
             <groupId>jakarta.ws.rs</groupId>
             <artifactId>jakarta.ws.rs-api</artifactId>
             <version>${jakarta.ws.rs-api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>${jakarta.xml.bind-api.version}</version>
         </dependency>
         <dependency>
             <groupId>javax.validation</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixes `ranger-pdp` startup and installation in docker container.


## How was this patch tested?

```
export RANGER_DB_TYPE=postgres
docker compose -f docker-compose.ranger.yml -f docker-compose.ranger-pdp.yml build
docker compose -f docker-compose.ranger.yml -f docker-compose.ranger-pdp.yml up -d
```
- Verified no errors are seen in application logs for pdp server.
