### PR TITLE
RANGER-5602: Local build failure due to unit test failure in TestPolicyACLs

### DIFF
--- a/agents-common/src/main/java/org/apache/ranger/plugin/model/validation/RangerServiceDefHelper.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/model/validation/RangerServiceDefHelper.java
@@ -507,14 +507,23 @@ public class RangerServiceDefHelper {
 
                         this.hierarchies.put(policyType, Collections.unmodifiableSet(hierarchies));
                         hierarchyKeys.put(policyType, Collections.unmodifiableSet(hierachyKeys));
+                        Map<String, RangerResourceDef> wildcardMap = new HashMap<>(resources.size());
+                        for (RangerResourceDef res : resources) {
+                            if (res != null) {
+                                wildcardMap.put(res.getName(), createWildcardEnabledResourceDef(res));
+                            }
+                        }
+                        wildcardEnabledResourceDefs.put(policyType, Collections.unmodifiableMap(wildcardMap));
                     } else {
                         isValid = false;
                         hierarchies.put(policyType, EMPTY_RESOURCE_HIERARCHY);
                         hierarchyKeys.put(policyType, Collections.emptySet());
+                        wildcardEnabledResourceDefs.put(policyType, Collections.emptyMap());
                     }
                 } else {
                     hierarchies.put(policyType, EMPTY_RESOURCE_HIERARCHY);
                     hierarchyKeys.put(policyType, Collections.emptySet());
+                    wildcardEnabledResourceDefs.put(policyType, Collections.emptyMap());
                 }
             }
 
