### PR TITLE
RANGER-5605 : Fix Ranger build failure when triggered through Docker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ on:
     branches: [ "master" ]
 
 env:
-  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
+  MAVEN_OPTS: -Xmx5g -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
 
 jobs:
   build-17:

--- a/dev-support/ranger-docker/README.md
+++ b/dev-support/ranger-docker/README.md
@@ -24,7 +24,7 @@ Use Dockerfiles in this directory to create docker images and run them to build 
 ### Environment Setup
 
 - Ensure that you have recent version of Docker installed from [docker.io](http://www.docker.io) (as of this writing: Engine v24.0.5, Compose v2.20.2).
-   Make sure to configure docker with at least 6gb of memory.
+   Make sure to configure docker with at least 8gb of memory.
 
 - Update environment variables in ```.env``` file, if necessary
 

--- a/dev-support/ranger-docker/scripts/build/ranger-build.sh
+++ b/dev-support/ranger-docker/scripts/build/ranger-build.sh
@@ -44,7 +44,7 @@ then
   BUILD_HOST_SRC=true
 fi
 
-export MAVEN_OPTS="-Xms2g -Xmx2g"
+export MAVEN_OPTS="-Xms512m -Xmx5g -XX:+UseG1GC -XX:+ExplicitGCInvokesConcurrent -XX:SoftRefLRUPolicyMSPerMB=50 ${JAVA_OPTS}"
 export M2=/home/ranger/.m2
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix Ranger build failure when triggered through Docker

(Please fill in changes proposed in this fix. Create an issue in ASF JIRA before opening a pull request and
set the title of the pull request which starts with
the corresponding JIRA issue number. (e.g. RANGER-XXXX: Fix a typo in YYY))


## How was this patch tested?
Increased the Maven heap size from 2GB to 5GB (minimum requirement).
Tested the Docker build trigger locally.

