### PR TITLE
RANGER-5586:Ranger Admin UI Fails to Load Access Page Due to Solr Integration Error in Docker Deployment

### DIFF
--- a/dev-support/ranger-docker/scripts/admin/ranger-admin-install-mysql.properties
+++ b/dev-support/ranger-docker/scripts/admin/ranger-admin-install-mysql.properties
@@ -44,7 +44,7 @@ keyadmin_password=rangerR0cks!
 
 
 audit_store=solr
-audit_solr_urls=http://ranger-solr:8983/solr/ranger_audits
+audit_solr_urls=http://ranger-solr.rangernw:8983/solr/ranger_audits
 audit_solr_collection_name=ranger_audits
 
 # audit_store=elasticsearch

--- a/dev-support/ranger-docker/scripts/admin/ranger-admin-install-oracle.properties
+++ b/dev-support/ranger-docker/scripts/admin/ranger-admin-install-oracle.properties
@@ -46,7 +46,7 @@ keyadmin_password=rangerR0cks!
 
 
 audit_store=solr
-audit_solr_urls=http://ranger-solr:8983/solr/ranger_audits
+audit_solr_urls=http://ranger-solr.rangernw:8983/solr/ranger_audits
 audit_solr_collection_name=ranger_audits
 
 # audit_store=elasticsearch

--- a/dev-support/ranger-docker/scripts/admin/ranger-admin-install-postgres.properties
+++ b/dev-support/ranger-docker/scripts/admin/ranger-admin-install-postgres.properties
@@ -44,7 +44,7 @@ keyadmin_password=rangerR0cks!
 
 
 audit_store=solr
-audit_solr_urls=http://ranger-solr:8983/solr/ranger_audits
+audit_solr_urls=http://ranger-solr.rangernw:8983/solr/ranger_audits
 audit_solr_collection_name=ranger_audits
 
 # audit_store=elasticsearch

--- a/dev-support/ranger-docker/scripts/admin/ranger-admin-install-sqlserver.properties
+++ b/dev-support/ranger-docker/scripts/admin/ranger-admin-install-sqlserver.properties
@@ -53,7 +53,7 @@ keyadmin_password=rangerR0cks!
 
 
 audit_store=solr
-audit_solr_urls=http://ranger-solr:8983/solr/ranger_audits
+audit_solr_urls=http://ranger-solr.rangernw:8983/solr/ranger_audits
 audit_solr_collection_name=ranger_audits
 
 # audit_store=elasticsearch


### PR DESCRIPTION
## What changes were proposed in this pull request?
Updated the audit_solr_urls configuration in Ranger Docker admin property files to use the Docker network hostname ranger-solr.rangernw instead of ranger-solr. This fixes Solr connectivity issues causing the Ranger Admin Access Logs page to fail in Docker deployments.


## How was this patch tested?
Tested manually by deploying Ranger using Docker, accessing the Ranger Admin UI, and verifying that the Access Logs page loaded successfully without Solr errors.
