### PR TITLE
RANGER-5602: Local build failure due to unit test failure in TestPolicyACLs

### DIFF
--- a/agents-common/src/test/java/org/apache/ranger/plugin/policyengine/TestPolicyACLs.java
+++ b/agents-common/src/test/java/org/apache/ranger/plugin/policyengine/TestPolicyACLs.java
@@ -119,7 +119,7 @@ public class TestPolicyACLs {
             RangerPluginContext       pluginContext       = new RangerPluginContext(new RangerPluginConfig(serviceType, null, "test-policy-acls", "cl1", "on-prem", policyEngineOptions));
             RangerPolicyEngine        policyEngine        = new RangerPolicyEngineImpl(testCase.servicePolicies, pluginContext, null);
 
-            testCase.tests.parallelStream().filter(Objects::nonNull).forEach(oneTest -> {
+            testCase.tests.stream().filter(Objects::nonNull).forEach(oneTest -> {
                 RangerAccessRequestImpl request = new RangerAccessRequestImpl(oneTest.resource, RangerPolicyEngine.ANY_ACCESS, null, null, null);
 
                 request.setResourceMatchingScope(oneTest.resourceMatchingScope);


### PR DESCRIPTION
local maven build i.e mvn clean install
is failing with
TestPolicyACLs.testResourceACLs_dataMask:85->runTestsFromResourceFiles:107->runTests:122->lambda$runTests$0:127 » ConcurrentModification
