### PR TITLE
RANGER-5592: [GDS] Validity Period is not working for dataset policy

### DIFF
--- a/agents-common/src/main/java/org/apache/ranger/plugin/policyengine/gds/GdsDatasetEvaluator.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/policyengine/gds/GdsDatasetEvaluator.java
@@ -124,10 +124,9 @@ public class GdsDatasetEvaluator {
                     RangerAccessRequestUtil.setAccessTypeACLResults(datasetRequest.getContext(), null);
 
                     policyEvaluators.forEach(e -> {
-                        if (!e.isApplicable(accessTime)) {
-                            return;
+                        if (e.isApplicable(accessTime)) {
+                            e.evaluate(datasetRequest, datasetResult);
                         }
-                        e.evaluate(datasetRequest, datasetResult);
                     });
                 } finally {
                     RangerAccessRequestUtil.setAccessTypeResults(datasetRequest.getContext(), null);

--- a/agents-common/src/main/java/org/apache/ranger/plugin/policyengine/gds/GdsDatasetEvaluator.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/policyengine/gds/GdsDatasetEvaluator.java
@@ -41,6 +41,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.Date;
 import java.util.List;
 import java.util.Set;
 
@@ -108,6 +109,7 @@ public class GdsDatasetEvaluator {
 
     public void evaluate(RangerAccessRequest request, GdsAccessResult result, Collection<GdsProjectEvaluator> projectsToEval) {
         LOG.debug("==> GdsDatasetEvaluator.evaluate({}, {}, {})", request, result, projectsToEval);
+        final Date accessTime = request.getAccessTime() != null ? request.getAccessTime() : new Date();
 
         if (isActive()) {
             result.addDataset(getName());
@@ -121,7 +123,12 @@ public class GdsDatasetEvaluator {
                     RangerAccessRequestUtil.setAccessTypeResults(datasetRequest.getContext(), null);
                     RangerAccessRequestUtil.setAccessTypeACLResults(datasetRequest.getContext(), null);
 
-                    policyEvaluators.forEach(e -> e.evaluate(datasetRequest, datasetResult));
+                    policyEvaluators.forEach(e -> {
+                        if (!e.isApplicable(accessTime)) {
+                            return;
+                        }
+                        e.evaluate(datasetRequest, datasetResult);
+                    });
                 } finally {
                     RangerAccessRequestUtil.setAccessTypeResults(datasetRequest.getContext(), null);
                     RangerAccessRequestUtil.setAccessTypeACLResults(datasetRequest.getContext(), null);


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fixed an issue where the GDS validity period was not enforced for dataset policies. Previously, when a dataset was configured with a validity end date set before the current date, users were still allowed to execute queries (e.g., SELECT) instead of being denied access. The validity period expiration is now correctly evaluated, ensuring that access through dataset policies is denied once the validity period has expired.

## How was this patch tested?
Manual testing is done.
build successful with "mvn clean install"