@@ -546,6 +555,15 @@ public class RangerServiceDefHelper {
             valid = isValid;
 
             LOG.debug("Found [{}] resource hierarchies for service [{}] update-date[{}]: {}", hierarchies.size(), serviceName, serviceDefFreshnessDate, hierarchies);
+        }
+
+        private RangerResourceDef createWildcardEnabledResourceDef(RangerResourceDef resourceDef) {
+            if (resourceDef == null) {
+                return null;
+            }
+            RangerResourceDef ret = new RangerResourceDef(resourceDef);
+            ret.getMatcherOptions().put(RangerAbstractResourceMatcher.OPTION_WILD_CARD, Boolean.TRUE.toString());
+            return ret;
         }
 
         public void patchServiceDefWithDefaultValues() {
@@ -686,31 +704,11 @@ public class RangerServiceDefHelper {
             if (policyType == null) {
                 policyType = RangerPolicy.POLICY_TYPE_ACCESS;
             }
-
-            Map<String, RangerResourceDef> wResourceDefs = wildcardEnabledResourceDefs.computeIfAbsent(policyType, k -> new HashMap<>());
-            RangerResourceDef              ret           = null;
-
-            if (!wResourceDefs.containsKey(resourceName)) {
-                List<RangerResourceDef> resourceDefs = getResourceDefs(servicedef, policyType);
-
-                if (resourceDefs != null) {
-                    for (RangerResourceDef resourceDef : resourceDefs) {
-                        if (StringUtils.equals(resourceName, resourceDef.getName())) {
-                            ret = new RangerResourceDef(resourceDef);
-
-                            ret.getMatcherOptions().put(RangerAbstractResourceMatcher.OPTION_WILD_CARD, Boolean.TRUE.toString());
-
-                            break;
-                        }
-                    }
-                }
-
-                wResourceDefs.put(resourceName, ret);
-            } else {
-                ret = wResourceDefs.get(resourceName);
+            Map<String, RangerResourceDef> wResourceDefs = wildcardEnabledResourceDefs.get(policyType);
+            if (wResourceDefs == null) {
+                return null;
             }
-
-            return ret;
+            return wResourceDefs.get(resourceName);
         }
 
         List<RangerResourceDef> getResourceDefs(RangerServiceDef serviceDef, Integer policyType) {

--- a/agents-common/src/main/java/org/apache/ranger/plugin/model/validation/RangerServiceDefHelper.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/model/validation/RangerServiceDefHelper.java
@@ -510,7 +510,7 @@ public class RangerServiceDefHelper {
                         Map<String, RangerResourceDef> wildcardMap = new HashMap<>(resources.size());
                         for (RangerResourceDef res : resources) {
                             if (res != null) {
-                                wildcardMap.put(res.getName(), createWildcardEnabledResourceDef(res));
+                                wildcardMap.putIfAbsent(res.getName(), createWildcardEnabledResourceDef(res));
                             }
                         }
                         wildcardEnabledResourceDefs.put(policyType, Collections.unmodifiableMap(wildcardMap));
@@ -558,9 +558,6 @@ public class RangerServiceDefHelper {
         }
 
         private RangerResourceDef createWildcardEnabledResourceDef(RangerResourceDef resourceDef) {
-            if (resourceDef == null) {
-                return null;
-            }
             RangerResourceDef ret = new RangerResourceDef(resourceDef);
             ret.getMatcherOptions().put(RangerAbstractResourceMatcher.OPTION_WILD_CARD, Boolean.TRUE.toString());
             return ret;

--- a/agents-common/src/test/java/org/apache/ranger/plugin/model/validation/TestRangerServiceDefHelper.java
+++ b/agents-common/src/test/java/org/apache/ranger/plugin/model/validation/TestRangerServiceDefHelper.java
@@ -25,6 +25,7 @@ import org.apache.ranger.plugin.model.RangerPolicy;
 import org.apache.ranger.plugin.model.RangerServiceDef;
 import org.apache.ranger.plugin.model.RangerServiceDef.RangerResourceDef;
 import org.apache.ranger.plugin.model.validation.RangerServiceDefHelper.Delegate;
+import org.apache.ranger.plugin.resourcematcher.RangerAbstractResourceMatcher;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
@@ -34,15 +35,23 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.InputStreamReader;
 import java.util.Calendar;
+import java.util.ConcurrentModificationException;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -405,6 +414,66 @@ public class TestRangerServiceDefHelper {
 
         assertEquals("bucket", svcDefHelper.getRrnTemplate("bucket"));
         assertEquals("bucket/path", svcDefHelper.getRrnTemplate("path"));
+    }
+
+    @Test
+    public void test_getWildcardEnabledResourceDef_returnsWildcardEnabledCopy() {
+        RangerResourceDef database = createResourceDef("database", "");
+        RangerResourceDef table = createResourceDef("table", "database", true);
+        when(serviceDef.getResources()).thenReturn(Lists.newArrayList(database, table));
+        helper = new RangerServiceDefHelper(serviceDef);
+        RangerResourceDef wildcardDefDatabase = helper.getWildcardEnabledResourceDef("database", RangerPolicy.POLICY_TYPE_ACCESS);
+        RangerResourceDef wildcardDefTable = helper.getWildcardEnabledResourceDef("table", RangerPolicy.POLICY_TYPE_ACCESS);
+        assertNotNull(wildcardDefDatabase, "getWildcardEnabledResourceDef() should not return null for a valid resource");
+        assertNotSame(database, wildcardDefDatabase, "getWildcardEnabledResourceDef() must return a copy, not the original");
+        assertNotSame(table, wildcardDefTable, "getWildcardEnabledResourceDef() must return a copy, not the original");
+        assertEquals(Boolean.TRUE.toString(), wildcardDefDatabase.getMatcherOptions().get(RangerAbstractResourceMatcher.OPTION_WILD_CARD),
+                "Wildcard option must be set to true on the returned copy");
+        assertEquals(Boolean.TRUE.toString(), wildcardDefTable.getMatcherOptions().get(RangerAbstractResourceMatcher.OPTION_WILD_CARD),
+                "Wildcard option must be set to true on the returned copy");
+    }
+
+    @Test
+    public void test_getWildcardEnabledResourceDef_threadSafety() throws InterruptedException {
+        int numberOfThreads = 3;
+        int numberOfIterations = 50;
+
+        RangerResourceDef database = createResourceDef("database", "");
+        RangerResourceDef table = createResourceDef("table", "database", true);
+        RangerResourceDef column = createResourceDef("column", "table", true);
+
+        when(serviceDef.getResources()).thenReturn(Lists.newArrayList(database, table, column));
+        helper = new RangerServiceDefHelper(serviceDef);
+        AtomicBoolean cmeObserved = new AtomicBoolean(false);
+        AtomicInteger successCount = new AtomicInteger(0);
+
+        for (int iter = 0; iter < numberOfIterations && !cmeObserved.get(); iter++) {
+            CountDownLatch startLatch = new CountDownLatch(1);
+            CountDownLatch doneLatch = new CountDownLatch(numberOfThreads);
+            ExecutorService pool = Executors.newFixedThreadPool(numberOfThreads);
+            for (int t = 0; t < numberOfThreads; t++) {
+                pool.submit(() -> {
+                    try {
+                        startLatch.await();
+                        RangerResourceDef def = helper.getWildcardEnabledResourceDef("database", RangerPolicy.POLICY_TYPE_ACCESS);
+                        if (def != null) {
+                            successCount.incrementAndGet();
+                        }
+                    } catch (ConcurrentModificationException e) {
+                        cmeObserved.set(true);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    } finally {
+                        doneLatch.countDown();
+                    }
+                });
+            }
+            startLatch.countDown();
+            doneLatch.await(10, TimeUnit.SECONDS);
+            pool.shutdownNow();
+        }
+        assertFalse(cmeObserved.get(), "ConcurrentModificationException must never occur — wildcardEnabledResourceDefs must be thread-safe after eager init fix");
+        assertEquals(numberOfThreads * numberOfIterations, successCount.get(), "All concurrent calls must return a valid result");
     }
 
     RangerResourceDef createResourceDef(String name, String parent) {


### PR DESCRIPTION


## What changes were proposed in this pull request?

Switched Delegate from lazy computeIfAbsent to eager initialization in the constructor. All internal maps are now fully populated and wrapped with unmodifiableMap before the Delegate is published to the cache.

This eliminates the CME because HashMap.get() is thread-safe for concurrent reads when there are no writes. The previous computeIfAbsent caused concurrent writes on a shared HashMap when multiple threads accessed the same cached Delegate, which parallelStream exposed


## How was this patch tested?

after fix mvn test -Dtest=TestPolicyACLs#testResourceACLs_dataMask is passing.
