### PR TITLE
Ranger -5587 modified && condition to OR  to resolve the issue of definition id 

### DIFF
--- a/security-admin/src/main/java/org/apache/ranger/rest/ServiceREST.java
+++ b/security-admin/src/main/java/org/apache/ranger/rest/ServiceREST.java
@@ -359,7 +359,7 @@ public class ServiceREST {
         // if serviceDef.id is null, then set param 'id' into serviceDef Object
         if (serviceDef.getId() == null) {
             serviceDef.setId(id);
-        } else if (StringUtils.isBlank(serviceDef.getName()) && !serviceDef.getId().equals(id)) {
+        } else if (StringUtils.isBlank(serviceDef.getName()) || !serviceDef.getId().equals(id)) {
             throw restErrorUtil.createRESTException(HttpServletResponse.SC_BAD_REQUEST, "serviceDef Id mismatch", true);
         }
 

--- a/security-admin/src/test/java/org/apache/ranger/rest/TestServiceREST.java
+++ b/security-admin/src/test/java/org/apache/ranger/rest/TestServiceREST.java
@@ -395,6 +395,20 @@ public class TestServiceREST {
     public void test2updateServiceDef() throws Exception {
         RangerServiceDef rangerServiceDef = rangerServiceDef();
 
+        // Ensure the service def has a name to pass validation
+        if (StringUtils.isBlank(rangerServiceDef.getName())) {
+            rangerServiceDef.setName("hdfs");
+        }
+
+        // Mock restErrorUtil to prevent NullPointerException
+        WebApplicationException mockException = new WebApplicationException(
+                "serviceDef Id mismatch",
+                HttpServletResponse.SC_BAD_REQUEST);
+        Mockito.when(restErrorUtil.createRESTException(
+                Mockito.anyInt(),
+                Mockito.anyString(),
+                Mockito.anyBoolean())).thenReturn(mockException);
+
         Mockito.when(validatorFactory.getServiceDefValidator(svcStore)).thenReturn(serviceDefValidator);
         Mockito.when(svcStore.updateServiceDef(Mockito.any())).thenReturn(rangerServiceDef);
 
@@ -4504,5 +4518,30 @@ public class TestServiceREST {
                 throw new RuntimeException(ite.getCause());
             }
         });
+    }
+
+    @Test
+    public void testUpdateServiceDefWithValidNameButMismatchedId() throws Exception {
+        // Arrange
+        RangerServiceDef serviceDef = rangerServiceDef();
+        serviceDef.setName("hdfs"); // Valid name
+        serviceDef.setId(999L);     // Mismatched ID (different from Id = 8L)
+
+        WebApplicationException mockException = new WebApplicationException();
+        Mockito.when(restErrorUtil.createRESTException(
+                Mockito.eq(HttpServletResponse.SC_BAD_REQUEST),
+                Mockito.eq("serviceDef Id mismatch"),
+                Mockito.eq(true)
+        )).thenReturn(mockException);
+
+        // Act & Assert
+        Assertions.assertThrows(WebApplicationException.class,
+                () -> serviceREST.updateServiceDef(serviceDef, Id));
+
+        // Verify the correct error was created
+        Mockito.verify(restErrorUtil).createRESTException(
+                HttpServletResponse.SC_BAD_REQUEST,
+                "serviceDef Id mismatch",
+                true);
     }
 }


### PR DESCRIPTION
  synchronization in put /definitions/{id}

## What changes were proposed in this pull request?
 The  PUT api    http://localhost:6080/service/plugins/definitions/{id}   is not throwing error when different id is passed from url and json payload , the issue is because in of a && condition updateServiceDef in ServiceREST which should have been OR ,I have  changed it  . On changing the And condition to or it is proprly throwing error as expected . 


