### PR TITLE
RANGER-5577:API to support bulk delete of resources in DataShare

### DIFF
--- a/security-admin/src/main/java/org/apache/ranger/rest/GdsREST.java
+++ b/security-admin/src/main/java/org/apache/ranger/rest/GdsREST.java
@@ -1292,12 +1292,16 @@ public class GdsREST {
     @DELETE
     @Path("/resources")
     @PreAuthorize("@rangerPreAuthSecurityHandler.isAPIAccessible(\"" + RangerAPIList.REMOVE_SHARED_RESOURCES + "\")")
-    public void removeSharedResources(List<Long> resourceIds) {
-        LOG.debug("==> GdsREST.removeSharedResources({})", resourceIds);
+    public void removeSharedResources(@QueryParam("resourceIds") List<Long> resourceIds) {
+        LOG.debug("==> GdsREST.removeSharedResources(resourceIds={})", resourceIds);
 
         RangerPerfTracer perf = null;
 
         try {
+            if (resourceIds == null) {
+                throw new Exception("resourceIds must not be null");
+            }
+
             if (resourceIds.size() > SHARED_RESOURCES_MAX_BATCH_SIZE) {
                 throw new Exception("removeSharedResources batch size exceeded the configured limit: Maximum allowed is " + SHARED_RESOURCES_MAX_BATCH_SIZE);
             }
@@ -1317,7 +1321,7 @@ public class GdsREST {
             RangerPerfTracer.log(perf);
         }
 
-        LOG.debug("<== GdsREST.removeSharedResources({})", resourceIds);
+        LOG.debug("<== GdsREST.removeSharedResources(resourceIds={})", resourceIds);
     }
 
     @GET

--- a/security-admin/src/main/java/org/apache/ranger/rest/GdsREST.java
+++ b/security-admin/src/main/java/org/apache/ranger/rest/GdsREST.java
@@ -1292,36 +1292,36 @@ public class GdsREST {
     @DELETE
     @Path("/resources")
     @PreAuthorize("@rangerPreAuthSecurityHandler.isAPIAccessible(\"" + RangerAPIList.REMOVE_SHARED_RESOURCES + "\")")
-    public void removeSharedResources(@QueryParam("resourceIds") List<Long> resourceIds) {
-        LOG.debug("==> GdsREST.removeSharedResources(resourceIds={})", resourceIds);
+    public void removeSharedResources(@QueryParam("id") List<Long> id) {
+        LOG.debug("==> GdsREST.removeSharedResources(resourceIds={})", id);
 
         RangerPerfTracer perf = null;
 
         try {
-            if (resourceIds == null) {
+            if (id == null) {
                 throw new Exception("resourceIds must not be null");
             }
 
-            if (resourceIds.size() > SHARED_RESOURCES_MAX_BATCH_SIZE) {
+            if (id.size() > SHARED_RESOURCES_MAX_BATCH_SIZE) {
                 throw new Exception("removeSharedResources batch size exceeded the configured limit: Maximum allowed is " + SHARED_RESOURCES_MAX_BATCH_SIZE);
             }
 
             if (RangerPerfTracer.isPerfTraceEnabled(PERF_LOG)) {
-                perf = RangerPerfTracer.getPerfTracer(PERF_LOG, "GdsREST.removeSharedResources(" + resourceIds + ")");
+                perf = RangerPerfTracer.getPerfTracer(PERF_LOG, "GdsREST.removeSharedResources(" + id + ")");
             }
 
-            gdsStore.removeSharedResources(resourceIds);
+            gdsStore.removeSharedResources(id);
         } catch (WebApplicationException excp) {
             throw excp;
         } catch (Throwable excp) {
-            LOG.error("removeSharedResources({}) failed", resourceIds, excp);
+            LOG.error("removeSharedResources({}) failed", id, excp);
 
             throw restErrorUtil.createRESTException(excp.getMessage());
         } finally {
             RangerPerfTracer.log(perf);
         }
 
-        LOG.debug("<== GdsREST.removeSharedResources(resourceIds={})", resourceIds);
+        LOG.debug("<== GdsREST.removeSharedResources(resourceIds={})", id);
     }
 
     @GET

--- a/security-admin/src/test/java/org/apache/ranger/rest/TestGdsREST.java
+++ b/security-admin/src/test/java/org/apache/ranger/rest/TestGdsREST.java
@@ -963,6 +963,13 @@ public class TestGdsREST {
     }
 
     @Test
+    public void testRemoveSharedResourcesNullResourceIds() {
+        Mockito.when(restErrorUtil.createRESTException(Mockito.anyString())).thenReturn(new WebApplicationException());
+
+        assertThrows(WebApplicationException.class, () -> gdsREST.removeSharedResources(null));
+    }
+
+    @Test
     public void testGetSharedResource() {
         Long resourceId = 1L;
         RangerGds.RangerSharedResource expected = createSharedResource();


### PR DESCRIPTION
## What changes were proposed in this pull request?
 To have the API to support bulk delete by getting the resources Id as query param.

## How was this patch tested?
Test in local via with curl call.
` curl -ikv --negotiate -u : -H "Accept: application/json" -H "Content-Type: application/json" -X GET 'https://<ranger-admin-host>:6182/service/gds/resources?Id=2'

curl -ikv --negotiate -u : -H "Accept: application/json" -H "Content-Type: application/json" -X DELETE 'https://<ranger-admin-host>:6182:6182/service/gds/resources?id=9&id=10'
`
