### PR TITLE
RANGER-5598:RangerHiveAuthorizer showprivileges should consider principal expiry condition in the GDS grants

### DIFF
--- a/hive-agent/src/main/java/org/apache/ranger/authorization/hive/authorizer/RangerHiveAuthorizer.java
+++ b/hive-agent/src/main/java/org/apache/ranger/authorization/hive/authorizer/RangerHiveAuthorizer.java
@@ -2608,7 +2608,7 @@ public class RangerHiveAuthorizer extends RangerHiveAuthorizerBase {
                     partValues          = (msObjRef.getPartValues() == null) ? new ArrayList<>() : msObjRef.getPartValues();
                     hivePrivilegeObject = new HivePrivilegeObject(objectType, dbName, objectName);
 
-                    RangerResourceACLs rangerResourceACLs = getRangerResourceACLs(hivePrivilegeObject);
+                    RangerResourceACLs rangerResourceACLs = getRangerResourceACLs(hivePrivilegeObject, principal);
 
                     if (rangerResourceACLs != null) {
                         Map<String, Map<String, RangerResourceACLs.AccessResult>> userRangerACLs  = rangerResourceACLs.getUserACLs();
@@ -2800,16 +2800,50 @@ public class RangerHiveAuthorizer extends RangerHiveAuthorizerBase {
         return Sets.newHashSet(ugi.getGroupNames());
     }
 
-    private RangerResourceACLs getRangerResourceACLs(HivePrivilegeObject hiveObject) {
-        LOG.debug("==> RangerHivePolicyProvider.getRangerResourceACLs:[{}]", hiveObject);
+    private RangerResourceACLs getRangerResourceACLs(HivePrivilegeObject hiveObject, HivePrincipal principal) {
+        RangerResourceACLs ret = null;
 
-        RangerResourceACLs      ret;
-        RangerHiveResource      hiveResource = createHiveResource(hiveObject);
-        RangerAccessRequestImpl request      = new RangerAccessRequestImpl(hiveResource, RangerPolicyEngine.ANY_ACCESS, null, null, null);
+        LOG.debug("==> RangerHivePolicyProvider.getRangerResourceACLs:[{}], principal=[{}]", hiveObject, principal);
+
+        RangerHiveResource hiveResource = createHiveResource(hiveObject);
+        if (hiveResource == null) {
+            return null;
+        }
+
+        RangerAccessRequestImpl request;
+        if (principal == null) {
+            request = new RangerAccessRequestImpl(hiveResource, RangerPolicyEngine.ANY_ACCESS, null, null, null);
+        } else {
+            String      user   = null;
+            Set<String> groups = Collections.emptySet();
+            Set<String> roles  = Collections.emptySet();
+
+            switch (principal.getType()) {
+                case USER:
+                    user   = principal.getName();
+                    groups = getPrincipalGroup(user);
+                    roles  = getCurrentRolesForUser(user, groups);
+                    break;
+                case GROUP:
+                    groups = Sets.newHashSet(principal.getName());
+                    break;
+                case ROLE:
+                    roles = Sets.newHashSet(principal.getName());
+                    break;
+                default:
+                    break;
+            }
+
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("getRangerResourceACLs(): principalType={}, user={}, groups={}, roles={}", principal.getType(), user, groups, roles);
+            }
+
+            request = new RangerHiveAccessRequest(hiveResource, user, groups, roles, "SHOW PRIVILEGES", HiveAccessType.USE, null, null);
+        }
 
         ret = hivePlugin.getResourceACLs(request);
 
-        LOG.debug("<== RangerHivePolicyProvider.getRangerResourceACLs:[{}], Computed ACLS:[{}]", hiveObject, ret);
+        LOG.debug("<== RangerHivePolicyProvider.getRangerResourceACLs:[{}], principal=[{}], Computed ACLS:[{}]", hiveObject, principal, ret);
 
         return ret;
     }

--- a/hive-agent/src/test/java/org/apache/ranger/authorization/hive/authorizer/TestRangerHiveAuthorizer.java
+++ b/hive-agent/src/test/java/org/apache/ranger/authorization/hive/authorizer/TestRangerHiveAuthorizer.java
@@ -1279,11 +1279,42 @@ public class TestRangerHiveAuthorizer {
         Mockito.when(msFactory.getHiveMetastoreClient()).thenReturn(ms);
 
         RangerHiveAuthorizer authorizer = new RangerHiveAuthorizer(msFactory, null, null, null);
-        Method               m          = RangerHiveAuthorizer.class.getDeclaredMethod("getRangerResourceACLs", HivePrivilegeObject.class);
+        Method               m          = RangerHiveAuthorizer.class.getDeclaredMethod("getRangerResourceACLs", HivePrivilegeObject.class, HivePrincipal.class);
         m.setAccessible(true);
-        HivePrivilegeObject obj = new HivePrivilegeObject(HivePrivilegeObjectType.TABLE_OR_VIEW, "db1", "t1");
-        Object              out = m.invoke(authorizer, obj);
+        HivePrivilegeObject obj       = new HivePrivilegeObject(HivePrivilegeObjectType.TABLE_OR_VIEW, "db1", "t1");
+        HivePrincipal       principal = new HivePrincipal("analyst", HivePrincipal.HivePrincipalType.ROLE);
+        Object              out = m.invoke(authorizer, obj, principal);
         assertInstanceOf(RangerResourceACLs.class, out);
+    }
+
+    @Test
+    void test66_getRangerResourceACLs_usesPrincipalContext() throws Exception {
+        RangerBasePlugin plugin = (RangerBasePlugin) Mockito.spy(newInstanceRangerHivePlugin("hiveCLI"));
+        Mockito.doReturn(new RangerResourceACLs()).when(plugin).getResourceACLs(Mockito.any(RangerAccessRequestImpl.class));
+        setStaticHivePlugin(plugin);
+
+        HiveMetastoreClientFactory msFactory = Mockito.mock(HiveMetastoreClientFactory.class);
+        IMetaStoreClient           ms        = Mockito.mock(IMetaStoreClient.class);
+        Mockito.when(msFactory.getHiveMetastoreClient()).thenReturn(ms);
+        RangerHiveAuthorizer authorizer = new RangerHiveAuthorizer(msFactory, null, null, null);
+
+        Method m = RangerHiveAuthorizer.class.getDeclaredMethod("getRangerResourceACLs", HivePrivilegeObject.class, HivePrincipal.class);
+        m.setAccessible(true);
+
+        HivePrivilegeObject obj       = new HivePrivilegeObject(HivePrivilegeObjectType.TABLE_OR_VIEW, "db1", "t1");
+        HivePrincipal       principal = new HivePrincipal("analyst", HivePrincipal.HivePrincipalType.ROLE);
+        m.invoke(authorizer, obj, principal);
+
+        Mockito.verify(plugin).getResourceACLs(Mockito.argThat(req -> {
+            if (!(req instanceof RangerHiveAccessRequest)) {
+                return false;
+            }
+            RangerHiveAccessRequest request = (RangerHiveAccessRequest) req;
+            return request.getUser() == null &&
+                    request.getUserGroups().isEmpty() &&
+                    request.getUserRoles().contains("analyst") &&
+                    request.getHiveAccessType() == RangerHiveAuthorizer.HiveAccessType.USE;
+        }));
     }
 
     @Test


### PR DESCRIPTION

## What changes were proposed in this pull request?

 RangerHiveAuthorizer showprivileges should consider principal expiry condition in the  GDS grants. Currently the showprivileges fetches the ACLs and filters the permission for principal and in this case expiry condition provided in the GDS policies are skipped resulting in wrong permission list shown. 


## How was this patch tested?

Tested in local vm for the showprivilege and unit test.
