### PR TITLE
Ranger -5587 modified and condition to or to resolve the issue of definition id  s…

### DIFF
--- a/security-admin/src/main/java/org/apache/ranger/rest/ServiceREST.java
+++ b/security-admin/src/main/java/org/apache/ranger/rest/ServiceREST.java
@@ -359,7 +359,7 @@ public class ServiceREST {
         // if serviceDef.id is null, then set param 'id' into serviceDef Object
         if (serviceDef.getId() == null) {
             serviceDef.setId(id);
-        } else if (StringUtils.isBlank(serviceDef.getName()) && !serviceDef.getId().equals(id)) {
+        } else if (StringUtils.isBlank(serviceDef.getName()) || !serviceDef.getId().equals(id)) {
             throw restErrorUtil.createRESTException(HttpServletResponse.SC_BAD_REQUEST, "serviceDef Id mismatch", true);
         }
 


### PR DESCRIPTION
…ynchronization in put /definitions/{id}

## What changes were proposed in this pull request?
 The  PUT api    http://localhost:6080/service/plugins/definitions/{id}   is not throwing error when different id is passed from url and json payload , the issue is because in of a && condition updateServiceDef in ServiceREST which should have been OR ,I have  changed it  . On changing the And condition to or it is proprly throwing error as expected . 


