### PR TITLE
RANGER-5604: Bump org.glassfish.jersey.core:jersey-client from 2.22.1 to 2.47 in /plugin-schema-registry

### DIFF
--- a/plugin-schema-registry/pom.xml
+++ b/plugin-schema-registry/pom.xml
@@ -31,7 +31,7 @@
 
     <properties>
         <avro.version>1.11.5</avro.version>
-        <jersey.version>2.22.1</jersey.version>
+        <jersey.version>2.47</jersey.version>
         <jettison.version>1.5.4</jettison.version>
         <schema.registry.version>0.9.1</schema.registry.version>
         <servlet-api.version>3.0.1</servlet-api.version>


### PR DESCRIPTION


## What changes were proposed in this pull request?

Bump org.glassfish.jersey.core:jersey-client from 2.22.1 to 2.47 in /plugin-schema-registry


## How was this patch tested?

Local build passed
