### PR TITLE
RANGER-3899: Policy creation/updation takes more time when there are more users,groups,roles

### DIFF
--- a/dev-support/checks/coverage.sh
+++ b/dev-support/checks/coverage.sh
@@ -49,6 +49,10 @@ find . -type d -name 'target' -prune -exec find {} -type f \( -name 'ranger-*.ja
 -or -name '*shim*' -prune \
 | xargs -n1 unzip -o -q -d target/coverage-classes
 
+# Multi-release JARs (e.g. BouncyCastle) ship the same classes under
+# META-INF/versions/* and at the root; JaCoCo fails with duplicate class names.
+rm -rf target/coverage-classes/META-INF/versions || true
+
 # get all source file paths
 src=$(find . -path '*/src/main/java' -o -path './target' -prune | sed 's/^/--sourcefiles /g' | xargs echo)
 

--- a/security-admin/src/main/java/org/apache/ranger/biz/PolicyRefUpdater.java
+++ b/security-admin/src/main/java/org/apache/ranger/biz/PolicyRefUpdater.java
@@ -28,11 +28,8 @@ import org.apache.ranger.db.RangerDaoManager;
 import org.apache.ranger.db.XXPolicyRefGroupDao;
 import org.apache.ranger.db.XXPolicyRefRoleDao;
 import org.apache.ranger.db.XXPolicyRefUserDao;
-import org.apache.ranger.entity.XXAccessTypeDef;
-import org.apache.ranger.entity.XXDataMaskTypeDef;
 import org.apache.ranger.entity.XXGroup;
 import org.apache.ranger.entity.XXPolicy;
-import org.apache.ranger.entity.XXPolicyConditionDef;
 import org.apache.ranger.entity.XXPolicyRefAccessType;
 import org.apache.ranger.entity.XXPolicyRefCondition;
 import org.apache.ranger.entity.XXPolicyRefDataMaskType;
@@ -40,7 +37,6 @@ import org.apache.ranger.entity.XXPolicyRefGroup;
 import org.apache.ranger.entity.XXPolicyRefResource;
 import org.apache.ranger.entity.XXPolicyRefRole;
 import org.apache.ranger.entity.XXPolicyRefUser;
-import org.apache.ranger.entity.XXResourceDef;
 import org.apache.ranger.entity.XXRole;
 import org.apache.ranger.entity.XXServiceDef;
 import org.apache.ranger.entity.XXUser;
@@ -187,15 +183,15 @@ public class PolicyRefUpdater {
 
         if (CollectionUtils.isNotEmpty(resourceNames)) {
             List<XXPolicyRefResource> xPolResources = new ArrayList<>();
-            Map<String, XXResourceDef> nameToResDefMap = daoMgr.getXXResourceDef().findXXResourceDefsByNameAndPolicyId(resourceNames, policy.getId());
+            Map<String, Long> nameToResDefIdMap = daoMgr.getXXResourceDef().findResourceDefIdsByNameAndPolicyId(resourceNames, policy.getId());
             for (String resource : resourceNames) {
-                XXResourceDef xResDef = nameToResDefMap.get(resource);
-                if (xResDef == null) {
+                Long resourceDefId = nameToResDefIdMap.get(resource);
+                if (resourceDefId == null) {
                     throw new Exception(resource + ": is not a valid resource-type. policy='" + policy.getName() + "' service='" + policy.getService() + "'");
                 }
                 XXPolicyRefResource xPolRes = new XXPolicyRefResource();
                 xPolRes.setPolicyId(policy.getId());
-                xPolRes.setResourceDefId(xResDef.getId());
+                xPolRes.setResourceDefId(resourceDefId);
                 xPolRes.setResourceName(resource);
                 xPolResources.add(xPolRes);
             }
@@ -216,17 +212,20 @@ public class PolicyRefUpdater {
                     .collect(Collectors.toSet());
             Map<String, Long> roleNameIdMap = daoMgr.getXXRole().getIdsByRoleNames(filteredRoleNames);
             for (String roleName : filteredRoleNames) {
-                PolicyPrincipalAssociator associator = new PolicyPrincipalAssociator(PRINCIPAL_TYPE.ROLE, roleName, xPolicy, roleNameIdMap.get(roleName), null, null, xPolRoles);
-                if (!associator.doAssociate(false)) {
-                    if (createPrincipalsIfAbsent) {
-                        rangerTransactionSynchronizationAdapter.executeOnTransactionCommit(associator);
-                    } else {
-                        VXResponse gjResponse = new VXResponse();
-
-                        gjResponse.setStatusCode(HttpServletResponse.SC_BAD_REQUEST);
-                        gjResponse.setMsgDesc("Operation denied. Role name: " + roleName + " specified in policy does not exist in ranger admin.");
-                        throw restErrorUtil.generateRESTException(gjResponse);
+                Long roleId = roleNameIdMap.get(roleName);
+                PolicyRoleAssociator associator = new PolicyRoleAssociator(roleName, roleId, xPolicy);
+                if (roleId != null) {
+                    XXPolicyRefRole roleRef = associator.getPolicyRef();
+                    if (roleRef != null) {
+                        xPolRoles.add(roleRef);
                     }
+                } else if (createPrincipalsIfAbsent) {
+                    rangerTransactionSynchronizationAdapter.executeOnTransactionCommit(associator);
+                } else {
+                    VXResponse gjResponse = new VXResponse();
+                    gjResponse.setStatusCode(HttpServletResponse.SC_BAD_REQUEST);
+                    gjResponse.setMsgDesc("Operation denied. Role name: " + roleName + " specified in policy does not exist in ranger admin.");
+                    throw restErrorUtil.generateRESTException(gjResponse);
                 }
             }
             batchInsert(xPolRoles, daoMgr.getXXPolicyRefRole(), oldBulkMode);
@@ -240,18 +239,20 @@ public class PolicyRefUpdater {
             Map<String, Long> groupNameIdMap = daoMgr.getXXGroup().getIdsByGroupNames(filteredGroupNames);
             List<XXPolicyRefGroup> xPolGroups = new ArrayList<>();
             for (String groupName : filteredGroupNames) {
-                PolicyPrincipalAssociator associator = new PolicyPrincipalAssociator(PRINCIPAL_TYPE.GROUP, groupName, xPolicy, groupNameIdMap.get(groupName), null, xPolGroups, null);
-                if (!associator.doAssociate(false)) {
-                    if (createPrincipalsIfAbsent) {
-                        rangerTransactionSynchronizationAdapter.executeOnTransactionCommit(associator);
-                    } else {
-                        VXResponse gjResponse = new VXResponse();
-
-                        gjResponse.setStatusCode(HttpServletResponse.SC_BAD_REQUEST);
-                        gjResponse.setMsgDesc("Operation denied. Group name: " + groupName + " specified in policy does not exist in ranger admin.");
-
-                        throw restErrorUtil.generateRESTException(gjResponse);
+                Long groupId = groupNameIdMap.get(groupName);
+                PolicyGroupAssociator associator = new PolicyGroupAssociator(groupName, groupId, xPolicy);
+                if (groupId != null) {
+                    XXPolicyRefGroup groupRef = associator.getPolicyRef();
+                    if (groupRef != null) {
+                        xPolGroups.add(groupRef);
                     }
+                } else if (createPrincipalsIfAbsent) {
+                    rangerTransactionSynchronizationAdapter.executeOnTransactionCommit(associator);
+                } else {
+                    VXResponse gjResponse = new VXResponse();
+                    gjResponse.setStatusCode(HttpServletResponse.SC_BAD_REQUEST);
+                    gjResponse.setMsgDesc("Operation denied. Group name: " + groupName + " specified in policy does not exist in ranger admin.");
+                    throw restErrorUtil.generateRESTException(gjResponse);
                 }
             }
             batchInsert(xPolGroups, daoMgr.getXXPolicyRefGroup(), oldBulkMode);
@@ -265,18 +266,20 @@ public class PolicyRefUpdater {
                     .collect(Collectors.toSet());
             Map<String, Long> userNameIdMap = daoMgr.getXXUser().getIdsByUserNames(filteredUserNames);
             for (String userName : filteredUserNames) {
-                PolicyPrincipalAssociator associator = new PolicyPrincipalAssociator(PRINCIPAL_TYPE.USER, userName, xPolicy, userNameIdMap.get(userName), xPolUsers, null, null);
-                if (!associator.doAssociate(false)) {
-                    if (createPrincipalsIfAbsent) {
-                        rangerTransactionSynchronizationAdapter.executeOnTransactionCommit(associator);
-                    } else {
-                        VXResponse gjResponse = new VXResponse();
-
-                        gjResponse.setStatusCode(HttpServletResponse.SC_BAD_REQUEST);
-                        gjResponse.setMsgDesc("Operation denied. User name: " + userName + " specified in policy does not exist in ranger admin.");
-
-                        throw restErrorUtil.generateRESTException(gjResponse);
+                Long userId = userNameIdMap.get(userName);
+                PolicyUserAssociator associator = new PolicyUserAssociator(userName, userId, xPolicy);
+                if (userId != null) {
+                    XXPolicyRefUser userRef = associator.getPolicyRef();
+                    if (userRef != null) {
+                        xPolUsers.add(userRef);
                     }
+                } else if (createPrincipalsIfAbsent) {
+                    rangerTransactionSynchronizationAdapter.executeOnTransactionCommit(associator);
+                } else {
+                    VXResponse gjResponse = new VXResponse();
+                    gjResponse.setStatusCode(HttpServletResponse.SC_BAD_REQUEST);
+                    gjResponse.setMsgDesc("Operation denied. User name: " + userName + " specified in policy does not exist in ranger admin.");
+                    throw restErrorUtil.generateRESTException(gjResponse);
                 }
             }
             batchInsert(xPolUsers, daoMgr.getXXPolicyRefUser(), oldBulkMode);
@@ -286,17 +289,17 @@ public class PolicyRefUpdater {
         accessTypes.removeAll(ServiceDefUtil.ACCESS_TYPE_MARKERS);
         if (CollectionUtils.isNotEmpty(accessTypes)) {
             List<XXPolicyRefAccessType> xPolAccesses = new ArrayList<>();
-            Map<String, XXAccessTypeDef> nameToAccessTypeDefMap = daoMgr.getXXAccessTypeDef().findByNamesAndServiceId(accessTypes, xPolicy.getService());
+            Map<String, Long> nameToAccessTypeDefIdMap = daoMgr.getXXAccessTypeDef().findAccessTypeDefIdsByNamesAndServiceId(accessTypes, xPolicy.getService());
             for (String accessType : accessTypes) {
-                XXAccessTypeDef xAccTypeDef = nameToAccessTypeDefMap.get(accessType);
-                if (xAccTypeDef == null) {
+                Long accessDefId = nameToAccessTypeDefIdMap.get(accessType);
+                if (accessDefId == null) {
                     throw new Exception(accessType + ": is not a valid access-type. policy='" + policy.getName() + "' service='" + policy.getService() + "'");
                 }
 
                 XXPolicyRefAccessType xPolAccess = new XXPolicyRefAccessType();
 
                 xPolAccess.setPolicyId(policy.getId());
-                xPolAccess.setAccessDefId(xAccTypeDef.getId());
+                xPolAccess.setAccessDefId(accessDefId);
                 xPolAccess.setAccessTypeName(accessType);
 
                 xPolAccesses.add(xPolAccess);
@@ -306,10 +309,10 @@ public class PolicyRefUpdater {
 
         if (CollectionUtils.isNotEmpty(conditionTypes)) {
             List<XXPolicyRefCondition> xPolConds = new ArrayList<>();
-            Map<String, XXPolicyConditionDef> nameToConditionDefMap = daoMgr.getXXPolicyConditionDef().findByServiceDefIdAndNames(xServiceDef.getId(), conditionTypes);
+            Map<String, Long> nameToConditionDefIdMap = daoMgr.getXXPolicyConditionDef().findConditionDefIdsByServiceDefIdAndNames(xServiceDef.getId(), conditionTypes);
             for (String condition : conditionTypes) {
-                XXPolicyConditionDef xPolCondDef = nameToConditionDefMap.get(condition);
-                if (xPolCondDef == null) {
+                Long conditionDefId = nameToConditionDefIdMap.get(condition);
+                if (conditionDefId == null) {
                     if (StringUtils.equalsIgnoreCase(condition, ServiceDefUtil.IMPLICIT_CONDITION_EXPRESSION_NAME)) {
                         continue;
                     }
@@ -318,7 +321,7 @@ public class PolicyRefUpdater {
 
                 XXPolicyRefCondition xPolCond = new XXPolicyRefCondition();
                 xPolCond.setPolicyId(policy.getId());
-                xPolCond.setConditionDefId(xPolCondDef.getId());
+                xPolCond.setConditionDefId(conditionDefId);
                 xPolCond.setConditionName(condition);
 
                 xPolConds.add(xPolCond);
@@ -328,17 +331,17 @@ public class PolicyRefUpdater {
 
         if (CollectionUtils.isNotEmpty(dataMaskTypes)) {
             List<XXPolicyRefDataMaskType> xxDataMaskInfos = new ArrayList<>();
-            Map<String, XXDataMaskTypeDef> namesToDataMaskTypeDefMap = daoMgr.getXXDataMaskTypeDef().findByNamesAndServiceId(dataMaskTypes, xPolicy.getService());
+            Map<String, Long> nameToDataMaskTypeDefIdMap = daoMgr.getXXDataMaskTypeDef().findDataMaskTypeDefIdsByNamesAndServiceId(dataMaskTypes, xPolicy.getService());
             for (String dataMaskType : dataMaskTypes) {
-                XXDataMaskTypeDef dataMaskDef = namesToDataMaskTypeDefMap.get(dataMaskType);
-                if (dataMaskDef == null) {
+                Long dataMaskDefId = nameToDataMaskTypeDefIdMap.get(dataMaskType);
+                if (dataMaskDefId == null) {
                     throw new Exception(dataMaskType + ": is not a valid datamask-type. policy='" + policy.getName() + "' service='" + policy.getService() + "'");
                 }
 
                 XXPolicyRefDataMaskType xxDataMaskInfo = new XXPolicyRefDataMaskType();
 
                 xxDataMaskInfo.setPolicyId(policy.getId());
-                xxDataMaskInfo.setDataMaskDefId(dataMaskDef.getId());
+                xxDataMaskInfo.setDataMaskDefId(dataMaskDefId);
                 xxDataMaskInfo.setDataMaskTypeName(dataMaskType);
 
                 xxDataMaskInfos.add(xxDataMaskInfo);
@@ -379,16 +382,9 @@ public class PolicyRefUpdater {
      * @return              true if cleanup was successful.
      */
     public Boolean cleanupRefTablesForUpdate(Long policyId, Set<String> policyUsers, Set<String> policyRoles, Set<String> policyGroups) {
-        XXPolicyRefUserDao xPolicyRefUserDao = daoMgr.getXXPolicyRefUser();
-        XXPolicyRefRoleDao xxPolicyRefRoleDao = daoMgr.getXXPolicyRefRole();
-        XXPolicyRefGroupDao xxPolicyRefGroupDao = daoMgr.getXXPolicyRefGroup();
-
-        Map<String, Long> policyUserNameIdMap   = xPolicyRefUserDao.findUserNameIdByPolicyId(policyId);
-        Map<String, Long> policyRoleNameIdMap   = xxPolicyRefRoleDao.findRoleNameIdByPolicyId(policyId);
-        Map<String, Long> policyGroupNameIdMap   = xxPolicyRefGroupDao.findGroupNameByPolicyId(policyId);
-        cleanupPolicyRefUsers(policyUsers, policyUserNameIdMap, policyId, xPolicyRefUserDao);
-        cleanupPolicyRefRoles(policyRoles, policyRoleNameIdMap, policyId, xxPolicyRefRoleDao);
-        cleanupPolicyRefGroups(policyGroups, policyGroupNameIdMap, policyId, xxPolicyRefGroupDao);
+        cleanupPolicyRefUsers(policyUsers, policyId, daoMgr.getXXPolicyRefUser());
+        cleanupPolicyRefRoles(policyRoles, policyId, daoMgr.getXXPolicyRefRole());
+        cleanupPolicyRefGroups(policyGroups, policyId, daoMgr.getXXPolicyRefGroup());
         daoMgr.getXXPolicyRefResource().deleteByPolicyId(policyId);
         daoMgr.getXXPolicyRefAccessType().deleteByPolicyId(policyId);
         daoMgr.getXXPolicyRefCondition().deleteByPolicyId(policyId);
@@ -400,12 +396,12 @@ public class PolicyRefUpdater {
      * Identifies and deletes outdated user references for a given policy,
      * and prepares a list of new users that need to be inserted.
      *
-     * @param policyUsers           Set of usernames from the new policy.
-     * @param policyUserNameIdMap   Existing mapping of usernames to their DB IDs for the policy.
-     * @param policyId              The ID of the policy.
-     * @param dao                   DAO for policy reference users.
+     * @param policyUsers   Set of usernames from the new policy.
+     * @param policyId      The ID of the policy.
+     * @param dao           DAO for policy reference users.
      */
-    public void cleanupPolicyRefUsers(Set<String> policyUsers, Map<String, Long> policyUserNameIdMap, Long policyId, XXPolicyRefUserDao dao) {
+    public void cleanupPolicyRefUsers(Set<String> policyUsers, Long policyId, XXPolicyRefUserDao dao) {
+        Map<String, Long> policyUserNameIdMap = dao.findUserNameIdByPolicyId(policyId);
         if (policyUserNameIdMap != null && !policyUserNameIdMap.isEmpty()) {
             Set<String> existingPolicyRefUsers = policyUserNameIdMap.keySet();
             Set<String> toDeletePolicyRefUsers = new HashSet<>(existingPolicyRefUsers);
@@ -432,12 +428,12 @@ public class PolicyRefUpdater {
      * Identifies and deletes outdated role references for a given policy,
      * and prepares a list of new roles that need to be inserted.
      *
-     * @param policyRoles           Set of role names from the new policy.
-     * @param policyRoleNameIdMap   Existing mapping of role names to their DB IDs for the policy.
-     * @param policyId              The ID of the policy.
-     * @param dao                   DAO for policy reference roles.
+     * @param policyRoles   Set of role names from the new policy.
+     * @param policyId      The ID of the policy.
+     * @param dao           DAO for policy reference roles.
      */
-    public void cleanupPolicyRefRoles(Set<String> policyRoles, Map<String, Long> policyRoleNameIdMap, Long policyId, XXPolicyRefRoleDao dao) {
+    public void cleanupPolicyRefRoles(Set<String> policyRoles, Long policyId, XXPolicyRefRoleDao dao) {
+        Map<String, Long> policyRoleNameIdMap = dao.findRoleNameIdByPolicyId(policyId);
         if (policyRoleNameIdMap != null && !policyRoleNameIdMap.isEmpty()) {
             Set<String> existingPolicyRefRoles = policyRoleNameIdMap.keySet();
             Set<String> toDeletePolicyRefRoles = new HashSet<>(existingPolicyRefRoles);
@@ -464,12 +460,12 @@ public class PolicyRefUpdater {
      * Identifies and deletes outdated group references for a given policy,
      * and prepares a list of new groups that need to be inserted.
      *
-     * @param policyGroups           Set of group names from the new policy.
-     * @param policyGroupNameIdMap   Existing mapping of group names to their DB IDs for the policy.
-     * @param policyId              The ID of the policy.
-     * @param dao                   DAO for policy reference groups.
+     * @param policyGroups   Set of group names from the new policy.
+     * @param policyId       The ID of the policy.
+     * @param dao            DAO for policy reference groups.
      */
-    public void cleanupPolicyRefGroups(Set<String> policyGroups, Map<String, Long> policyGroupNameIdMap, Long policyId, XXPolicyRefGroupDao dao) {
+    public void cleanupPolicyRefGroups(Set<String> policyGroups, Long policyId, XXPolicyRefGroupDao dao) {
+        Map<String, Long> policyGroupNameIdMap = dao.findGroupNameByPolicyId(policyId);
         if (policyGroupNameIdMap != null && !policyGroupNameIdMap.isEmpty()) {
             Set<String> existingPolicyRefGroups = policyGroupNameIdMap.keySet();
             Set<String> toDeletePolicyRefGroups = new HashSet<>(existingPolicyRefGroups);
@@ -494,229 +490,232 @@ public class PolicyRefUpdater {
 
     public enum PRINCIPAL_TYPE { USER, GROUP, ROLE }
 
-    private class PolicyPrincipalAssociator implements Runnable {
-        final PRINCIPAL_TYPE type;
-        final String         name;
-        final XXPolicy       xPolicy;
-        final Long id;
-        final List<XXPolicyRefUser> xPolUsers;
-        final List<XXPolicyRefGroup> xPolGroups;
-        final List<XXPolicyRefRole> xPolRoles;
+    private boolean doesPolicyExist(XXPolicy policy) {
+        return daoMgr.getXXPolicy().getById(policy.getId()) != null;
+    }
 
-        public PolicyPrincipalAssociator(PRINCIPAL_TYPE type, String name, XXPolicy xPolicy, Long id, List<XXPolicyRefUser> xPolUsers, List<XXPolicyRefGroup> xPolGroups, List<XXPolicyRefRole> xPolRoles) {
-            this.type    = type;
+    private class PolicyRoleAssociator implements Runnable {
+        private final String   name;
+        private final Long     roleId;
+        private final XXPolicy xPolicy;
+
+        PolicyRoleAssociator(String name, Long roleId, XXPolicy xPolicy) {
             this.name    = name;
+            this.roleId  = roleId;
             this.xPolicy = xPolicy;
-            this.id = id;
-            this.xPolUsers = xPolUsers;
-            this.xPolGroups = xPolGroups;
-            this.xPolRoles = xPolRoles;
+        }
+
+        public XXPolicyRefRole getPolicyRef() {
+            Long id = resolveRoleId(false);
+            if (id == null || !doesPolicyExist(xPolicy)) {
+                return null;
+            }
+            XXPolicyRefRole xPolRole = new XXPolicyRefRole();
+            xPolRole.setPolicyId(xPolicy.getId());
+            xPolRole.setRoleId(id);
+            xPolRole.setRoleName(name);
+            return xPolRole;
+        }
+
+        public void createPolicyRef(Long id) {
+            if (doesPolicyExist(xPolicy)) {
+                XXPolicyRefRole xPolRole = new XXPolicyRefRole();
+                xPolRole.setPolicyId(xPolicy.getId());
+                xPolRole.setRoleId(id);
+                xPolRole.setRoleName(name);
+                daoMgr.getXXPolicyRefRole().create(xPolRole);
+            } else {
+                LOG.info("Policy with id ={} does not exist, skipping policy association!", xPolicy.getId());
+            }
         }
 
         @Override
         public void run() {
-            if (doAssociate(true)) {
-                LOG.debug("Associated {}:{} with policy id:[{}]", type.name(), name, xPolicy.getId());
-            } else {
-                throw new RuntimeException("Failed to associate " + type.name() + ":" + name + " with policy id:[" + xPolicy.getId() + "]");
-            }
-        }
-
-        boolean doAssociate(boolean isAdmin) {
-            LOG.debug("===> PolicyPrincipalAssociator.doAssociate({})", isAdmin);
-
-            final boolean ret;
-
-            Long id = createOrGetPrincipal(isAdmin);
-
+            Long id = resolveRoleId(true);
             if (id != null) {
-                // associate with policy
-                createPolicyAssociation(id, name, isAdmin);
-
-                ret = true;
+                createPolicyRef(id);
+                LOG.debug("Associated ROLE:{} with policy id:[{}]", name, xPolicy.getId());
             } else {
-                ret = false;
+                throw new RuntimeException("Failed to associate ROLE:" + name + " with policy id:[" + xPolicy.getId() + "]");
             }
-
-            LOG.debug("<=== PolicyPrincipalAssociator.doAssociate({}) : {}", isAdmin, ret);
-
-            return ret;
         }
 
-        private Long createOrGetPrincipal(final boolean createIfAbsent) {
-            LOG.debug("===> PolicyPrincipalAssociator.createOrGetPrincipal({})", createIfAbsent);
-
-            if (id != null) {
-                return id;
+        private Long resolveRoleId(boolean createIfAbsent) {
+            if (roleId != null) {
+                return roleId;
             }
-
-            Long ret = null;
-
-            switch (type) {
-                case USER: {
-                    XXUser xUser = daoMgr.getXXUser().findByUserName(name);
-
-                    if (xUser != null) {
-                        ret = xUser.getId();
-                    } else {
-                        if (createIfAbsent) {
-                            ret = createPrincipal(name);
-                        }
-                    }
-                }
-                break;
-                case GROUP: {
-                    XXGroup xGroup = daoMgr.getXXGroup().findByGroupName(name);
-
-                    if (xGroup != null) {
-                        ret = xGroup.getId();
-                    } else {
-                        if (createIfAbsent) {
-                            ret = createPrincipal(name);
-                        }
-                    }
-                }
-                break;
-                case ROLE: {
-                    XXRole xRole = daoMgr.getXXRole().findByRoleName(name);
-
-                    if (xRole != null) {
-                        ret = xRole.getId();
-                    } else {
-                        if (createIfAbsent) {
-                            RangerBizUtil.setBulkMode(false);
-                            ret = createPrincipal(name);
-                        }
-                    }
-                }
-                break;
-                default:
-                    break;
+            XXRole xRole = daoMgr.getXXRole().findByRoleName(name);
+            if (xRole != null) {
+                return xRole.getId();
             }
-
-            LOG.debug("<=== PolicyPrincipalAssociator.createOrGetPrincipal({}) : {}", createIfAbsent, ret);
-
-            return ret;
+            if (createIfAbsent) {
+                RangerBizUtil.setBulkMode(false);
+                return createRole();
+            }
+            return null;
         }
 
-        private Long createPrincipal(String user) {
-            LOG.warn("User specified in policy does not exist in ranger admin, creating new user, Type: {}, name = {}", type.name(), user);
-
-            LOG.debug("===> PolicyPrincipalAssociator.createPrincipal(type={}, name={})", type.name(), name);
-
-            Long ret = null;
-
-            switch (type) {
-                case USER: {
-                    // Create External user
-                    VXUser vXUser = xUserMgr.createServiceConfigUser(name);
-                    if (vXUser != null) {
-                        XXUser xUser = daoMgr.getXXUser().findByUserName(name);
-
-                        if (xUser == null) {
-                            LOG.error("No User created!! Irrecoverable error! [{}]", name);
-                        } else {
-                            ret = xUser.getId();
-                        }
-                    } else {
-                        LOG.warn("serviceConfigUser:[{}] creation failed. This may be a transient/spurious condition that may correct itself when transaction is committed", name);
-                    }
-                }
-                break;
-                case GROUP: {
-                    // Create group
-                    VXGroup vxGroup = new VXGroup();
-
-                    vxGroup.setName(name);
-                    vxGroup.setDescription(name);
-                    vxGroup.setGroupSource(RangerCommonEnums.GROUP_EXTERNAL);
-
-                    VXGroup vXGroup = xGroupService.createXGroupWithOutLogin(vxGroup);
-
-                    if (vXGroup != null) {
-                        xGroupService.createTransactionLog(vXGroup, null, OPERATION_CREATE_CONTEXT, xPolicy.getAddedByUserId());
-
-                        ret = vXGroup.getId();
-                    }
-                }
-                break;
-                case ROLE: {
-                    try {
-                        RangerRole rRole       = new RangerRole(name, null, null, null, null);
-                        RangerRole createdRole = roleStore.createRole(rRole, false);
-
-                        ret = createdRole.getId();
-                    } catch (Exception e) {
-                        // Ignore
-                    }
-                }
-                break;
-                default:
-                    break;
+        private Long createRole() {
+            LOG.warn("Role specified in policy does not exist in ranger admin, creating new role, name = {}", name);
+            try {
+                RangerRole rRole       = new RangerRole(name, null, null, null, null);
+                RangerRole createdRole = roleStore.createRole(rRole, false);
+                return createdRole.getId();
+            } catch (Exception e) {
+                return null;
             }
+        }
+    }
 
-            LOG.debug("<=== PolicyPrincipalAssociator.createPrincipal(type={}, name={}) : {}", type.name(), name, ret);
+    private class PolicyGroupAssociator implements Runnable {
+        private final String   name;
+        private final Long     groupId;
+        private final XXPolicy xPolicy;
 
-            return ret;
+        PolicyGroupAssociator(String name, Long groupId, XXPolicy xPolicy) {
+            this.name     = name;
+            this.groupId  = groupId;
+            this.xPolicy  = xPolicy;
         }
 
-        private boolean doesPolicyExist(XXPolicy xPolicy) {
-            return daoMgr.getXXPolicy().getById(xPolicy.getId()) != null;
+        public XXPolicyRefGroup getPolicyRef() {
+            Long id = resolveGroupId(false);
+            if (id == null || !doesPolicyExist(xPolicy)) {
+                return null;
+            }
+            XXPolicyRefGroup xPolGroup = new XXPolicyRefGroup();
+            xPolGroup.setPolicyId(xPolicy.getId());
+            xPolGroup.setGroupId(id);
+            xPolGroup.setGroupName(name);
+            return xPolGroup;
         }
 
-        private void createPolicyAssociation(Long id, String name, boolean isAdmin) {
-            LOG.debug("===> PolicyPrincipalAssociator.createPolicyAssociation(policyId={}, type={}, name={}, id={}, isAdmin={})", xPolicy.getId(), type.name(),
-                    name, id, isAdmin);
-
+        public void createPolicyRef(Long id) {
             if (doesPolicyExist(xPolicy)) {
-                switch (type) {
-                    case USER: {
-                        XXPolicyRefUser xPolUser = new XXPolicyRefUser();
-
-                        xPolUser.setPolicyId(xPolicy.getId());
-                        xPolUser.setUserId(id);
-                        xPolUser.setUserName(name);
-                        if (isAdmin) {
-                            daoMgr.getXXPolicyRefUser().create(xPolUser);
-                        } else {
-                            xPolUsers.add(xPolUser);
-                        }
-                    }
-                    break;
-                    case GROUP: {
-                        XXPolicyRefGroup xPolGroup = new XXPolicyRefGroup();
-
-                        xPolGroup.setPolicyId(xPolicy.getId());
-                        xPolGroup.setGroupId(id);
-                        xPolGroup.setGroupName(name);
-                        if (isAdmin) {
-                            daoMgr.getXXPolicyRefGroup().create(xPolGroup);
-                        } else {
-                            xPolGroups.add(xPolGroup);
-                        }
-                    }
-                    break;
-                    case ROLE: {
-                        XXPolicyRefRole xPolRole = new XXPolicyRefRole();
-
-                        xPolRole.setPolicyId(xPolicy.getId());
-                        xPolRole.setRoleId(id);
-                        xPolRole.setRoleName(name);
-                        if (isAdmin) {
-                            daoMgr.getXXPolicyRefRole().create(xPolRole);
-                        } else {
-                            xPolRoles.add(xPolRole);
-                        }
-                    }
-                    break;
-                    default:
-                        break;
-                }
+                XXPolicyRefGroup xPolGroup = new XXPolicyRefGroup();
+                xPolGroup.setPolicyId(xPolicy.getId());
+                xPolGroup.setGroupId(id);
+                xPolGroup.setGroupName(name);
+                daoMgr.getXXPolicyRefGroup().create(xPolGroup);
             } else {
                 LOG.info("Policy with id ={} does not exist, skipping policy association!", xPolicy.getId());
             }
+        }
 
-            LOG.debug("<=== PolicyPrincipalAssociator.createPolicyAssociation(policyId={}, type={}, name={}, id={})", xPolicy.getId(), type.name(), name, id);
+        @Override
+        public void run() {
+            Long id = resolveGroupId(true);
+            if (id != null) {
+                createPolicyRef(id);
+                LOG.debug("Associated GROUP:{} with policy id:[{}]", name, xPolicy.getId());
+            } else {
+                throw new RuntimeException("Failed to associate GROUP:" + name + " with policy id:[" + xPolicy.getId() + "]");
+            }
+        }
+
+        private Long resolveGroupId(boolean createIfAbsent) {
+            if (groupId != null) {
+                return groupId;
+            }
+            XXGroup xGroup = daoMgr.getXXGroup().findByGroupName(name);
+            if (xGroup != null) {
+                return xGroup.getId();
+            }
+            if (createIfAbsent) {
+                return createGroup();
+            }
+            return null;
+        }
+
+        private Long createGroup() {
+            LOG.warn("Group specified in policy does not exist in ranger admin, creating new group, name = {}", name);
+            VXGroup vxGroup = new VXGroup();
+            vxGroup.setName(name);
+            vxGroup.setDescription(name);
+            vxGroup.setGroupSource(RangerCommonEnums.GROUP_EXTERNAL);
+            VXGroup vXGroup = xGroupService.createXGroupWithOutLogin(vxGroup);
+            if (vXGroup != null) {
+                xGroupService.createTransactionLog(vXGroup, null, OPERATION_CREATE_CONTEXT, xPolicy.getAddedByUserId());
+                return vXGroup.getId();
+            }
+            return null;
+        }
+    }
+
+    private class PolicyUserAssociator implements Runnable {
+        private final String   name;
+        private final Long     userId;
+        private final XXPolicy xPolicy;
+
+        PolicyUserAssociator(String name, Long userId, XXPolicy xPolicy) {
+            this.name    = name;
+            this.userId  = userId;
+            this.xPolicy = xPolicy;
+        }
+
+        public XXPolicyRefUser getPolicyRef() {
+            Long id = resolveUserId(false);
+            if (id == null || !doesPolicyExist(xPolicy)) {
+                return null;
+            }
+            XXPolicyRefUser xPolUser = new XXPolicyRefUser();
+            xPolUser.setPolicyId(xPolicy.getId());
+            xPolUser.setUserId(id);
+            xPolUser.setUserName(name);
+            return xPolUser;
+        }
+
+        public void createPolicyRef(Long id) {
+            if (doesPolicyExist(xPolicy)) {
+                XXPolicyRefUser xPolUser = new XXPolicyRefUser();
+                xPolUser.setPolicyId(xPolicy.getId());
+                xPolUser.setUserId(id);
+                xPolUser.setUserName(name);
+                daoMgr.getXXPolicyRefUser().create(xPolUser);
+            } else {
+                LOG.info("Policy with id ={} does not exist, skipping policy association!", xPolicy.getId());
+            }
+        }
+
+        @Override
+        public void run() {
+            Long id = resolveUserId(true);
+            if (id != null) {
+                createPolicyRef(id);
+                LOG.debug("Associated USER:{} with policy id:[{}]", name, xPolicy.getId());
+            } else {
+                throw new RuntimeException("Failed to associate USER:" + name + " with policy id:[" + xPolicy.getId() + "]");
+            }
+        }
+
+        private Long resolveUserId(boolean createIfAbsent) {
+            if (userId != null) {
+                return userId;
+            }
+            XXUser xUser = daoMgr.getXXUser().findByUserName(name);
+            if (xUser != null) {
+                return xUser.getId();
+            }
+            if (createIfAbsent) {
+                return createUser();
+            }
+            return null;
+        }
+
+        private Long createUser() {
+            LOG.warn("User specified in policy does not exist in ranger admin, creating new user, name = {}", name);
+            VXUser vXUser = xUserMgr.createServiceConfigUser(name);
+            if (vXUser != null) {
+                XXUser xUser = daoMgr.getXXUser().findByUserName(name);
+                if (xUser == null) {
+                    LOG.error("No User created!! Irrecoverable error! [{}]", name);
+                } else {
+                    return xUser.getId();
+                }
+            } else {
+                LOG.warn("serviceConfigUser:[{}] creation failed. This may be a transient/spurious condition that may correct itself when transaction is committed", name);
+            }
+            return null;
         }
     }
 

--- a/security-admin/src/main/java/org/apache/ranger/biz/PolicyRefUpdater.java
+++ b/security-admin/src/main/java/org/apache/ranger/biz/PolicyRefUpdater.java
@@ -22,8 +22,12 @@ import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.ranger.common.RESTErrorUtil;
 import org.apache.ranger.common.RangerCommonEnums;
+import org.apache.ranger.common.db.BaseDao;
 import org.apache.ranger.common.db.RangerTransactionSynchronizationAdapter;
 import org.apache.ranger.db.RangerDaoManager;
+import org.apache.ranger.db.XXPolicyRefGroupDao;
+import org.apache.ranger.db.XXPolicyRefRoleDao;
+import org.apache.ranger.db.XXPolicyRefUserDao;
 import org.apache.ranger.entity.XXAccessTypeDef;
 import org.apache.ranger.entity.XXDataMaskTypeDef;
 import org.apache.ranger.entity.XXGroup;
@@ -62,7 +66,10 @@ import javax.servlet.http.HttpServletResponse;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.apache.ranger.service.RangerBaseModelService.OPERATION_CREATE_CONTEXT;
 
@@ -121,12 +128,10 @@ public class PolicyRefUpdater {
         return ret;
     }
 
-    public void createNewPolMappingForRefTable(RangerPolicy policy, XXPolicy xPolicy, XXServiceDef xServiceDef, boolean createPrincipalsIfAbsent) throws Exception {
+    public void createNewPolMappingForRefTable(RangerPolicy policy, XXPolicy xPolicy, XXServiceDef xServiceDef, boolean createPrincipalsIfAbsent, boolean isCleanupRefTablesNeeded) throws Exception {
         if (policy == null) {
             return;
         }
-
-        cleanupRefTables(policy);
 
         final Set<String> resourceNames  = policy.getResources().keySet();
         final Set<String> roleNames      = new HashSet<>();
@@ -136,6 +141,7 @@ public class PolicyRefUpdater {
         final Set<String> conditionTypes = new HashSet<>();
         final Set<String> dataMaskTypes  = new HashSet<>();
         boolean           oldBulkMode    = RangerBizUtil.isBulkMode();
+        final Long policyId = policy.getId();
 
         List<RangerPolicy.RangerPolicyItemCondition> rangerPolicyConditions = policy.getConditions();
 
@@ -175,25 +181,26 @@ public class PolicyRefUpdater {
             }
         }
 
-        List<XXPolicyRefResource> xPolResources = new ArrayList<>();
-
-        for (String resource : resourceNames) {
-            XXResourceDef xResDef = daoMgr.getXXResourceDef().findByNameAndPolicyId(resource, policy.getId());
-
-            if (xResDef == null) {
-                throw new Exception(resource + ": is not a valid resource-type. policy='" + policy.getName() + "' service='" + policy.getService() + "'");
-            }
-
-            XXPolicyRefResource xPolRes = new XXPolicyRefResource();
-
-            xPolRes.setPolicyId(policy.getId());
-            xPolRes.setResourceDefId(xResDef.getId());
-            xPolRes.setResourceName(resource);
-
-            xPolResources.add(xPolRes);
+        if (isCleanupRefTablesNeeded) {
+            cleanupRefTablesForUpdate(policyId, userNames, roleNames, groupNames);
         }
 
-        daoMgr.getXXPolicyRefResource().batchCreate(xPolResources);
+        if (CollectionUtils.isNotEmpty(resourceNames)) {
+            List<XXPolicyRefResource> xPolResources = new ArrayList<>();
+            Map<String, XXResourceDef> nameToResDefMap = daoMgr.getXXResourceDef().findXXResourceDefsByNameAndPolicyId(resourceNames, policy.getId());
+            for (String resource : resourceNames) {
+                XXResourceDef xResDef = nameToResDefMap.get(resource);
+                if (xResDef == null) {
+                    throw new Exception(resource + ": is not a valid resource-type. policy='" + policy.getName() + "' service='" + policy.getService() + "'");
+                }
+                XXPolicyRefResource xPolRes = new XXPolicyRefResource();
+                xPolRes.setPolicyId(policy.getId());
+                xPolRes.setResourceDefId(xResDef.getId());
+                xPolRes.setResourceName(resource);
+                xPolResources.add(xPolRes);
+            }
+            batchInsert(xPolResources, daoMgr.getXXPolicyRefResource(), oldBulkMode);
+        }
 
         if (createPrincipalsIfAbsent && !rangerBizUtil.checkAdminAccess()) {
             LOG.warn("policy={}: createPrincipalIfAbsent=true, but current user does not have admin privileges!", policy.getName());
@@ -202,140 +209,143 @@ public class PolicyRefUpdater {
         }
 
         List<XXPolicyRefRole> xPolRoles = new ArrayList<>();
+        if (CollectionUtils.isNotEmpty(roleNames)) {
+            LOG.debug("x_policy_ref_role - New role entries to insert for policy ID {}: {}", policyId, roleNames);
+            Set<String> filteredRoleNames = roleNames.stream()
+                    .filter(str -> !StringUtils.isBlank(str))
+                    .collect(Collectors.toSet());
+            Map<String, Long> roleNameIdMap = daoMgr.getXXRole().getIdsByRoleNames(filteredRoleNames);
+            for (String roleName : filteredRoleNames) {
+                PolicyPrincipalAssociator associator = new PolicyPrincipalAssociator(PRINCIPAL_TYPE.ROLE, roleName, xPolicy, roleNameIdMap.get(roleName), null, null, xPolRoles);
+                if (!associator.doAssociate(false)) {
+                    if (createPrincipalsIfAbsent) {
+                        rangerTransactionSynchronizationAdapter.executeOnTransactionCommit(associator);
+                    } else {
+                        VXResponse gjResponse = new VXResponse();
 
-        for (String role : roleNames) {
-            if (StringUtils.isBlank(role)) {
-                continue;
-            }
-
-            PolicyPrincipalAssociator associator = new PolicyPrincipalAssociator(PRINCIPAL_TYPE.ROLE, role, xPolicy);
-
-            if (!associator.doAssociate(false)) {
-                if (createPrincipalsIfAbsent) {
-                    rangerTransactionSynchronizationAdapter.executeOnTransactionCommit(associator);
-                } else {
-                    VXResponse gjResponse = new VXResponse();
-
-                    gjResponse.setStatusCode(HttpServletResponse.SC_BAD_REQUEST);
-                    gjResponse.setMsgDesc("Operation denied. Role name: " + role + " specified in policy does not exist in ranger admin.");
-
-                    throw restErrorUtil.generateRESTException(gjResponse);
+                        gjResponse.setStatusCode(HttpServletResponse.SC_BAD_REQUEST);
+                        gjResponse.setMsgDesc("Operation denied. Role name: " + roleName + " specified in policy does not exist in ranger admin.");
+                        throw restErrorUtil.generateRESTException(gjResponse);
+                    }
                 }
             }
+            batchInsert(xPolRoles, daoMgr.getXXPolicyRefRole(), oldBulkMode);
         }
 
-        RangerBizUtil.setBulkMode(oldBulkMode);
+        if (CollectionUtils.isNotEmpty(groupNames)) {
+            LOG.debug("x_policy_ref_group - New group entries to insert for policy ID {}: {}", policyId, groupNames);
+            Set<String> filteredGroupNames = groupNames.stream()
+                    .filter(str -> !StringUtils.isBlank(str))
+                    .collect(Collectors.toSet());
+            Map<String, Long> groupNameIdMap = daoMgr.getXXGroup().getIdsByGroupNames(filteredGroupNames);
+            List<XXPolicyRefGroup> xPolGroups = new ArrayList<>();
+            for (String groupName : filteredGroupNames) {
+                PolicyPrincipalAssociator associator = new PolicyPrincipalAssociator(PRINCIPAL_TYPE.GROUP, groupName, xPolicy, groupNameIdMap.get(groupName), null, xPolGroups, null);
+                if (!associator.doAssociate(false)) {
+                    if (createPrincipalsIfAbsent) {
+                        rangerTransactionSynchronizationAdapter.executeOnTransactionCommit(associator);
+                    } else {
+                        VXResponse gjResponse = new VXResponse();
 
-        daoMgr.getXXPolicyRefRole().batchCreate(xPolRoles);
+                        gjResponse.setStatusCode(HttpServletResponse.SC_BAD_REQUEST);
+                        gjResponse.setMsgDesc("Operation denied. Group name: " + groupName + " specified in policy does not exist in ranger admin.");
 
-        for (String group : groupNames) {
-            if (StringUtils.isBlank(group)) {
-                continue;
-            }
-
-            PolicyPrincipalAssociator associator = new PolicyPrincipalAssociator(PRINCIPAL_TYPE.GROUP, group, xPolicy);
-
-            if (!associator.doAssociate(false)) {
-                if (createPrincipalsIfAbsent) {
-                    rangerTransactionSynchronizationAdapter.executeOnTransactionCommit(associator);
-                } else {
-                    VXResponse gjResponse = new VXResponse();
-
-                    gjResponse.setStatusCode(HttpServletResponse.SC_BAD_REQUEST);
-                    gjResponse.setMsgDesc("Operation denied. Group name: " + group + " specified in policy does not exist in ranger admin.");
-
-                    throw restErrorUtil.generateRESTException(gjResponse);
+                        throw restErrorUtil.generateRESTException(gjResponse);
+                    }
                 }
             }
+            batchInsert(xPolGroups, daoMgr.getXXPolicyRefGroup(), oldBulkMode);
         }
 
-        for (String user : userNames) {
-            if (StringUtils.isBlank(user)) {
-                continue;
-            }
+        if (CollectionUtils.isNotEmpty(userNames)) {
+            LOG.debug("x_policy_ref_user - New user entries to insert for policy ID {}: {}", policyId, userNames);
+            List<XXPolicyRefUser> xPolUsers = new ArrayList<>();
+            Set<String> filteredUserNames = userNames.stream()
+                    .filter(str -> !StringUtils.isBlank(str))
+                    .collect(Collectors.toSet());
+            Map<String, Long> userNameIdMap = daoMgr.getXXUser().getIdsByUserNames(filteredUserNames);
+            for (String userName : filteredUserNames) {
+                PolicyPrincipalAssociator associator = new PolicyPrincipalAssociator(PRINCIPAL_TYPE.USER, userName, xPolicy, userNameIdMap.get(userName), xPolUsers, null, null);
+                if (!associator.doAssociate(false)) {
+                    if (createPrincipalsIfAbsent) {
+                        rangerTransactionSynchronizationAdapter.executeOnTransactionCommit(associator);
+                    } else {
+                        VXResponse gjResponse = new VXResponse();
 
-            PolicyPrincipalAssociator associator = new PolicyPrincipalAssociator(PRINCIPAL_TYPE.USER, user, xPolicy);
+                        gjResponse.setStatusCode(HttpServletResponse.SC_BAD_REQUEST);
+                        gjResponse.setMsgDesc("Operation denied. User name: " + userName + " specified in policy does not exist in ranger admin.");
 
-            if (!associator.doAssociate(false)) {
-                if (createPrincipalsIfAbsent) {
-                    rangerTransactionSynchronizationAdapter.executeOnTransactionCommit(associator);
-                } else {
-                    VXResponse gjResponse = new VXResponse();
-
-                    gjResponse.setStatusCode(HttpServletResponse.SC_BAD_REQUEST);
-                    gjResponse.setMsgDesc("Operation denied. User name: " + user + " specified in policy does not exist in ranger admin.");
-
-                    throw restErrorUtil.generateRESTException(gjResponse);
+                        throw restErrorUtil.generateRESTException(gjResponse);
+                    }
                 }
             }
+            batchInsert(xPolUsers, daoMgr.getXXPolicyRefUser(), oldBulkMode);
         }
-
-        List<XXPolicyRefAccessType> xPolAccesses = new ArrayList<>();
 
         // ignore built-in access-types while creating ref-table entries
         accessTypes.removeAll(ServiceDefUtil.ACCESS_TYPE_MARKERS);
-
-        for (String accessType : accessTypes) {
-            XXAccessTypeDef xAccTypeDef = daoMgr.getXXAccessTypeDef().findByNameAndServiceId(accessType, xPolicy.getService());
-
-            if (xAccTypeDef == null) {
-                throw new Exception(accessType + ": is not a valid access-type. policy='" + policy.getName() + "' service='" + policy.getService() + "'");
-            }
-
-            XXPolicyRefAccessType xPolAccess = new XXPolicyRefAccessType();
-
-            xPolAccess.setPolicyId(policy.getId());
-            xPolAccess.setAccessDefId(xAccTypeDef.getId());
-            xPolAccess.setAccessTypeName(accessType);
-
-            xPolAccesses.add(xPolAccess);
-        }
-
-        daoMgr.getXXPolicyRefAccessType().batchCreate(xPolAccesses);
-
-        List<XXPolicyRefCondition> xPolConds = new ArrayList<>();
-
-        for (String condition : conditionTypes) {
-            XXPolicyConditionDef xPolCondDef = daoMgr.getXXPolicyConditionDef().findByServiceDefIdAndName(xServiceDef.getId(), condition);
-
-            if (xPolCondDef == null) {
-                if (StringUtils.equalsIgnoreCase(condition, ServiceDefUtil.IMPLICIT_CONDITION_EXPRESSION_NAME)) {
-                    continue;
+        if (CollectionUtils.isNotEmpty(accessTypes)) {
+            List<XXPolicyRefAccessType> xPolAccesses = new ArrayList<>();
+            Map<String, XXAccessTypeDef> nameToAccessTypeDefMap = daoMgr.getXXAccessTypeDef().findByNamesAndServiceId(accessTypes, xPolicy.getService());
+            for (String accessType : accessTypes) {
+                XXAccessTypeDef xAccTypeDef = nameToAccessTypeDefMap.get(accessType);
+                if (xAccTypeDef == null) {
+                    throw new Exception(accessType + ": is not a valid access-type. policy='" + policy.getName() + "' service='" + policy.getService() + "'");
                 }
 
-                throw new Exception(condition + ": is not a valid condition-type. policy='" + xPolicy.getName() + "' service='" + xPolicy.getService() + "'");
+                XXPolicyRefAccessType xPolAccess = new XXPolicyRefAccessType();
+
+                xPolAccess.setPolicyId(policy.getId());
+                xPolAccess.setAccessDefId(xAccTypeDef.getId());
+                xPolAccess.setAccessTypeName(accessType);
+
+                xPolAccesses.add(xPolAccess);
             }
-
-            XXPolicyRefCondition xPolCond = new XXPolicyRefCondition();
-
-            xPolCond.setPolicyId(policy.getId());
-            xPolCond.setConditionDefId(xPolCondDef.getId());
-            xPolCond.setConditionName(condition);
-
-            xPolConds.add(xPolCond);
+            batchInsert(xPolAccesses, daoMgr.getXXPolicyRefAccessType(), oldBulkMode);
         }
 
-        daoMgr.getXXPolicyRefCondition().batchCreate(xPolConds);
+        if (CollectionUtils.isNotEmpty(conditionTypes)) {
+            List<XXPolicyRefCondition> xPolConds = new ArrayList<>();
+            Map<String, XXPolicyConditionDef> nameToConditionDefMap = daoMgr.getXXPolicyConditionDef().findByServiceDefIdAndNames(xServiceDef.getId(), conditionTypes);
+            for (String condition : conditionTypes) {
+                XXPolicyConditionDef xPolCondDef = nameToConditionDefMap.get(condition);
+                if (xPolCondDef == null) {
+                    if (StringUtils.equalsIgnoreCase(condition, ServiceDefUtil.IMPLICIT_CONDITION_EXPRESSION_NAME)) {
+                        continue;
+                    }
+                    throw new Exception(condition + ": is not a valid condition-type. policy='" + xPolicy.getName() + "' service='" + xPolicy.getService() + "'");
+                }
 
-        List<XXPolicyRefDataMaskType> xxDataMaskInfos = new ArrayList<>();
+                XXPolicyRefCondition xPolCond = new XXPolicyRefCondition();
+                xPolCond.setPolicyId(policy.getId());
+                xPolCond.setConditionDefId(xPolCondDef.getId());
+                xPolCond.setConditionName(condition);
 
-        for (String dataMaskType : dataMaskTypes) {
-            XXDataMaskTypeDef dataMaskDef = daoMgr.getXXDataMaskTypeDef().findByNameAndServiceId(dataMaskType, xPolicy.getService());
-
-            if (dataMaskDef == null) {
-                throw new Exception(dataMaskType + ": is not a valid datamask-type. policy='" + policy.getName() + "' service='" + policy.getService() + "'");
+                xPolConds.add(xPolCond);
             }
-
-            XXPolicyRefDataMaskType xxDataMaskInfo = new XXPolicyRefDataMaskType();
-
-            xxDataMaskInfo.setPolicyId(policy.getId());
-            xxDataMaskInfo.setDataMaskDefId(dataMaskDef.getId());
-            xxDataMaskInfo.setDataMaskTypeName(dataMaskType);
-
-            xxDataMaskInfos.add(xxDataMaskInfo);
+            batchInsert(xPolConds, daoMgr.getXXPolicyRefCondition(), oldBulkMode);
         }
 
-        daoMgr.getXXPolicyRefDataMaskType().batchCreate(xxDataMaskInfos);
+        if (CollectionUtils.isNotEmpty(dataMaskTypes)) {
+            List<XXPolicyRefDataMaskType> xxDataMaskInfos = new ArrayList<>();
+            Map<String, XXDataMaskTypeDef> namesToDataMaskTypeDefMap = daoMgr.getXXDataMaskTypeDef().findByNamesAndServiceId(dataMaskTypes, xPolicy.getService());
+            for (String dataMaskType : dataMaskTypes) {
+                XXDataMaskTypeDef dataMaskDef = namesToDataMaskTypeDefMap.get(dataMaskType);
+                if (dataMaskDef == null) {
+                    throw new Exception(dataMaskType + ": is not a valid datamask-type. policy='" + policy.getName() + "' service='" + policy.getService() + "'");
+                }
+
+                XXPolicyRefDataMaskType xxDataMaskInfo = new XXPolicyRefDataMaskType();
+
+                xxDataMaskInfo.setPolicyId(policy.getId());
+                xxDataMaskInfo.setDataMaskDefId(dataMaskDef.getId());
+                xxDataMaskInfo.setDataMaskTypeName(dataMaskType);
+
+                xxDataMaskInfos.add(xxDataMaskInfo);
+            }
+
+            batchInsert(xxDataMaskInfos, daoMgr.getXXPolicyRefDataMaskType(), oldBulkMode);
+        }
     }
 
     public Boolean cleanupRefTables(RangerPolicy policy) {
@@ -356,17 +366,151 @@ public class PolicyRefUpdater {
         return true;
     }
 
+    /**
+     * Cleans up reference tables for a given policy before updating it.
+     * This includes handling policy reference users, roles, and other
+     * associated reference entities like resources, groups, access types,
+     * conditions, and data mask types.
+     *
+     * @param policyId      ID of the policy being updated.
+     * @param policyUsers   Set of usernames associated with the updated policy.
+     * @param policyRoles   Set of role names associated with the updated policy.
+     * @param policyGroups   Set of group names associated with the updated policy.
+     * @return              true if cleanup was successful.
+     */
+    public Boolean cleanupRefTablesForUpdate(Long policyId, Set<String> policyUsers, Set<String> policyRoles, Set<String> policyGroups) {
+        XXPolicyRefUserDao xPolicyRefUserDao = daoMgr.getXXPolicyRefUser();
+        XXPolicyRefRoleDao xxPolicyRefRoleDao = daoMgr.getXXPolicyRefRole();
+        XXPolicyRefGroupDao xxPolicyRefGroupDao = daoMgr.getXXPolicyRefGroup();
+
+        Map<String, Long> policyUserNameIdMap   = xPolicyRefUserDao.findUserNameIdByPolicyId(policyId);
+        Map<String, Long> policyRoleNameIdMap   = xxPolicyRefRoleDao.findRoleNameIdByPolicyId(policyId);
+        Map<String, Long> policyGroupNameIdMap   = xxPolicyRefGroupDao.findGroupNameByPolicyId(policyId);
+        cleanupPolicyRefUsers(policyUsers, policyUserNameIdMap, policyId, xPolicyRefUserDao);
+        cleanupPolicyRefRoles(policyRoles, policyRoleNameIdMap, policyId, xxPolicyRefRoleDao);
+        cleanupPolicyRefGroups(policyGroups, policyGroupNameIdMap, policyId, xxPolicyRefGroupDao);
+        daoMgr.getXXPolicyRefResource().deleteByPolicyId(policyId);
+        daoMgr.getXXPolicyRefAccessType().deleteByPolicyId(policyId);
+        daoMgr.getXXPolicyRefCondition().deleteByPolicyId(policyId);
+        daoMgr.getXXPolicyRefDataMaskType().deleteByPolicyId(policyId);
+        return true;
+    }
+
+    /**
+     * Identifies and deletes outdated user references for a given policy,
+     * and prepares a list of new users that need to be inserted.
+     *
+     * @param policyUsers           Set of usernames from the new policy.
+     * @param policyUserNameIdMap   Existing mapping of usernames to their DB IDs for the policy.
+     * @param policyId              The ID of the policy.
+     * @param dao                   DAO for policy reference users.
+     */
+    public void cleanupPolicyRefUsers(Set<String> policyUsers, Map<String, Long> policyUserNameIdMap, Long policyId, XXPolicyRefUserDao dao) {
+        if (policyUserNameIdMap != null && !policyUserNameIdMap.isEmpty()) {
+            Set<String> existingPolicyRefUsers = policyUserNameIdMap.keySet();
+            Set<String> toDeletePolicyRefUsers = new HashSet<>(existingPolicyRefUsers);
+            Set<String> commonUsers = new HashSet<>(policyUsers);
+            // Identify users present in both new and existing sets
+            commonUsers.retainAll(toDeletePolicyRefUsers);
+            // Identify users to delete (in DB but not in new set)
+            toDeletePolicyRefUsers.removeAll(commonUsers);
+            // Remove already existing users from the new set (they don’t need to be inserted again)
+            policyUsers.removeAll(commonUsers);
+            if (CollectionUtils.isNotEmpty(toDeletePolicyRefUsers)) {
+                List<Long> idsToDelete = toDeletePolicyRefUsers.stream()
+                        .map(policyUserNameIdMap::get)
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toList());
+
+                LOG.debug("Deleting user IDs from x_policy_ref_user table: {} for policy ID: {}", idsToDelete, policyId);
+                dao.deletePolicyRefUserByIds(idsToDelete);
+            }
+        }
+    }
+
+    /**
+     * Identifies and deletes outdated role references for a given policy,
+     * and prepares a list of new roles that need to be inserted.
+     *
+     * @param policyRoles           Set of role names from the new policy.
+     * @param policyRoleNameIdMap   Existing mapping of role names to their DB IDs for the policy.
+     * @param policyId              The ID of the policy.
+     * @param dao                   DAO for policy reference roles.
+     */
+    public void cleanupPolicyRefRoles(Set<String> policyRoles, Map<String, Long> policyRoleNameIdMap, Long policyId, XXPolicyRefRoleDao dao) {
+        if (policyRoleNameIdMap != null && !policyRoleNameIdMap.isEmpty()) {
+            Set<String> existingPolicyRefRoles = policyRoleNameIdMap.keySet();
+            Set<String> toDeletePolicyRefRoles = new HashSet<>(existingPolicyRefRoles);
+            Set<String> commonRoles = new HashSet<>(policyRoles);
+            // Identify roles present in both new and existing sets
+            commonRoles.retainAll(toDeletePolicyRefRoles);
+            // Identify roles to delete (in DB but not in new set)
+            toDeletePolicyRefRoles.removeAll(commonRoles);
+            // Remove already existing roles from the new set (they don’t need to be inserted again)
+            policyRoles.removeAll(commonRoles);
+            if (CollectionUtils.isNotEmpty(toDeletePolicyRefRoles)) {
+                List<Long> idsToDelete = toDeletePolicyRefRoles.stream()
+                        .map(policyRoleNameIdMap::get)
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toList());
+
+                LOG.debug("Deleting Role IDs from x_policy_ref_role: {} for policy ID: {}", idsToDelete, policyId);
+                dao.deletePolicyRefRoleByIds(idsToDelete);
+            }
+        }
+    }
+
+    /**
+     * Identifies and deletes outdated group references for a given policy,
+     * and prepares a list of new groups that need to be inserted.
+     *
+     * @param policyGroups           Set of group names from the new policy.
+     * @param policyGroupNameIdMap   Existing mapping of group names to their DB IDs for the policy.
+     * @param policyId              The ID of the policy.
+     * @param dao                   DAO for policy reference groups.
+     */
+    public void cleanupPolicyRefGroups(Set<String> policyGroups, Map<String, Long> policyGroupNameIdMap, Long policyId, XXPolicyRefGroupDao dao) {
+        if (policyGroupNameIdMap != null && !policyGroupNameIdMap.isEmpty()) {
+            Set<String> existingPolicyRefGroups = policyGroupNameIdMap.keySet();
+            Set<String> toDeletePolicyRefGroups = new HashSet<>(existingPolicyRefGroups);
+            Set<String> commonGroups = new HashSet<>(policyGroups);
+            // Identify groups present in both new and existing sets
+            commonGroups.retainAll(toDeletePolicyRefGroups);
+            // Identify groups to delete (in DB but not in new set)
+            toDeletePolicyRefGroups.removeAll(commonGroups);
+            // Remove already existing groups from the new set (they don’t need to be inserted again)
+            policyGroups.removeAll(commonGroups);
+            if (CollectionUtils.isNotEmpty(toDeletePolicyRefGroups)) {
+                List<Long> idsToDelete = toDeletePolicyRefGroups.stream()
+                        .map(policyGroupNameIdMap::get)
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toList());
+
+                LOG.debug("Deleting Group IDs from x_policy_ref_group: {} for policy ID: {}", idsToDelete, policyId);
+                dao.deletePolicyRefGroupByIds(idsToDelete);
+            }
+        }
+    }
+
     public enum PRINCIPAL_TYPE { USER, GROUP, ROLE }
 
     private class PolicyPrincipalAssociator implements Runnable {
         final PRINCIPAL_TYPE type;
         final String         name;
         final XXPolicy       xPolicy;
+        final Long id;
+        final List<XXPolicyRefUser> xPolUsers;
+        final List<XXPolicyRefGroup> xPolGroups;
+        final List<XXPolicyRefRole> xPolRoles;
 
-        public PolicyPrincipalAssociator(PRINCIPAL_TYPE type, String name, XXPolicy xPolicy) {
+        public PolicyPrincipalAssociator(PRINCIPAL_TYPE type, String name, XXPolicy xPolicy, Long id, List<XXPolicyRefUser> xPolUsers, List<XXPolicyRefGroup> xPolGroups, List<XXPolicyRefRole> xPolRoles) {
             this.type    = type;
             this.name    = name;
             this.xPolicy = xPolicy;
+            this.id = id;
+            this.xPolUsers = xPolUsers;
+            this.xPolGroups = xPolGroups;
+            this.xPolRoles = xPolRoles;
         }
 
         @Override
@@ -387,7 +531,7 @@ public class PolicyRefUpdater {
 
             if (id != null) {
                 // associate with policy
-                createPolicyAssociation(id, name);
+                createPolicyAssociation(id, name, isAdmin);
 
                 ret = true;
             } else {
@@ -401,6 +545,10 @@ public class PolicyRefUpdater {
 
         private Long createOrGetPrincipal(final boolean createIfAbsent) {
             LOG.debug("===> PolicyPrincipalAssociator.createOrGetPrincipal({})", createIfAbsent);
+
+            if (id != null) {
+                return id;
+            }
 
             Long ret = null;
 
@@ -512,45 +660,75 @@ public class PolicyRefUpdater {
             return ret;
         }
 
-        private void createPolicyAssociation(Long id, String name) {
-            LOG.debug("===> PolicyPrincipalAssociator.createPolicyAssociation(policyId={}, type={}, name={}, id={})", xPolicy.getId(), type.name(), name, id);
+        private boolean doesPolicyExist(XXPolicy xPolicy) {
+            return daoMgr.getXXPolicy().getById(xPolicy.getId()) != null;
+        }
 
-            switch (type) {
-                case USER: {
-                    XXPolicyRefUser xPolUser = new XXPolicyRefUser();
+        private void createPolicyAssociation(Long id, String name, boolean isAdmin) {
+            LOG.debug("===> PolicyPrincipalAssociator.createPolicyAssociation(policyId={}, type={}, name={}, id={}, isAdmin={})", xPolicy.getId(), type.name(),
+                    name, id, isAdmin);
 
-                    xPolUser.setPolicyId(xPolicy.getId());
-                    xPolUser.setUserId(id);
-                    xPolUser.setUserName(name);
+            if (doesPolicyExist(xPolicy)) {
+                switch (type) {
+                    case USER: {
+                        XXPolicyRefUser xPolUser = new XXPolicyRefUser();
 
-                    daoMgr.getXXPolicyRefUser().create(xPolUser);
-                }
-                break;
-                case GROUP: {
-                    XXPolicyRefGroup xPolGroup = new XXPolicyRefGroup();
-
-                    xPolGroup.setPolicyId(xPolicy.getId());
-                    xPolGroup.setGroupId(id);
-                    xPolGroup.setGroupName(name);
-
-                    daoMgr.getXXPolicyRefGroup().create(xPolGroup);
-                }
-                break;
-                case ROLE: {
-                    XXPolicyRefRole xPolRole = new XXPolicyRefRole();
-
-                    xPolRole.setPolicyId(xPolicy.getId());
-                    xPolRole.setRoleId(id);
-                    xPolRole.setRoleName(name);
-
-                    daoMgr.getXXPolicyRefRole().create(xPolRole);
-                }
-                break;
-                default:
+                        xPolUser.setPolicyId(xPolicy.getId());
+                        xPolUser.setUserId(id);
+                        xPolUser.setUserName(name);
+                        if (isAdmin) {
+                            daoMgr.getXXPolicyRefUser().create(xPolUser);
+                        } else {
+                            xPolUsers.add(xPolUser);
+                        }
+                    }
                     break;
+                    case GROUP: {
+                        XXPolicyRefGroup xPolGroup = new XXPolicyRefGroup();
+
+                        xPolGroup.setPolicyId(xPolicy.getId());
+                        xPolGroup.setGroupId(id);
+                        xPolGroup.setGroupName(name);
+                        if (isAdmin) {
+                            daoMgr.getXXPolicyRefGroup().create(xPolGroup);
+                        } else {
+                            xPolGroups.add(xPolGroup);
+                        }
+                    }
+                    break;
+                    case ROLE: {
+                        XXPolicyRefRole xPolRole = new XXPolicyRefRole();
+
+                        xPolRole.setPolicyId(xPolicy.getId());
+                        xPolRole.setRoleId(id);
+                        xPolRole.setRoleName(name);
+                        if (isAdmin) {
+                            daoMgr.getXXPolicyRefRole().create(xPolRole);
+                        } else {
+                            xPolRoles.add(xPolRole);
+                        }
+                    }
+                    break;
+                    default:
+                        break;
+                }
+            } else {
+                LOG.info("Policy with id ={} does not exist, skipping policy association!", xPolicy.getId());
             }
 
             LOG.debug("<=== PolicyPrincipalAssociator.createPolicyAssociation(policyId={}, type={}, name={}, id={})", xPolicy.getId(), type.name(), name, id);
+        }
+    }
+
+    private <T> void batchInsert(List<T> entities, BaseDao<T> dao, boolean oldBulkMode) {
+        if (CollectionUtils.isNotEmpty(entities)) {
+            long startTimeMs = System.currentTimeMillis();
+            LOG.debug("Batch insert started for create/update {} with {} records.", dao.getClass().getSimpleName(), entities.size());
+            RangerBizUtil.setBulkMode(false);
+            dao.batchCreate(entities);
+            RangerBizUtil.setBulkMode(oldBulkMode);
+            long timeTakenMs = System.currentTimeMillis() - startTimeMs;
+            LOG.debug("Batch insert completed for create/update {} with {} records in {} ms.", dao.getClass().getSimpleName(), entities.size(), timeTakenMs);
         }
     }
 }

--- a/security-admin/src/main/java/org/apache/ranger/biz/PolicyRefUpdater.java
+++ b/security-admin/src/main/java/org/apache/ranger/biz/PolicyRefUpdater.java
@@ -183,18 +183,24 @@ public class PolicyRefUpdater {
 
         if (CollectionUtils.isNotEmpty(resourceNames)) {
             List<XXPolicyRefResource> xPolResources = new ArrayList<>();
-            Map<String, Long> nameToResDefIdMap = daoMgr.getXXResourceDef().findResourceDefIdsByNameAndPolicyId(resourceNames, policy.getId());
+            Map<String, Long>         nameToId      = daoMgr.getXXResourceDef().findResourceDefIdsByNameAndPolicyId(resourceNames, policy.getId());
+
             for (String resource : resourceNames) {
-                Long resourceDefId = nameToResDefIdMap.get(resource);
+                Long resourceDefId = nameToId.get(resource);
+
                 if (resourceDefId == null) {
                     throw new Exception(resource + ": is not a valid resource-type. policy='" + policy.getName() + "' service='" + policy.getService() + "'");
                 }
+
                 XXPolicyRefResource xPolRes = new XXPolicyRefResource();
+
                 xPolRes.setPolicyId(policy.getId());
                 xPolRes.setResourceDefId(resourceDefId);
                 xPolRes.setResourceName(resource);
+
                 xPolResources.add(xPolRes);
             }
+
             batchInsert(xPolResources, daoMgr.getXXPolicyRefResource(), oldBulkMode);
         }
 
@@ -204,18 +210,23 @@ public class PolicyRefUpdater {
             createPrincipalsIfAbsent = false;
         }
 
-        List<XXPolicyRefRole> xPolRoles = new ArrayList<>();
         if (CollectionUtils.isNotEmpty(roleNames)) {
             LOG.debug("x_policy_ref_role - New role entries to insert for policy ID {}: {}", policyId, roleNames);
+
             Set<String> filteredRoleNames = roleNames.stream()
-                    .filter(str -> !StringUtils.isBlank(str))
+                    .filter(StringUtils::isNotBlank)
                     .collect(Collectors.toSet());
-            Map<String, Long> roleNameIdMap = daoMgr.getXXRole().getIdsByRoleNames(filteredRoleNames);
+
+            List<XXPolicyRefRole> xPolRoles = new ArrayList<>();
+            Map<String, Long>     nameToId  = daoMgr.getXXRole().getIdsByRoleNames(filteredRoleNames);
+
             for (String roleName : filteredRoleNames) {
-                Long roleId = roleNameIdMap.get(roleName);
+                Long                 roleId     = nameToId.get(roleName);
                 PolicyRoleAssociator associator = new PolicyRoleAssociator(roleName, roleId, xPolicy);
+
                 if (roleId != null) {
                     XXPolicyRefRole roleRef = associator.getPolicyRef();
+
                     if (roleRef != null) {
                         xPolRoles.add(roleRef);
                     }
@@ -223,26 +234,34 @@ public class PolicyRefUpdater {
                     rangerTransactionSynchronizationAdapter.executeOnTransactionCommit(associator);
                 } else {
                     VXResponse gjResponse = new VXResponse();
+
                     gjResponse.setStatusCode(HttpServletResponse.SC_BAD_REQUEST);
                     gjResponse.setMsgDesc("Operation denied. Role name: " + roleName + " specified in policy does not exist in ranger admin.");
+
                     throw restErrorUtil.generateRESTException(gjResponse);
                 }
             }
+
             batchInsert(xPolRoles, daoMgr.getXXPolicyRefRole(), oldBulkMode);
         }
 
         if (CollectionUtils.isNotEmpty(groupNames)) {
             LOG.debug("x_policy_ref_group - New group entries to insert for policy ID {}: {}", policyId, groupNames);
+
             Set<String> filteredGroupNames = groupNames.stream()
-                    .filter(str -> !StringUtils.isBlank(str))
+                    .filter(StringUtils::isNotBlank)
                     .collect(Collectors.toSet());
-            Map<String, Long> groupNameIdMap = daoMgr.getXXGroup().getIdsByGroupNames(filteredGroupNames);
+
             List<XXPolicyRefGroup> xPolGroups = new ArrayList<>();
+            Map<String, Long>      nameToId   = daoMgr.getXXGroup().getIdsByGroupNames(filteredGroupNames);
+
             for (String groupName : filteredGroupNames) {
-                Long groupId = groupNameIdMap.get(groupName);
+                Long                  groupId    = nameToId.get(groupName);
                 PolicyGroupAssociator associator = new PolicyGroupAssociator(groupName, groupId, xPolicy);
+
                 if (groupId != null) {
                     XXPolicyRefGroup groupRef = associator.getPolicyRef();
+
                     if (groupRef != null) {
                         xPolGroups.add(groupRef);
                     }
@@ -250,26 +269,34 @@ public class PolicyRefUpdater {
                     rangerTransactionSynchronizationAdapter.executeOnTransactionCommit(associator);
                 } else {
                     VXResponse gjResponse = new VXResponse();
+
                     gjResponse.setStatusCode(HttpServletResponse.SC_BAD_REQUEST);
                     gjResponse.setMsgDesc("Operation denied. Group name: " + groupName + " specified in policy does not exist in ranger admin.");
+
                     throw restErrorUtil.generateRESTException(gjResponse);
                 }
             }
+
             batchInsert(xPolGroups, daoMgr.getXXPolicyRefGroup(), oldBulkMode);
         }
 
         if (CollectionUtils.isNotEmpty(userNames)) {
             LOG.debug("x_policy_ref_user - New user entries to insert for policy ID {}: {}", policyId, userNames);
-            List<XXPolicyRefUser> xPolUsers = new ArrayList<>();
+
             Set<String> filteredUserNames = userNames.stream()
-                    .filter(str -> !StringUtils.isBlank(str))
+                    .filter(StringUtils::isNotBlank)
                     .collect(Collectors.toSet());
-            Map<String, Long> userNameIdMap = daoMgr.getXXUser().getIdsByUserNames(filteredUserNames);
+
+            List<XXPolicyRefUser> xPolUsers = new ArrayList<>();
+            Map<String, Long>     nameToId  = daoMgr.getXXUser().getIdsByUserNames(filteredUserNames);
+
             for (String userName : filteredUserNames) {
-                Long userId = userNameIdMap.get(userName);
+                Long                 userId     = nameToId.get(userName);
                 PolicyUserAssociator associator = new PolicyUserAssociator(userName, userId, xPolicy);
+
                 if (userId != null) {
                     XXPolicyRefUser userRef = associator.getPolicyRef();
+
                     if (userRef != null) {
                         xPolUsers.add(userRef);
                     }
@@ -277,21 +304,27 @@ public class PolicyRefUpdater {
                     rangerTransactionSynchronizationAdapter.executeOnTransactionCommit(associator);
                 } else {
                     VXResponse gjResponse = new VXResponse();
+
                     gjResponse.setStatusCode(HttpServletResponse.SC_BAD_REQUEST);
                     gjResponse.setMsgDesc("Operation denied. User name: " + userName + " specified in policy does not exist in ranger admin.");
+
                     throw restErrorUtil.generateRESTException(gjResponse);
                 }
             }
+
             batchInsert(xPolUsers, daoMgr.getXXPolicyRefUser(), oldBulkMode);
         }
 
         // ignore built-in access-types while creating ref-table entries
         accessTypes.removeAll(ServiceDefUtil.ACCESS_TYPE_MARKERS);
+
         if (CollectionUtils.isNotEmpty(accessTypes)) {
             List<XXPolicyRefAccessType> xPolAccesses = new ArrayList<>();
-            Map<String, Long> nameToAccessTypeDefIdMap = daoMgr.getXXAccessTypeDef().findAccessTypeDefIdsByNamesAndServiceId(accessTypes, xPolicy.getService());
+            Map<String, Long>           nameToId     = daoMgr.getXXAccessTypeDef().findAccessTypeDefIdsByNamesAndServiceId(accessTypes, xPolicy.getService());
+
             for (String accessType : accessTypes) {
-                Long accessDefId = nameToAccessTypeDefIdMap.get(accessType);
+                Long accessDefId = nameToId.get(accessType);
+
                 if (accessDefId == null) {
                     throw new Exception(accessType + ": is not a valid access-type. policy='" + policy.getName() + "' service='" + policy.getService() + "'");
                 }
@@ -304,36 +337,44 @@ public class PolicyRefUpdater {
 
                 xPolAccesses.add(xPolAccess);
             }
+
             batchInsert(xPolAccesses, daoMgr.getXXPolicyRefAccessType(), oldBulkMode);
         }
 
         if (CollectionUtils.isNotEmpty(conditionTypes)) {
             List<XXPolicyRefCondition> xPolConds = new ArrayList<>();
-            Map<String, Long> nameToConditionDefIdMap = daoMgr.getXXPolicyConditionDef().findConditionDefIdsByServiceDefIdAndNames(xServiceDef.getId(), conditionTypes);
+            Map<String, Long>          nameToId  = daoMgr.getXXPolicyConditionDef().findConditionDefIdsByServiceDefIdAndNames(xServiceDef.getId(), conditionTypes);
+
             for (String condition : conditionTypes) {
-                Long conditionDefId = nameToConditionDefIdMap.get(condition);
+                Long conditionDefId = nameToId.get(condition);
+
                 if (conditionDefId == null) {
                     if (StringUtils.equalsIgnoreCase(condition, ServiceDefUtil.IMPLICIT_CONDITION_EXPRESSION_NAME)) {
                         continue;
                     }
+
                     throw new Exception(condition + ": is not a valid condition-type. policy='" + xPolicy.getName() + "' service='" + xPolicy.getService() + "'");
                 }
 
                 XXPolicyRefCondition xPolCond = new XXPolicyRefCondition();
+
                 xPolCond.setPolicyId(policy.getId());
                 xPolCond.setConditionDefId(conditionDefId);
                 xPolCond.setConditionName(condition);
 
                 xPolConds.add(xPolCond);
             }
+
             batchInsert(xPolConds, daoMgr.getXXPolicyRefCondition(), oldBulkMode);
         }
 
         if (CollectionUtils.isNotEmpty(dataMaskTypes)) {
             List<XXPolicyRefDataMaskType> xxDataMaskInfos = new ArrayList<>();
-            Map<String, Long> nameToDataMaskTypeDefIdMap = daoMgr.getXXDataMaskTypeDef().findDataMaskTypeDefIdsByNamesAndServiceId(dataMaskTypes, xPolicy.getService());
+            Map<String, Long>             nameToId        = daoMgr.getXXDataMaskTypeDef().findDataMaskTypeDefIdsByNamesAndServiceId(dataMaskTypes, xPolicy.getService());
+
             for (String dataMaskType : dataMaskTypes) {
-                Long dataMaskDefId = nameToDataMaskTypeDefIdMap.get(dataMaskType);
+                Long dataMaskDefId = nameToId.get(dataMaskType);
+
                 if (dataMaskDefId == null) {
                     throw new Exception(dataMaskType + ": is not a valid datamask-type. policy='" + policy.getName() + "' service='" + policy.getService() + "'");
                 }
@@ -385,10 +426,12 @@ public class PolicyRefUpdater {
         cleanupPolicyRefUsers(policyUsers, policyId, daoMgr.getXXPolicyRefUser());
         cleanupPolicyRefRoles(policyRoles, policyId, daoMgr.getXXPolicyRefRole());
         cleanupPolicyRefGroups(policyGroups, policyId, daoMgr.getXXPolicyRefGroup());
+
         daoMgr.getXXPolicyRefResource().deleteByPolicyId(policyId);
         daoMgr.getXXPolicyRefAccessType().deleteByPolicyId(policyId);
         daoMgr.getXXPolicyRefCondition().deleteByPolicyId(policyId);
         daoMgr.getXXPolicyRefDataMaskType().deleteByPolicyId(policyId);
+
         return true;
     }
 
@@ -402,16 +445,21 @@ public class PolicyRefUpdater {
      */
     public void cleanupPolicyRefUsers(Set<String> policyUsers, Long policyId, XXPolicyRefUserDao dao) {
         Map<String, Long> policyUserNameIdMap = dao.findUserNameIdByPolicyId(policyId);
+
         if (policyUserNameIdMap != null && !policyUserNameIdMap.isEmpty()) {
             Set<String> existingPolicyRefUsers = policyUserNameIdMap.keySet();
             Set<String> toDeletePolicyRefUsers = new HashSet<>(existingPolicyRefUsers);
-            Set<String> commonUsers = new HashSet<>(policyUsers);
+            Set<String> commonUsers            = new HashSet<>(policyUsers);
+
             // Identify users present in both new and existing sets
             commonUsers.retainAll(toDeletePolicyRefUsers);
+
             // Identify users to delete (in DB but not in new set)
             toDeletePolicyRefUsers.removeAll(commonUsers);
+
             // Remove already existing users from the new set (they don’t need to be inserted again)
             policyUsers.removeAll(commonUsers);
+
             if (CollectionUtils.isNotEmpty(toDeletePolicyRefUsers)) {
                 List<Long> idsToDelete = toDeletePolicyRefUsers.stream()
                         .map(policyUserNameIdMap::get)
@@ -419,6 +467,7 @@ public class PolicyRefUpdater {
                         .collect(Collectors.toList());
 
                 LOG.debug("Deleting user IDs from x_policy_ref_user table: {} for policy ID: {}", idsToDelete, policyId);
+
                 dao.deletePolicyRefUserByIds(idsToDelete);
             }
         }
@@ -434,16 +483,21 @@ public class PolicyRefUpdater {
      */
     public void cleanupPolicyRefRoles(Set<String> policyRoles, Long policyId, XXPolicyRefRoleDao dao) {
         Map<String, Long> policyRoleNameIdMap = dao.findRoleNameIdByPolicyId(policyId);
+
         if (policyRoleNameIdMap != null && !policyRoleNameIdMap.isEmpty()) {
             Set<String> existingPolicyRefRoles = policyRoleNameIdMap.keySet();
             Set<String> toDeletePolicyRefRoles = new HashSet<>(existingPolicyRefRoles);
-            Set<String> commonRoles = new HashSet<>(policyRoles);
+            Set<String> commonRoles            = new HashSet<>(policyRoles);
+
             // Identify roles present in both new and existing sets
             commonRoles.retainAll(toDeletePolicyRefRoles);
+
             // Identify roles to delete (in DB but not in new set)
             toDeletePolicyRefRoles.removeAll(commonRoles);
+
             // Remove already existing roles from the new set (they don’t need to be inserted again)
             policyRoles.removeAll(commonRoles);
+
             if (CollectionUtils.isNotEmpty(toDeletePolicyRefRoles)) {
                 List<Long> idsToDelete = toDeletePolicyRefRoles.stream()
                         .map(policyRoleNameIdMap::get)
@@ -451,6 +505,7 @@ public class PolicyRefUpdater {
                         .collect(Collectors.toList());
 
                 LOG.debug("Deleting Role IDs from x_policy_ref_role: {} for policy ID: {}", idsToDelete, policyId);
+
                 dao.deletePolicyRefRoleByIds(idsToDelete);
             }
         }
@@ -466,16 +521,21 @@ public class PolicyRefUpdater {
      */
     public void cleanupPolicyRefGroups(Set<String> policyGroups, Long policyId, XXPolicyRefGroupDao dao) {
         Map<String, Long> policyGroupNameIdMap = dao.findGroupNameByPolicyId(policyId);
+
         if (policyGroupNameIdMap != null && !policyGroupNameIdMap.isEmpty()) {
             Set<String> existingPolicyRefGroups = policyGroupNameIdMap.keySet();
             Set<String> toDeletePolicyRefGroups = new HashSet<>(existingPolicyRefGroups);
-            Set<String> commonGroups = new HashSet<>(policyGroups);
+            Set<String> commonGroups            = new HashSet<>(policyGroups);
+
             // Identify groups present in both new and existing sets
             commonGroups.retainAll(toDeletePolicyRefGroups);
+
             // Identify groups to delete (in DB but not in new set)
             toDeletePolicyRefGroups.removeAll(commonGroups);
+
             // Remove already existing groups from the new set (they don’t need to be inserted again)
             policyGroups.removeAll(commonGroups);
+
             if (CollectionUtils.isNotEmpty(toDeletePolicyRefGroups)) {
                 List<Long> idsToDelete = toDeletePolicyRefGroups.stream()
                         .map(policyGroupNameIdMap::get)
@@ -483,6 +543,7 @@ public class PolicyRefUpdater {
                         .collect(Collectors.toList());
 
                 LOG.debug("Deleting Group IDs from x_policy_ref_group: {} for policy ID: {}", idsToDelete, policyId);
+
                 dao.deletePolicyRefGroupByIds(idsToDelete);
             }
         }
@@ -507,22 +568,28 @@ public class PolicyRefUpdater {
 
         public XXPolicyRefRole getPolicyRef() {
             Long id = resolveRoleId(false);
-            if (id == null || !doesPolicyExist(xPolicy)) {
-                return null;
+
+            if (id != null && doesPolicyExist(xPolicy)) {
+                XXPolicyRefRole xPolRole = new XXPolicyRefRole();
+
+                xPolRole.setPolicyId(xPolicy.getId());
+                xPolRole.setRoleId(id);
+                xPolRole.setRoleName(name);
+
+                return xPolRole;
             }
-            XXPolicyRefRole xPolRole = new XXPolicyRefRole();
-            xPolRole.setPolicyId(xPolicy.getId());
-            xPolRole.setRoleId(id);
-            xPolRole.setRoleName(name);
-            return xPolRole;
+
+            return null;
         }
 
         public void createPolicyRef(Long id) {
             if (doesPolicyExist(xPolicy)) {
                 XXPolicyRefRole xPolRole = new XXPolicyRefRole();
+
                 xPolRole.setPolicyId(xPolicy.getId());
                 xPolRole.setRoleId(id);
                 xPolRole.setRoleName(name);
+
                 daoMgr.getXXPolicyRefRole().create(xPolRole);
             } else {
                 LOG.info("Policy with id ={} does not exist, skipping policy association!", xPolicy.getId());
@@ -532,8 +599,10 @@ public class PolicyRefUpdater {
         @Override
         public void run() {
             Long id = resolveRoleId(true);
+
             if (id != null) {
                 createPolicyRef(id);
+
                 LOG.debug("Associated ROLE:{} with policy id:[{}]", name, xPolicy.getId());
             } else {
                 throw new RuntimeException("Failed to associate ROLE:" + name + " with policy id:[" + xPolicy.getId() + "]");
@@ -541,25 +610,30 @@ public class PolicyRefUpdater {
         }
 
         private Long resolveRoleId(boolean createIfAbsent) {
-            if (roleId != null) {
-                return roleId;
+            Long ret = roleId;
+
+            if (ret == null) {
+                XXRole xRole = daoMgr.getXXRole().findByRoleName(name);
+
+                if (xRole != null) {
+                    ret = xRole.getId();
+                } else if (createIfAbsent) {
+                    RangerBizUtil.setBulkMode(false);
+
+                    ret = createRole();
+                }
             }
-            XXRole xRole = daoMgr.getXXRole().findByRoleName(name);
-            if (xRole != null) {
-                return xRole.getId();
-            }
-            if (createIfAbsent) {
-                RangerBizUtil.setBulkMode(false);
-                return createRole();
-            }
-            return null;
+
+            return ret;
         }
 
         private Long createRole() {
             LOG.warn("Role specified in policy does not exist in ranger admin, creating new role, name = {}", name);
+
             try {
                 RangerRole rRole       = new RangerRole(name, null, null, null, null);
                 RangerRole createdRole = roleStore.createRole(rRole, false);
+
                 return createdRole.getId();
             } catch (Exception e) {
                 return null;
@@ -580,22 +654,28 @@ public class PolicyRefUpdater {
 
         public XXPolicyRefGroup getPolicyRef() {
             Long id = resolveGroupId(false);
-            if (id == null || !doesPolicyExist(xPolicy)) {
-                return null;
+
+            if (id != null && doesPolicyExist(xPolicy)) {
+                XXPolicyRefGroup xPolGroup = new XXPolicyRefGroup();
+
+                xPolGroup.setPolicyId(xPolicy.getId());
+                xPolGroup.setGroupId(id);
+                xPolGroup.setGroupName(name);
+
+                return xPolGroup;
             }
-            XXPolicyRefGroup xPolGroup = new XXPolicyRefGroup();
-            xPolGroup.setPolicyId(xPolicy.getId());
-            xPolGroup.setGroupId(id);
-            xPolGroup.setGroupName(name);
-            return xPolGroup;
+
+            return null;
         }
 
         public void createPolicyRef(Long id) {
             if (doesPolicyExist(xPolicy)) {
                 XXPolicyRefGroup xPolGroup = new XXPolicyRefGroup();
+
                 xPolGroup.setPolicyId(xPolicy.getId());
                 xPolGroup.setGroupId(id);
                 xPolGroup.setGroupName(name);
+
                 daoMgr.getXXPolicyRefGroup().create(xPolGroup);
             } else {
                 LOG.info("Policy with id ={} does not exist, skipping policy association!", xPolicy.getId());
@@ -605,8 +685,10 @@ public class PolicyRefUpdater {
         @Override
         public void run() {
             Long id = resolveGroupId(true);
+
             if (id != null) {
                 createPolicyRef(id);
+
                 LOG.debug("Associated GROUP:{} with policy id:[{}]", name, xPolicy.getId());
             } else {
                 throw new RuntimeException("Failed to associate GROUP:" + name + " with policy id:[" + xPolicy.getId() + "]");
@@ -614,30 +696,38 @@ public class PolicyRefUpdater {
         }
 
         private Long resolveGroupId(boolean createIfAbsent) {
-            if (groupId != null) {
-                return groupId;
+            Long ret = groupId;
+
+            if (ret == null) {
+                XXGroup xGroup = daoMgr.getXXGroup().findByGroupName(name);
+
+                if (xGroup != null) {
+                    ret = xGroup.getId();
+                } else if (createIfAbsent) {
+                    ret = createGroup();
+                }
             }
-            XXGroup xGroup = daoMgr.getXXGroup().findByGroupName(name);
-            if (xGroup != null) {
-                return xGroup.getId();
-            }
-            if (createIfAbsent) {
-                return createGroup();
-            }
-            return null;
+
+            return ret;
         }
 
         private Long createGroup() {
             LOG.warn("Group specified in policy does not exist in ranger admin, creating new group, name = {}", name);
+
             VXGroup vxGroup = new VXGroup();
+
             vxGroup.setName(name);
             vxGroup.setDescription(name);
             vxGroup.setGroupSource(RangerCommonEnums.GROUP_EXTERNAL);
+
             VXGroup vXGroup = xGroupService.createXGroupWithOutLogin(vxGroup);
+
             if (vXGroup != null) {
                 xGroupService.createTransactionLog(vXGroup, null, OPERATION_CREATE_CONTEXT, xPolicy.getAddedByUserId());
+
                 return vXGroup.getId();
             }
+
             return null;
         }
     }
@@ -655,22 +745,28 @@ public class PolicyRefUpdater {
 
         public XXPolicyRefUser getPolicyRef() {
             Long id = resolveUserId(false);
-            if (id == null || !doesPolicyExist(xPolicy)) {
-                return null;
+
+            if (id != null && doesPolicyExist(xPolicy)) {
+                XXPolicyRefUser xPolUser = new XXPolicyRefUser();
+
+                xPolUser.setPolicyId(xPolicy.getId());
+                xPolUser.setUserId(id);
+                xPolUser.setUserName(name);
+
+                return xPolUser;
             }
-            XXPolicyRefUser xPolUser = new XXPolicyRefUser();
-            xPolUser.setPolicyId(xPolicy.getId());
-            xPolUser.setUserId(id);
-            xPolUser.setUserName(name);
-            return xPolUser;
+
+            return null;
         }
 
         public void createPolicyRef(Long id) {
             if (doesPolicyExist(xPolicy)) {
                 XXPolicyRefUser xPolUser = new XXPolicyRefUser();
+
                 xPolUser.setPolicyId(xPolicy.getId());
                 xPolUser.setUserId(id);
                 xPolUser.setUserName(name);
+
                 daoMgr.getXXPolicyRefUser().create(xPolUser);
             } else {
                 LOG.info("Policy with id ={} does not exist, skipping policy association!", xPolicy.getId());
@@ -680,8 +776,10 @@ public class PolicyRefUpdater {
         @Override
         public void run() {
             Long id = resolveUserId(true);
+
             if (id != null) {
                 createPolicyRef(id);
+
                 LOG.debug("Associated USER:{} with policy id:[{}]", name, xPolicy.getId());
             } else {
                 throw new RuntimeException("Failed to associate USER:" + name + " with policy id:[" + xPolicy.getId() + "]");
@@ -689,24 +787,29 @@ public class PolicyRefUpdater {
         }
 
         private Long resolveUserId(boolean createIfAbsent) {
-            if (userId != null) {
-                return userId;
+            Long ret = userId;
+
+            if (ret == null) {
+                XXUser xUser = daoMgr.getXXUser().findByUserName(name);
+
+                if (xUser != null) {
+                    ret = xUser.getId();
+                } else if (createIfAbsent) {
+                    return createUser();
+                }
             }
-            XXUser xUser = daoMgr.getXXUser().findByUserName(name);
-            if (xUser != null) {
-                return xUser.getId();
-            }
-            if (createIfAbsent) {
-                return createUser();
-            }
-            return null;
+
+            return ret;
         }
 
         private Long createUser() {
             LOG.warn("User specified in policy does not exist in ranger admin, creating new user, name = {}", name);
+
             VXUser vXUser = xUserMgr.createServiceConfigUser(name);
+
             if (vXUser != null) {
                 XXUser xUser = daoMgr.getXXUser().findByUserName(name);
+
                 if (xUser == null) {
                     LOG.error("No User created!! Irrecoverable error! [{}]", name);
                 } else {
@@ -715,6 +818,7 @@ public class PolicyRefUpdater {
             } else {
                 LOG.warn("serviceConfigUser:[{}] creation failed. This may be a transient/spurious condition that may correct itself when transaction is committed", name);
             }
+
             return null;
         }
     }
@@ -722,12 +826,14 @@ public class PolicyRefUpdater {
     private <T> void batchInsert(List<T> entities, BaseDao<T> dao, boolean oldBulkMode) {
         if (CollectionUtils.isNotEmpty(entities)) {
             long startTimeMs = System.currentTimeMillis();
+
             LOG.debug("Batch insert started for create/update {} with {} records.", dao.getClass().getSimpleName(), entities.size());
+
             RangerBizUtil.setBulkMode(false);
             dao.batchCreate(entities);
             RangerBizUtil.setBulkMode(oldBulkMode);
-            long timeTakenMs = System.currentTimeMillis() - startTimeMs;
-            LOG.debug("Batch insert completed for create/update {} with {} records in {} ms.", dao.getClass().getSimpleName(), entities.size(), timeTakenMs);
+
+            LOG.debug("Batch insert completed for create/update {} with {} records in {} ms.", dao.getClass().getSimpleName(), entities.size(), (System.currentTimeMillis() - startTimeMs));
         }
     }
 }

--- a/security-admin/src/main/java/org/apache/ranger/biz/ServiceDBStore.java
+++ b/security-admin/src/main/java/org/apache/ranger/biz/ServiceDBStore.java
@@ -1472,11 +1472,9 @@ public class ServiceDBStore extends AbstractServiceStore {
 
         XXPolicy newUpdPolicy = daoMgr.getXXPolicy().getById(policy.getId());
 
-        policyRefUpdater.cleanupRefTables(policy);
-
         deleteExistingPolicyLabel(policy);
 
-        policyRefUpdater.createNewPolMappingForRefTable(policy, newUpdPolicy, xServiceDef, bizUtil.getCreatePrincipalsIfAbsent());
+        policyRefUpdater.createNewPolMappingForRefTable(policy, newUpdPolicy, xServiceDef, bizUtil.getCreatePrincipalsIfAbsent(), true);
 
         createOrMapLabels(newUpdPolicy, uniquePolicyLabels);
 
@@ -2290,7 +2288,7 @@ public class ServiceDBStore extends AbstractServiceStore {
 
         XXPolicy xCreatedPolicy = daoMgr.getXXPolicy().getById(policy.getId());
 
-        policyRefUpdater.createNewPolMappingForRefTable(policy, xCreatedPolicy, xServiceDef, createPrincipalsIfAbsent);
+        policyRefUpdater.createNewPolMappingForRefTable(policy, xCreatedPolicy, xServiceDef, createPrincipalsIfAbsent, false);
 
         createOrMapLabels(xCreatedPolicy, uniquePolicyLabels);
 

--- a/security-admin/src/main/java/org/apache/ranger/db/XXAccessTypeDefDao.java
+++ b/security-admin/src/main/java/org/apache/ranger/db/XXAccessTypeDefDao.java
@@ -87,7 +87,6 @@ public class XXAccessTypeDefDao extends BaseDao<XXAccessTypeDef> {
     }
 
     public Map<String, Long> findAccessTypeDefIdsByNamesAndServiceId(Set<String> names, Long serviceId) {
-        Map<String, Long> ret = Collections.emptyMap();
         if (serviceId != null && CollectionUtils.isNotEmpty(names)) {
             try {
                 Collection<Object[]> result = getEntityManager()
@@ -95,15 +94,13 @@ public class XXAccessTypeDefDao extends BaseDao<XXAccessTypeDef> {
                         .setParameter("names", names)
                         .setParameter("serviceId", serviceId)
                         .getResultList();
-                ret = result.stream().collect(
-                        Collectors.toMap(
-                                object -> (String) object[1],
-                                object -> (Long) object[0],
-                                (a, b) -> a));
+
+                return result.stream().collect(Collectors.toMap(object -> (String) object[1], object -> (Long) object[0], (a, b) -> a));
             } catch (NoResultException e) {
                 logger.debug(e.getMessage());
             }
         }
-        return ret;
+
+        return Collections.emptyMap();
     }
 }

--- a/security-admin/src/main/java/org/apache/ranger/db/XXAccessTypeDefDao.java
+++ b/security-admin/src/main/java/org/apache/ranger/db/XXAccessTypeDefDao.java
@@ -27,6 +27,7 @@ import org.springframework.stereotype.Service;
 import javax.persistence.NoResultException;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -85,28 +86,23 @@ public class XXAccessTypeDefDao extends BaseDao<XXAccessTypeDef> {
         return ret != null ? ret : Collections.emptyList();
     }
 
-    public Map<String, XXAccessTypeDef> findByNamesAndServiceId(Set<String> names, Long serviceId) {
-        Map<String, XXAccessTypeDef> ret = Collections.emptyMap();
-        if (CollectionUtils.isEmpty(names) || serviceId == null) {
-            return ret;
-        }
-        try {
-            // Fetches all matching access type definitions inside a single list execution
-            List<XXAccessTypeDef> result = getEntityManager()
-                    .createNamedQuery("XXAccessTypeDef.findByNamesAndServiceId", tClass)
-                    .setParameter("names", names)
-                    .setParameter("serviceId", serviceId)
-                    .getResultList();
-
-            if (CollectionUtils.isEmpty(result)) {
-                return ret;
+    public Map<String, Long> findAccessTypeDefIdsByNamesAndServiceId(Set<String> names, Long serviceId) {
+        Map<String, Long> ret = Collections.emptyMap();
+        if (serviceId != null && CollectionUtils.isNotEmpty(names)) {
+            try {
+                Collection<Object[]> result = getEntityManager()
+                        .createNamedQuery("XXAccessTypeDef.findAccessTypeDefIdsByNamesAndServiceId", Object[].class)
+                        .setParameter("names", names)
+                        .setParameter("serviceId", serviceId)
+                        .getResultList();
+                ret = result.stream().collect(
+                        Collectors.toMap(
+                                object -> (String) object[1],
+                                object -> (Long) object[0],
+                                (a, b) -> a));
+            } catch (NoResultException e) {
+                logger.debug(e.getMessage());
             }
-
-            // Maps everything into an in-memory dictionary keyed by access type name
-            return result.stream()
-                    .collect(Collectors.toMap(XXAccessTypeDef::getName, java.util.function.Function.identity(), (a, b) -> a));
-        } catch (javax.persistence.NoResultException e) {
-            logger.error("No access type definitions found for serviceId={} and names={}", serviceId, names);
         }
         return ret;
     }

--- a/security-admin/src/main/java/org/apache/ranger/db/XXAccessTypeDefDao.java
+++ b/security-admin/src/main/java/org/apache/ranger/db/XXAccessTypeDefDao.java
@@ -17,8 +17,11 @@
 
 package org.apache.ranger.db;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.ranger.common.db.BaseDao;
 import org.apache.ranger.entity.XXAccessTypeDef;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import javax.persistence.NoResultException;
@@ -26,9 +29,14 @@ import javax.persistence.NoResultException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 public class XXAccessTypeDefDao extends BaseDao<XXAccessTypeDef> {
+    private static final Logger logger = LoggerFactory.getLogger(XXAccessTypeDefDao.class);
+
     public XXAccessTypeDefDao(RangerDaoManagerBase daoManager) {
         super(daoManager);
     }
@@ -75,5 +83,31 @@ public class XXAccessTypeDefDao extends BaseDao<XXAccessTypeDef> {
         }
 
         return ret != null ? ret : Collections.emptyList();
+    }
+
+    public Map<String, XXAccessTypeDef> findByNamesAndServiceId(Set<String> names, Long serviceId) {
+        Map<String, XXAccessTypeDef> ret = Collections.emptyMap();
+        if (CollectionUtils.isEmpty(names) || serviceId == null) {
+            return ret;
+        }
+        try {
+            // Fetches all matching access type definitions inside a single list execution
+            List<XXAccessTypeDef> result = getEntityManager()
+                    .createNamedQuery("XXAccessTypeDef.findByNamesAndServiceId", tClass)
+                    .setParameter("names", names)
+                    .setParameter("serviceId", serviceId)
+                    .getResultList();
+
+            if (CollectionUtils.isEmpty(result)) {
+                return ret;
+            }
+
+            // Maps everything into an in-memory dictionary keyed by access type name
+            return result.stream()
+                    .collect(Collectors.toMap(XXAccessTypeDef::getName, java.util.function.Function.identity(), (a, b) -> a));
+        } catch (javax.persistence.NoResultException e) {
+            logger.error("No access type definitions found for serviceId={} and names={}", serviceId, names);
+        }
+        return ret;
     }
 }

--- a/security-admin/src/main/java/org/apache/ranger/db/XXDataMaskTypeDefDao.java
+++ b/security-admin/src/main/java/org/apache/ranger/db/XXDataMaskTypeDefDao.java
@@ -87,7 +87,6 @@ public class XXDataMaskTypeDefDao extends BaseDao<XXDataMaskTypeDef> {
     }
 
     public Map<String, Long> findDataMaskTypeDefIdsByNamesAndServiceId(Set<String> names, Long serviceId) {
-        Map<String, Long> ret = Collections.emptyMap();
         if (serviceId != null && CollectionUtils.isNotEmpty(names)) {
             try {
                 Collection<Object[]> result = getEntityManager()
@@ -95,15 +94,13 @@ public class XXDataMaskTypeDefDao extends BaseDao<XXDataMaskTypeDef> {
                         .setParameter("names", names)
                         .setParameter("serviceId", serviceId)
                         .getResultList();
-                ret = result.stream().collect(
-                        Collectors.toMap(
-                                object -> (String) object[1],
-                                object -> (Long) object[0],
-                                (a, b) -> a));
+
+                return result.stream().collect(Collectors.toMap(object -> (String) object[1], object -> (Long) object[0], (a, b) -> a));
             } catch (NoResultException e) {
                 logger.debug(e.getMessage());
             }
         }
-        return ret;
+
+        return Collections.emptyMap();
     }
 }

--- a/security-admin/src/main/java/org/apache/ranger/db/XXDataMaskTypeDefDao.java
+++ b/security-admin/src/main/java/org/apache/ranger/db/XXDataMaskTypeDefDao.java
@@ -17,8 +17,11 @@
 
 package org.apache.ranger.db;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.ranger.common.db.BaseDao;
 import org.apache.ranger.entity.XXDataMaskTypeDef;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import javax.persistence.NoResultException;
@@ -26,9 +29,14 @@ import javax.persistence.NoResultException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 public class XXDataMaskTypeDefDao extends BaseDao<XXDataMaskTypeDef> {
+    private static final Logger logger = LoggerFactory.getLogger(XXDataMaskTypeDefDao.class);
+
     public XXDataMaskTypeDefDao(RangerDaoManagerBase daoManager) {
         super(daoManager);
     }
@@ -75,5 +83,29 @@ public class XXDataMaskTypeDefDao extends BaseDao<XXDataMaskTypeDef> {
         }
 
         return ret != null ? ret : Collections.emptyList();
+    }
+
+    public Map<String, XXDataMaskTypeDef> findByNamesAndServiceId(Set<String> names, Long serviceId) {
+        Map<String, XXDataMaskTypeDef> ret = Collections.emptyMap();
+        if (CollectionUtils.isEmpty(names) || serviceId == null) {
+            return ret;
+        }
+        try {
+            List<XXDataMaskTypeDef> result = getEntityManager()
+                    .createNamedQuery("XXDataMaskTypeDef.findByNamesAndServiceId", tClass)
+                    .setParameter("names", names)
+                    .setParameter("serviceId", serviceId)
+                    .getResultList();
+
+            if (CollectionUtils.isEmpty(result)) {
+                return ret;
+            }
+            return result.stream()
+                    .collect(Collectors.toMap(XXDataMaskTypeDef::getName, java.util.function.Function.identity(), (a, b) -> a));
+        } catch (Exception e) {
+            logger.error("Error retrieving data mask type definitions for serviceId={} and names={}", serviceId, names);
+        }
+
+        return ret;
     }
 }

--- a/security-admin/src/main/java/org/apache/ranger/db/XXDataMaskTypeDefDao.java
+++ b/security-admin/src/main/java/org/apache/ranger/db/XXDataMaskTypeDefDao.java
@@ -27,6 +27,7 @@ import org.springframework.stereotype.Service;
 import javax.persistence.NoResultException;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -85,27 +86,24 @@ public class XXDataMaskTypeDefDao extends BaseDao<XXDataMaskTypeDef> {
         return ret != null ? ret : Collections.emptyList();
     }
 
-    public Map<String, XXDataMaskTypeDef> findByNamesAndServiceId(Set<String> names, Long serviceId) {
-        Map<String, XXDataMaskTypeDef> ret = Collections.emptyMap();
-        if (CollectionUtils.isEmpty(names) || serviceId == null) {
-            return ret;
-        }
-        try {
-            List<XXDataMaskTypeDef> result = getEntityManager()
-                    .createNamedQuery("XXDataMaskTypeDef.findByNamesAndServiceId", tClass)
-                    .setParameter("names", names)
-                    .setParameter("serviceId", serviceId)
-                    .getResultList();
-
-            if (CollectionUtils.isEmpty(result)) {
-                return ret;
+    public Map<String, Long> findDataMaskTypeDefIdsByNamesAndServiceId(Set<String> names, Long serviceId) {
+        Map<String, Long> ret = Collections.emptyMap();
+        if (serviceId != null && CollectionUtils.isNotEmpty(names)) {
+            try {
+                Collection<Object[]> result = getEntityManager()
+                        .createNamedQuery("XXDataMaskTypeDef.findDataMaskTypeDefIdsByNamesAndServiceId", Object[].class)
+                        .setParameter("names", names)
+                        .setParameter("serviceId", serviceId)
+                        .getResultList();
+                ret = result.stream().collect(
+                        Collectors.toMap(
+                                object -> (String) object[1],
+                                object -> (Long) object[0],
+                                (a, b) -> a));
+            } catch (NoResultException e) {
+                logger.debug(e.getMessage());
             }
-            return result.stream()
-                    .collect(Collectors.toMap(XXDataMaskTypeDef::getName, java.util.function.Function.identity(), (a, b) -> a));
-        } catch (Exception e) {
-            logger.error("Error retrieving data mask type definitions for serviceId={} and names={}", serviceId, names);
         }
-
         return ret;
     }
 }

--- a/security-admin/src/main/java/org/apache/ranger/db/XXGroupDao.java
+++ b/security-admin/src/main/java/org/apache/ranger/db/XXGroupDao.java
@@ -19,6 +19,7 @@
 
 package org.apache.ranger.db;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.ranger.authorization.utils.JsonUtils;
 import org.apache.ranger.common.RangerCommonEnums;
@@ -32,9 +33,12 @@ import org.springframework.stereotype.Service;
 import javax.persistence.NoResultException;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.apache.ranger.plugin.util.RangerCommonConstants.SCRIPT_FIELD__IS_INTERNAL;
 import static org.apache.ranger.plugin.util.RangerCommonConstants.SCRIPT_FIELD__SYNC_SOURCE;
@@ -111,6 +115,25 @@ public class XXGroupDao extends BaseDao<XXGroup> {
             logger.debug(excp.getMessage());
         }
 
+        return ret;
+    }
+
+    public Map<String, Long> getIdsByGroupNames(Collection<String> groupNames) {
+        Map<String, Long> ret = Collections.emptyMap();
+        if (CollectionUtils.isNotEmpty(groupNames)) {
+            try {
+                Collection<Object[]> result = getEntityManager()
+                        .createNamedQuery("XXGroup.getIdsByGroupNames", Object[].class)
+                        .setParameter("names", groupNames)
+                        .getResultList();
+                ret = result.stream().collect(
+                    Collectors.toMap(
+                        object -> (String) (object[1]),
+                        object -> (Long) (object[0])));
+            } catch (NoResultException excp) {
+                logger.debug(excp.getMessage());
+            }
+        }
         return ret;
     }
 

--- a/security-admin/src/main/java/org/apache/ranger/db/XXGroupDao.java
+++ b/security-admin/src/main/java/org/apache/ranger/db/XXGroupDao.java
@@ -119,22 +119,20 @@ public class XXGroupDao extends BaseDao<XXGroup> {
     }
 
     public Map<String, Long> getIdsByGroupNames(Collection<String> groupNames) {
-        Map<String, Long> ret = Collections.emptyMap();
         if (CollectionUtils.isNotEmpty(groupNames)) {
             try {
                 Collection<Object[]> result = getEntityManager()
                         .createNamedQuery("XXGroup.getIdsByGroupNames", Object[].class)
                         .setParameter("names", groupNames)
                         .getResultList();
-                ret = result.stream().collect(
-                    Collectors.toMap(
-                        object -> (String) (object[1]),
-                        object -> (Long) (object[0])));
+
+                return result.stream().collect(Collectors.toMap(object -> (String) (object[1]), object -> (Long) (object[0])));
             } catch (NoResultException excp) {
                 logger.debug(excp.getMessage());
             }
         }
-        return ret;
+
+        return Collections.emptyMap();
     }
 
     private GroupInfo toGroupInfo(Object[] row) {

--- a/security-admin/src/main/java/org/apache/ranger/db/XXPolicyConditionDefDao.java
+++ b/security-admin/src/main/java/org/apache/ranger/db/XXPolicyConditionDefDao.java
@@ -72,7 +72,6 @@ public class XXPolicyConditionDefDao extends BaseDao<XXPolicyConditionDef> {
     }
 
     public Map<String, Long> findConditionDefIdsByServiceDefIdAndNames(Long serviceDefId, Set<String> names) {
-        Map<String, Long> ret = Collections.emptyMap();
         if (serviceDefId != null && CollectionUtils.isNotEmpty(names)) {
             try {
                 Collection<Object[]> result = getEntityManager()
@@ -80,15 +79,13 @@ public class XXPolicyConditionDefDao extends BaseDao<XXPolicyConditionDef> {
                         .setParameter("serviceDefId", serviceDefId)
                         .setParameter("names", names)
                         .getResultList();
-                ret = result.stream().collect(
-                        Collectors.toMap(
-                                object -> (String) object[1],
-                                object -> (Long) object[0],
-                                (a, b) -> a));
+
+                return result.stream().collect(Collectors.toMap(object -> (String) object[1], object -> (Long) object[0], (a, b) -> a));
             } catch (NoResultException e) {
                 logger.debug(e.getMessage());
             }
         }
-        return ret;
+
+        return Collections.emptyMap();
     }
 }

--- a/security-admin/src/main/java/org/apache/ranger/db/XXPolicyConditionDefDao.java
+++ b/security-admin/src/main/java/org/apache/ranger/db/XXPolicyConditionDefDao.java
@@ -17,17 +17,26 @@
 
 package org.apache.ranger.db;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.ranger.common.db.BaseDao;
 import org.apache.ranger.entity.XXPolicyConditionDef;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import javax.persistence.NoResultException;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 public class XXPolicyConditionDefDao extends BaseDao<XXPolicyConditionDef> {
+    private static final Logger logger = LoggerFactory.getLogger(XXPolicyConditionDefDao.class);
+
     public XXPolicyConditionDefDao(RangerDaoManagerBase daoManager) {
         super(daoManager);
     }
@@ -59,5 +68,29 @@ public class XXPolicyConditionDefDao extends BaseDao<XXPolicyConditionDef> {
         } catch (NoResultException e) {
             return null;
         }
+    }
+
+    public Map<String, XXPolicyConditionDef> findByServiceDefIdAndNames(Long serviceDefId, Set<String> names) {
+        Map<String, XXPolicyConditionDef> ret = Collections.emptyMap();
+        if (serviceDefId == null || CollectionUtils.isEmpty(names)) {
+            return ret;
+        }
+        try {
+            List<XXPolicyConditionDef> result = getEntityManager()
+                    .createNamedQuery("XXPolicyConditionDef.findByServiceDefIdAndNames", tClass)
+                    .setParameter("serviceDefId", serviceDefId)
+                    .setParameter("names", names)
+                    .getResultList();
+
+            if (CollectionUtils.isEmpty(result)) {
+                return ret;
+            }
+            return result.stream()
+                    .collect(Collectors.toMap(XXPolicyConditionDef::getName, java.util.function.Function.identity(), (a, b) -> a));
+        } catch (Exception e) {
+            logger.error("Error retrieving policy condition definitions for serviceDefId={} and names={}", serviceDefId, names);
+        }
+
+        return ret;
     }
 }

--- a/security-admin/src/main/java/org/apache/ranger/db/XXPolicyConditionDefDao.java
+++ b/security-admin/src/main/java/org/apache/ranger/db/XXPolicyConditionDefDao.java
@@ -27,6 +27,7 @@ import org.springframework.stereotype.Service;
 import javax.persistence.NoResultException;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -70,27 +71,24 @@ public class XXPolicyConditionDefDao extends BaseDao<XXPolicyConditionDef> {
         }
     }
 
-    public Map<String, XXPolicyConditionDef> findByServiceDefIdAndNames(Long serviceDefId, Set<String> names) {
-        Map<String, XXPolicyConditionDef> ret = Collections.emptyMap();
-        if (serviceDefId == null || CollectionUtils.isEmpty(names)) {
-            return ret;
-        }
-        try {
-            List<XXPolicyConditionDef> result = getEntityManager()
-                    .createNamedQuery("XXPolicyConditionDef.findByServiceDefIdAndNames", tClass)
-                    .setParameter("serviceDefId", serviceDefId)
-                    .setParameter("names", names)
-                    .getResultList();
-
-            if (CollectionUtils.isEmpty(result)) {
-                return ret;
+    public Map<String, Long> findConditionDefIdsByServiceDefIdAndNames(Long serviceDefId, Set<String> names) {
+        Map<String, Long> ret = Collections.emptyMap();
+        if (serviceDefId != null && CollectionUtils.isNotEmpty(names)) {
+            try {
+                Collection<Object[]> result = getEntityManager()
+                        .createNamedQuery("XXPolicyConditionDef.findConditionDefIdsByServiceDefIdAndNames", Object[].class)
+                        .setParameter("serviceDefId", serviceDefId)
+                        .setParameter("names", names)
+                        .getResultList();
+                ret = result.stream().collect(
+                        Collectors.toMap(
+                                object -> (String) object[1],
+                                object -> (Long) object[0],
+                                (a, b) -> a));
+            } catch (NoResultException e) {
+                logger.debug(e.getMessage());
             }
-            return result.stream()
-                    .collect(Collectors.toMap(XXPolicyConditionDef::getName, java.util.function.Function.identity(), (a, b) -> a));
-        } catch (Exception e) {
-            logger.error("Error retrieving policy condition definitions for serviceDefId={} and names={}", serviceDefId, names);
         }
-
         return ret;
     }
 }

--- a/security-admin/src/main/java/org/apache/ranger/db/XXPolicyRefGroupDao.java
+++ b/security-admin/src/main/java/org/apache/ranger/db/XXPolicyRefGroupDao.java
@@ -28,10 +28,11 @@ import org.springframework.stereotype.Service;
 import javax.persistence.NoResultException;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 public class XXPolicyRefGroupDao extends BaseDao<XXPolicyRefGroup> {
@@ -124,26 +125,22 @@ public class XXPolicyRefGroupDao extends BaseDao<XXPolicyRefGroup> {
     }
 
     public Map<String, Long> findGroupNameByPolicyId(Long policyId) {
-        if (policyId == null) {
-            return Collections.emptyMap();
-        }
-        try {
-            List<Object[]> results = getEntityManager()
-                    .createNamedQuery("XXPolicyRefGroup.findGroupNameByPolicyId", Object[].class)
-                    .setParameter("policyId", policyId)
-                    .getResultList();
-
-            Map<String, Long> groupNameIdMap = new HashMap<>();
-            for (Object[] row : results) {
-                String groupName = (String) row[0];
-                Long id = (Long) row[1];
-                groupNameIdMap.put(groupName, id);
+        Map<String, Long> ret = Collections.emptyMap();
+        if (policyId != null) {
+            try {
+                Collection<Object[]> results = getEntityManager()
+                        .createNamedQuery("XXPolicyRefGroup.findGroupNameByPolicyId", Object[].class)
+                        .setParameter("policyId", policyId)
+                        .getResultList();
+                ret = results.stream().collect(
+                        Collectors.toMap(
+                                object -> (String) object[0],
+                                object -> (Long) object[1]));
+            } catch (NoResultException e) {
+                // ignore
             }
-
-            return groupNameIdMap;
-        } catch (NoResultException e) {
-            return Collections.emptyMap();
         }
+        return ret;
     }
 
     public void deletePolicyRefGroupByIds(List<Long> ids) {

--- a/security-admin/src/main/java/org/apache/ranger/db/XXPolicyRefGroupDao.java
+++ b/security-admin/src/main/java/org/apache/ranger/db/XXPolicyRefGroupDao.java
@@ -29,7 +29,9 @@ import javax.persistence.NoResultException;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Service
 public class XXPolicyRefGroupDao extends BaseDao<XXPolicyRefGroup> {
@@ -119,5 +121,35 @@ public class XXPolicyRefGroupDao extends BaseDao<XXPolicyRefGroup> {
         }
 
         batchDeleteByIds("XXPolicyRefGroup.deleteByIds", ids, "ids");
+    }
+
+    public Map<String, Long> findGroupNameByPolicyId(Long policyId) {
+        if (policyId == null) {
+            return Collections.emptyMap();
+        }
+        try {
+            List<Object[]> results = getEntityManager()
+                    .createNamedQuery("XXPolicyRefGroup.findGroupNameByPolicyId", Object[].class)
+                    .setParameter("policyId", policyId)
+                    .getResultList();
+
+            Map<String, Long> groupNameIdMap = new HashMap<>();
+            for (Object[] row : results) {
+                String groupName = (String) row[0];
+                Long id = (Long) row[1];
+                groupNameIdMap.put(groupName, id);
+            }
+
+            return groupNameIdMap;
+        } catch (NoResultException e) {
+            return Collections.emptyMap();
+        }
+    }
+
+    public void deletePolicyRefGroupByIds(List<Long> ids) {
+        if (CollectionUtils.isEmpty(ids)) {
+            return;
+        }
+        batchDeleteByIds("XXPolicyRefGroup.deletePolicyRefGroupByIds", ids, "ids");
     }
 }

--- a/security-admin/src/main/java/org/apache/ranger/db/XXPolicyRefRoleDao.java
+++ b/security-admin/src/main/java/org/apache/ranger/db/XXPolicyRefRoleDao.java
@@ -28,10 +28,11 @@ import org.springframework.stereotype.Service;
 import javax.persistence.NoResultException;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 public class XXPolicyRefRoleDao extends BaseDao<XXPolicyRefRole> {
@@ -137,26 +138,22 @@ public class XXPolicyRefRoleDao extends BaseDao<XXPolicyRefRole> {
     }
 
     public Map<String, Long> findRoleNameIdByPolicyId(Long policyId) {
-        if (policyId == null) {
-            return Collections.emptyMap();
-        }
-        try {
-            List<Object[]> results = getEntityManager()
-                    .createNamedQuery("XXPolicyRefRole.findRoleNameIdByPolicyId", Object[].class)
-                    .setParameter("policyId", policyId)
-                    .getResultList();
-
-            Map<String, Long> roleNameIdMap = new HashMap<>();
-            for (Object[] row : results) {
-                String roleName = (String) row[0];
-                Long id = (Long) row[1];
-                roleNameIdMap.put(roleName, id);
+        Map<String, Long> ret = Collections.emptyMap();
+        if (policyId != null) {
+            try {
+                Collection<Object[]> results = getEntityManager()
+                        .createNamedQuery("XXPolicyRefRole.findRoleNameIdByPolicyId", Object[].class)
+                        .setParameter("policyId", policyId)
+                        .getResultList();
+                ret = results.stream().collect(
+                        Collectors.toMap(
+                                object -> (String) object[0],
+                                object -> (Long) object[1]));
+            } catch (NoResultException e) {
+                // ignore
             }
-
-            return roleNameIdMap;
-        } catch (NoResultException e) {
-            return Collections.emptyMap();
         }
+        return ret;
     }
 
     public void deletePolicyRefRoleByIds(List<Long> ids) {

--- a/security-admin/src/main/java/org/apache/ranger/db/XXPolicyRefRoleDao.java
+++ b/security-admin/src/main/java/org/apache/ranger/db/XXPolicyRefRoleDao.java
@@ -29,7 +29,9 @@ import javax.persistence.NoResultException;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Service
 public class XXPolicyRefRoleDao extends BaseDao<XXPolicyRefRole> {
@@ -132,5 +134,35 @@ public class XXPolicyRefRoleDao extends BaseDao<XXPolicyRefRole> {
         }
 
         batchDeleteByIds("XXPolicyRefRole.deleteByIds", ids, "ids");
+    }
+
+    public Map<String, Long> findRoleNameIdByPolicyId(Long policyId) {
+        if (policyId == null) {
+            return Collections.emptyMap();
+        }
+        try {
+            List<Object[]> results = getEntityManager()
+                    .createNamedQuery("XXPolicyRefRole.findRoleNameIdByPolicyId", Object[].class)
+                    .setParameter("policyId", policyId)
+                    .getResultList();
+
+            Map<String, Long> roleNameIdMap = new HashMap<>();
+            for (Object[] row : results) {
+                String roleName = (String) row[0];
+                Long id = (Long) row[1];
+                roleNameIdMap.put(roleName, id);
+            }
+
+            return roleNameIdMap;
+        } catch (NoResultException e) {
+            return Collections.emptyMap();
+        }
+    }
+
+    public void deletePolicyRefRoleByIds(List<Long> ids) {
+        if (CollectionUtils.isEmpty(ids)) {
+            return;
+        }
+        batchDeleteByIds("XXPolicyRefRole.deletePolicyRefRoleByIds", ids, "ids");
     }
 }

--- a/security-admin/src/main/java/org/apache/ranger/db/XXPolicyRefUserDao.java
+++ b/security-admin/src/main/java/org/apache/ranger/db/XXPolicyRefUserDao.java
@@ -29,7 +29,9 @@ import javax.persistence.NoResultException;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Service
 public class XXPolicyRefUserDao extends BaseDao<XXPolicyRefUser> {
@@ -132,5 +134,35 @@ public class XXPolicyRefUserDao extends BaseDao<XXPolicyRefUser> {
         }
 
         batchDeleteByIds("XXPolicyRefUser.deleteByIds", ids, "ids");
+    }
+
+    public Map<String, Long> findUserNameIdByPolicyId(Long policyId) {
+        if (policyId == null) {
+            return Collections.emptyMap();
+        }
+        try {
+            List<Object[]> results = getEntityManager()
+                    .createNamedQuery("XXPolicyRefUser.findUserNameIdByPolicyId", Object[].class)
+                    .setParameter("policyId", policyId)
+                    .getResultList();
+
+            Map<String, Long> userNameIdMap = new HashMap<>();
+            for (Object[] row : results) {
+                String userName = (String) row[0];
+                Long id = (Long) row[1];
+                userNameIdMap.put(userName, id);
+            }
+
+            return userNameIdMap;
+        } catch (NoResultException e) {
+            return Collections.emptyMap();
+        }
+    }
+
+    public void deletePolicyRefUserByIds(List<Long> ids) {
+        if (CollectionUtils.isEmpty(ids)) {
+            return;
+        }
+        batchDeleteByIds("XXPolicyRefUser.deletePolicyRefUserByIds", ids, "ids");
     }
 }

--- a/security-admin/src/main/java/org/apache/ranger/db/XXPolicyRefUserDao.java
+++ b/security-admin/src/main/java/org/apache/ranger/db/XXPolicyRefUserDao.java
@@ -28,10 +28,11 @@ import org.springframework.stereotype.Service;
 import javax.persistence.NoResultException;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 public class XXPolicyRefUserDao extends BaseDao<XXPolicyRefUser> {
@@ -137,26 +138,22 @@ public class XXPolicyRefUserDao extends BaseDao<XXPolicyRefUser> {
     }
 
     public Map<String, Long> findUserNameIdByPolicyId(Long policyId) {
-        if (policyId == null) {
-            return Collections.emptyMap();
-        }
-        try {
-            List<Object[]> results = getEntityManager()
-                    .createNamedQuery("XXPolicyRefUser.findUserNameIdByPolicyId", Object[].class)
-                    .setParameter("policyId", policyId)
-                    .getResultList();
-
-            Map<String, Long> userNameIdMap = new HashMap<>();
-            for (Object[] row : results) {
-                String userName = (String) row[0];
-                Long id = (Long) row[1];
-                userNameIdMap.put(userName, id);
+        Map<String, Long> ret = Collections.emptyMap();
+        if (policyId != null) {
+            try {
+                Collection<Object[]> results = getEntityManager()
+                        .createNamedQuery("XXPolicyRefUser.findUserNameIdByPolicyId", Object[].class)
+                        .setParameter("policyId", policyId)
+                        .getResultList();
+                ret = results.stream().collect(
+                        Collectors.toMap(
+                                object -> (String) object[0],
+                                object -> (Long) object[1]));
+            } catch (NoResultException e) {
+                // ignore
             }
-
-            return userNameIdMap;
-        } catch (NoResultException e) {
-            return Collections.emptyMap();
         }
+        return ret;
     }
 
     public void deletePolicyRefUserByIds(List<Long> ids) {

--- a/security-admin/src/main/java/org/apache/ranger/db/XXResourceDefDao.java
+++ b/security-admin/src/main/java/org/apache/ranger/db/XXResourceDefDao.java
@@ -113,7 +113,6 @@ public class XXResourceDefDao extends BaseDao<XXResourceDef> {
     }
 
     public Map<String, Long> findResourceDefIdsByNameAndPolicyId(Set<String> names, Long policyId) {
-        Map<String, Long> ret = Collections.emptyMap();
         if (policyId != null && CollectionUtils.isNotEmpty(names)) {
             try {
                 Collection<Object[]> result = getEntityManager()
@@ -121,15 +120,13 @@ public class XXResourceDefDao extends BaseDao<XXResourceDef> {
                         .setParameter("policyId", policyId)
                         .setParameter("names", names)
                         .getResultList();
-                ret = result.stream().collect(
-                        Collectors.toMap(
-                                object -> (String) object[1],
-                                object -> (Long) object[0],
-                                (a, b) -> a));
+
+                return result.stream().collect(Collectors.toMap(object -> (String) object[1], object -> (Long) object[0], (a, b) -> a));
             } catch (NoResultException e) {
                 logger.debug(e.getMessage());
             }
         }
-        return ret;
+
+        return Collections.emptyMap();
     }
 }

--- a/security-admin/src/main/java/org/apache/ranger/db/XXResourceDefDao.java
+++ b/security-admin/src/main/java/org/apache/ranger/db/XXResourceDefDao.java
@@ -27,6 +27,7 @@ import org.springframework.stereotype.Service;
 import javax.persistence.NoResultException;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -111,28 +112,24 @@ public class XXResourceDefDao extends BaseDao<XXResourceDef> {
         }
     }
 
-    public Map<String, XXResourceDef> findXXResourceDefsByNameAndPolicyId(Set<String> names, Long policyId) {
-        Map<String, XXResourceDef> ret = Collections.emptyMap();
-        if (policyId == null || CollectionUtils.isEmpty(names)) {
-            return ret;
-        }
-        try {
-            List<XXResourceDef> result = getEntityManager()
-                    .createNamedQuery("XXResourceDef.findByNamesAndPolicyId", XXResourceDef.class)
-                    .setParameter("policyId", policyId)
-                    .setParameter("names", names)
-                    .getResultList();
-
-            if (CollectionUtils.isEmpty(result)) {
-                return ret;
+    public Map<String, Long> findResourceDefIdsByNameAndPolicyId(Set<String> names, Long policyId) {
+        Map<String, Long> ret = Collections.emptyMap();
+        if (policyId != null && CollectionUtils.isNotEmpty(names)) {
+            try {
+                Collection<Object[]> result = getEntityManager()
+                        .createNamedQuery("XXResourceDef.findResourceDefIdsByNameAndPolicyId", Object[].class)
+                        .setParameter("policyId", policyId)
+                        .setParameter("names", names)
+                        .getResultList();
+                ret = result.stream().collect(
+                        Collectors.toMap(
+                                object -> (String) object[1],
+                                object -> (Long) object[0],
+                                (a, b) -> a));
+            } catch (NoResultException e) {
+                logger.debug(e.getMessage());
             }
-            // Group rows into an in-memory map keyed by resource name
-            ret = result.stream()
-                    .collect(Collectors.toMap(XXResourceDef::getName, java.util.function.Function.identity(), (a, b) -> a));
-        } catch (javax.persistence.NoResultException e) {
-            logger.error("No resource definitions found for policyId={} and names={}", policyId, names);
         }
-
         return ret;
     }
 }

--- a/security-admin/src/main/java/org/apache/ranger/db/XXResourceDefDao.java
+++ b/security-admin/src/main/java/org/apache/ranger/db/XXResourceDefDao.java
@@ -17,17 +17,26 @@
 
 package org.apache.ranger.db;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.ranger.common.db.BaseDao;
 import org.apache.ranger.entity.XXResourceDef;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import javax.persistence.NoResultException;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 public class XXResourceDefDao extends BaseDao<XXResourceDef> {
+    private static final Logger logger = LoggerFactory.getLogger(XXResourceDefDao.class);
+
     public XXResourceDefDao(RangerDaoManagerBase daoMgr) {
         super(daoMgr);
     }
@@ -100,5 +109,30 @@ public class XXResourceDefDao extends BaseDao<XXResourceDef> {
         } catch (NoResultException e) {
             return new ArrayList<>();
         }
+    }
+
+    public Map<String, XXResourceDef> findXXResourceDefsByNameAndPolicyId(Set<String> names, Long policyId) {
+        Map<String, XXResourceDef> ret = Collections.emptyMap();
+        if (policyId == null || CollectionUtils.isEmpty(names)) {
+            return ret;
+        }
+        try {
+            List<XXResourceDef> result = getEntityManager()
+                    .createNamedQuery("XXResourceDef.findByNamesAndPolicyId", XXResourceDef.class)
+                    .setParameter("policyId", policyId)
+                    .setParameter("names", names)
+                    .getResultList();
+
+            if (CollectionUtils.isEmpty(result)) {
+                return ret;
+            }
+            // Group rows into an in-memory map keyed by resource name
+            ret = result.stream()
+                    .collect(Collectors.toMap(XXResourceDef::getName, java.util.function.Function.identity(), (a, b) -> a));
+        } catch (javax.persistence.NoResultException e) {
+            logger.error("No resource definitions found for policyId={} and names={}", policyId, names);
+        }
+
+        return ret;
     }
 }

--- a/security-admin/src/main/java/org/apache/ranger/db/XXRoleDao.java
+++ b/security-admin/src/main/java/org/apache/ranger/db/XXRoleDao.java
@@ -17,19 +17,27 @@
 
 package org.apache.ranger.db;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.ranger.common.db.BaseDao;
 import org.apache.ranger.entity.XXRole;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import javax.persistence.NoResultException;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 public class XXRoleDao extends BaseDao<XXRole> {
+    private static final Logger logger = LoggerFactory.getLogger(XXRoleDao.class);
+
     /**
      * Default Constructor
      */
@@ -118,6 +126,25 @@ public class XXRoleDao extends BaseDao<XXRole> {
             ret = getEntityManager().createNamedQuery("XXRole.findByGroupId", tClass).setParameter("groupId", groupId).getResultList();
         } catch (NoResultException e) {
             ret = Collections.emptyList();
+        }
+        return ret;
+    }
+
+    public Map<String, Long> getIdsByRoleNames(Collection<String> roleNames) {
+        Map<String, Long> ret = Collections.emptyMap();
+        if (CollectionUtils.isNotEmpty(roleNames)) {
+            try {
+                Collection<Object[]> result = getEntityManager()
+                        .createNamedQuery("XXRole.getIdsByRoleNames", Object[].class)
+                        .setParameter("roleNames", roleNames)
+                        .getResultList();
+                ret = result.stream().collect(
+                    Collectors.toMap(
+                        object -> (String) (object[1]),
+                        object -> (Long) (object[0])));
+            } catch (NoResultException e) {
+                logger.debug(e.getMessage());
+            }
         }
         return ret;
     }

--- a/security-admin/src/main/java/org/apache/ranger/db/XXRoleDao.java
+++ b/security-admin/src/main/java/org/apache/ranger/db/XXRoleDao.java
@@ -131,21 +131,19 @@ public class XXRoleDao extends BaseDao<XXRole> {
     }
 
     public Map<String, Long> getIdsByRoleNames(Collection<String> roleNames) {
-        Map<String, Long> ret = Collections.emptyMap();
         if (CollectionUtils.isNotEmpty(roleNames)) {
             try {
                 Collection<Object[]> result = getEntityManager()
                         .createNamedQuery("XXRole.getIdsByRoleNames", Object[].class)
                         .setParameter("roleNames", roleNames)
                         .getResultList();
-                ret = result.stream().collect(
-                    Collectors.toMap(
-                        object -> (String) (object[1]),
-                        object -> (Long) (object[0])));
+
+                return result.stream().collect(Collectors.toMap(object -> (String) (object[1]), object -> (Long) (object[0])));
             } catch (NoResultException e) {
                 logger.debug(e.getMessage());
             }
         }
-        return ret;
+
+        return Collections.emptyMap();
     }
 }

--- a/security-admin/src/main/java/org/apache/ranger/db/XXUserDao.java
+++ b/security-admin/src/main/java/org/apache/ranger/db/XXUserDao.java
@@ -19,6 +19,7 @@
 
 package org.apache.ranger.db;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.ranger.authorization.utils.JsonUtils;
 import org.apache.ranger.common.RangerCommonEnums;
@@ -33,12 +34,14 @@ import org.springframework.stereotype.Service;
 import javax.persistence.NoResultException;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.apache.ranger.plugin.util.RangerCommonConstants.SCRIPT_FIELD__EMAIL_ADDRESS;
 import static org.apache.ranger.plugin.util.RangerCommonConstants.SCRIPT_FIELD__IS_INTERNAL;
@@ -182,6 +185,25 @@ public class XXUserDao extends BaseDao<XXUser> {
             logger.debug(excp.getMessage());
         }
 
+        return ret;
+    }
+
+    public Map<String, Long> getIdsByUserNames(Collection<String> names) {
+        Map<String, Long> ret = Collections.emptyMap();
+        if (CollectionUtils.isNotEmpty(names)) {
+            try {
+                Collection<Object[]> result = getEntityManager()
+                        .createNamedQuery("XXUser.getIdsByUserNames", Object[].class)
+                        .setParameter("names", names)
+                        .getResultList();
+                ret = result.stream().collect(
+                    Collectors.toMap(
+                        object -> (String) (object[1]),
+                        object -> (Long) (object[0])));
+            } catch (NoResultException e) {
+                logger.debug(e.getMessage());
+            }
+        }
         return ret;
     }
 

--- a/security-admin/src/main/java/org/apache/ranger/db/XXUserDao.java
+++ b/security-admin/src/main/java/org/apache/ranger/db/XXUserDao.java
@@ -189,22 +189,20 @@ public class XXUserDao extends BaseDao<XXUser> {
     }
 
     public Map<String, Long> getIdsByUserNames(Collection<String> names) {
-        Map<String, Long> ret = Collections.emptyMap();
         if (CollectionUtils.isNotEmpty(names)) {
             try {
                 Collection<Object[]> result = getEntityManager()
                         .createNamedQuery("XXUser.getIdsByUserNames", Object[].class)
                         .setParameter("names", names)
                         .getResultList();
-                ret = result.stream().collect(
-                    Collectors.toMap(
-                        object -> (String) (object[1]),
-                        object -> (Long) (object[0])));
+
+                return result.stream().collect(Collectors.toMap(object -> (String) (object[1]), object -> (Long) (object[0])));
             } catch (NoResultException e) {
                 logger.debug(e.getMessage());
             }
         }
-        return ret;
+
+        return Collections.emptyMap();
     }
 
     private UserInfo toUserInfo(Object[] row) {

--- a/security-admin/src/main/resources/META-INF/jpa_named_queries.xml
+++ b/security-admin/src/main/resources/META-INF/jpa_named_queries.xml
@@ -591,8 +591,8 @@
 				and xSvc.id = xPol.service and xPol.id = :policyId and obj.name = :name order by obj.level</query>
 	</named-query>
 
-	<named-query name="XXResourceDef.findByNamesAndPolicyId">
-		<query>select obj from XXResourceDef obj, XXPolicy xPol, XXServiceDef xSvcDef,
+	<named-query name="XXResourceDef.findResourceDefIdsByNameAndPolicyId">
+		<query>select obj.id, obj.name from XXResourceDef obj, XXPolicy xPol, XXServiceDef xSvcDef,
 			XXService xSvc where obj.defId = xSvcDef.id and xSvcDef.id = xSvc.type
 			and xSvc.id = xPol.service and xPol.id = :policyId and obj.name IN :names order by obj.level
 		</query>
@@ -651,8 +651,8 @@
 				obj.name = :name and xSvc.id = :serviceId and obj.defId = xSvc.type</query>
 	</named-query>
 
-	<named-query name="XXAccessTypeDef.findByNamesAndServiceId">
-		<query>select obj from XXAccessTypeDef obj, XXService xSvc where obj.name IN :names and xSvc.id = :serviceId and obj.defId = xSvc.type</query>
+	<named-query name="XXAccessTypeDef.findAccessTypeDefIdsByNamesAndServiceId">
+		<query>select obj.id, obj.name from XXAccessTypeDef obj, XXService xSvc where obj.name IN :names and xSvc.id = :serviceId and obj.defId = xSvc.type</query>
 	</named-query>
 
 	<named-query name="XXAccessTypeDef.getNamesByServiceName">
@@ -671,8 +671,8 @@
 		<query>select obj from XXPolicyConditionDef obj where obj.defId = :serviceDefId and obj.name = :name order by obj.order</query>
 	</named-query>
 
-	<named-query name="XXPolicyConditionDef.findByServiceDefIdAndNames">
-		<query>select obj from XXPolicyConditionDef obj where obj.defId = :serviceDefId and obj.name IN :names order by obj.order</query>
+	<named-query name="XXPolicyConditionDef.findConditionDefIdsByServiceDefIdAndNames">
+		<query>select obj.id, obj.name from XXPolicyConditionDef obj where obj.defId = :serviceDefId and obj.name IN :names order by obj.order</query>
 	</named-query>
 
 	<!-- XXContextEnricherDef -->
@@ -700,8 +700,8 @@
 			obj.name = :name and xSvc.id = :serviceId and obj.defId = xSvc.type</query>
 	</named-query>
 
-	<named-query name="XXDataMaskTypeDef.findByNamesAndServiceId">
-		<query>select obj from XXDataMaskTypeDef obj, XXService xSvc where obj.name IN :names and xSvc.id = :serviceId and obj.defId = xSvc.type</query>
+	<named-query name="XXDataMaskTypeDef.findDataMaskTypeDefIdsByNamesAndServiceId">
+		<query>select obj.id, obj.name from XXDataMaskTypeDef obj, XXService xSvc where obj.name IN :names and xSvc.id = :serviceId and obj.defId = xSvc.type</query>
 	</named-query>
 
 	<named-query name="XXDataMaskTypeDef.getNamesByServiceName">

--- a/security-admin/src/main/resources/META-INF/jpa_named_queries.xml
+++ b/security-admin/src/main/resources/META-INF/jpa_named_queries.xml
@@ -176,6 +176,10 @@
 		</query>
 	</named-query>
 
+	<named-query name="XXGroup.getIdsByGroupNames">
+		<query>SELECT obj.id, obj.name FROM XXGroup obj WHERE obj.name IN :names</query>
+	</named-query>
+
 	<!-- XXGroup -->
 	<named-query name="XXUser.findGroupsByUserIds">
 		<query>SELECT user.name, group.name FROM XXUser user, XXGroup group, XXGroupUser groupUser
@@ -191,6 +195,10 @@
 	<named-query name="XXUser.getAllUserIdNames">
 		<query>SELECT portalUser.id, user.id, user.name FROM XXUser user, XXPortalUser portalUser WHERE user.name=portalUser.loginId
 		</query>
+	</named-query>
+
+	<named-query name="XXUser.getIdsByUserNames">
+		<query>SELECT obj.id, obj.name FROM XXUser obj WHERE obj.name IN :names</query>
 	</named-query>
 
 	<named-query name="VXXPrincipal.lookupByName">
@@ -583,6 +591,13 @@
 				and xSvc.id = xPol.service and xPol.id = :policyId and obj.name = :name order by obj.level</query>
 	</named-query>
 
+	<named-query name="XXResourceDef.findByNamesAndPolicyId">
+		<query>select obj from XXResourceDef obj, XXPolicy xPol, XXServiceDef xSvcDef,
+			XXService xSvc where obj.defId = xSvcDef.id and xSvcDef.id = xSvc.type
+			and xSvc.id = xPol.service and xPol.id = :policyId and obj.name IN :names order by obj.level
+		</query>
+	</named-query>
+
 	<named-query name="XXResourceDef.findByParentResId">
 		<query>
 			select obj from XXResourceDef obj where obj.parent = :parentId
@@ -636,6 +651,10 @@
 				obj.name = :name and xSvc.id = :serviceId and obj.defId = xSvc.type</query>
 	</named-query>
 
+	<named-query name="XXAccessTypeDef.findByNamesAndServiceId">
+		<query>select obj from XXAccessTypeDef obj, XXService xSvc where obj.name IN :names and xSvc.id = :serviceId and obj.defId = xSvc.type</query>
+	</named-query>
+
 	<named-query name="XXAccessTypeDef.getNamesByServiceName">
 		<query>SELECT obj.name FROM XXAccessTypeDef obj, XXService svc
 		        WHERE svc.name = :serviceName
@@ -650,6 +669,10 @@
 
 	<named-query name="XXPolicyConditionDef.findByServiceDefIdAndName">
 		<query>select obj from XXPolicyConditionDef obj where obj.defId = :serviceDefId and obj.name = :name order by obj.order</query>
+	</named-query>
+
+	<named-query name="XXPolicyConditionDef.findByServiceDefIdAndNames">
+		<query>select obj from XXPolicyConditionDef obj where obj.defId = :serviceDefId and obj.name IN :names order by obj.order</query>
 	</named-query>
 
 	<!-- XXContextEnricherDef -->
@@ -675,6 +698,10 @@
 	<named-query name="XXDataMaskTypeDef.findByNameAndServiceId">
 		<query>select obj from XXDataMaskTypeDef obj, XXService xSvc where
 			obj.name = :name and xSvc.id = :serviceId and obj.defId = xSvc.type</query>
+	</named-query>
+
+	<named-query name="XXDataMaskTypeDef.findByNamesAndServiceId">
+		<query>select obj from XXDataMaskTypeDef obj, XXService xSvc where obj.name IN :names and xSvc.id = :serviceId and obj.defId = xSvc.type</query>
 	</named-query>
 
 	<named-query name="XXDataMaskTypeDef.getNamesByServiceName">
@@ -916,6 +943,14 @@
 		<query>select obj from XXPolicyRefGroup obj where obj.groupName = :groupName</query>
 	</named-query>
 
+	<named-query name="XXPolicyRefGroup.findGroupNameByPolicyId">
+		<query>select obj.groupName, obj.id from XXPolicyRefGroup obj where obj.policyId = :policyId</query>
+	</named-query>
+
+	<named-query name="XXPolicyRefGroup.deletePolicyRefGroupByIds">
+		<query>DELETE FROM XXPolicyRefGroup obj WHERE obj.id IN :ids </query>
+	</named-query>
+
 <!-- 	new queries -->
 	<named-query name="XXPolicyRefGroup.findByGroupIdAndPolicyId">
 		<query>select obj from XXPolicyRefGroup obj where obj.groupId = :groupId and obj.policyId = :policyId </query>
@@ -1120,6 +1155,14 @@
 
 	<named-query name="XXPolicyRefUser.deleteByIds">
 		<query>DELETE FROM XXPolicyRefUser obj WHERE obj.id IN :ids</query>
+	</named-query>
+
+	<named-query name="XXPolicyRefUser.findUserNameIdByPolicyId">
+		<query>SELECT obj.userName, obj.id FROM XXPolicyRefUser obj WHERE obj.policyId = :policyId</query>
+	</named-query>
+
+	<named-query name="XXPolicyRefUser.deletePolicyRefUserByIds">
+		<query>DELETE FROM XXPolicyRefUser obj WHERE obj.id IN :ids </query>
 	</named-query>
 
 	<!-- XXPolicyItemCondition -->
@@ -1956,6 +1999,10 @@
         <query>select obj.name from XXRole obj</query>
     </named-query>
 
+    <named-query name="XXRole.getIdsByRoleNames">
+        <query>SELECT obj.id, obj.name FROM XXRole obj WHERE obj.name IN :roleNames</query>
+    </named-query>
+
 	<!-- XXRoleRef* -->
 
     <named-query name="XXRoleRefUser.findByRoleId">
@@ -2024,6 +2071,14 @@
 	<!-- XXPolicyRefRole -->
 	<named-query name="XXPolicyRefRole.findByPolicyId">
 		<query>select obj from XXPolicyRefRole obj where obj.policyId = :policyId </query>
+	</named-query>
+
+	<named-query name="XXPolicyRefRole.findRoleNameIdByPolicyId">
+		<query>SELECT obj.roleName, obj.id FROM XXPolicyRefRole obj WHERE obj.policyId = :policyId</query>
+	</named-query>
+
+	<named-query name="XXPolicyRefRole.deletePolicyRefRoleByIds">
+		<query>DELETE FROM XXPolicyRefRole obj WHERE obj.id IN :ids </query>
 	</named-query>
 
 	<named-query name="XXPolicyRefRole.findIdsByPolicyId">

--- a/security-admin/src/main/resources/META-INF/jpa_named_queries.xml
+++ b/security-admin/src/main/resources/META-INF/jpa_named_queries.xml
@@ -592,9 +592,11 @@
 	</named-query>
 
 	<named-query name="XXResourceDef.findResourceDefIdsByNameAndPolicyId">
-		<query>select obj.id, obj.name from XXResourceDef obj, XXPolicy xPol, XXServiceDef xSvcDef,
-			XXService xSvc where obj.defId = xSvcDef.id and xSvcDef.id = xSvc.type
-			and xSvc.id = xPol.service and xPol.id = :policyId and obj.name IN :names order by obj.level
+		<query>SELECT obj.id, obj.name FROM XXResourceDef obj
+		        WHERE obj.name IN :names AND obj.defId IN
+		              (SELECT xSvcDef.id FROM XXServiceDef xSvcDef, XXService xSvc, XXPolicy xPol
+		                WHERE xSvcDef.id = xSvc.type AND xSvc.id = xPol.service AND xPol.id = :policyId)
+		        ORDER BY obj.level
 		</query>
 	</named-query>
 
@@ -652,7 +654,8 @@
 	</named-query>
 
 	<named-query name="XXAccessTypeDef.findAccessTypeDefIdsByNamesAndServiceId">
-		<query>select obj.id, obj.name from XXAccessTypeDef obj, XXService xSvc where obj.name IN :names and xSvc.id = :serviceId and obj.defId = xSvc.type</query>
+		<query>SELECT obj.id, obj.name FROM XXAccessTypeDef obj
+		        WHERE obj.name IN :names AND obj.defId IN (SELECT xSvc.type FROM XXService xSvc WHERE xSvc.id = :serviceId)</query>
 	</named-query>
 
 	<named-query name="XXAccessTypeDef.getNamesByServiceName">

--- a/security-admin/src/test/java/org/apache/ranger/biz/TestPolicyRefUpdater.java
+++ b/security-admin/src/test/java/org/apache/ranger/biz/TestPolicyRefUpdater.java
@@ -69,14 +69,21 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -122,7 +129,7 @@ public class TestPolicyRefUpdater {
 
     @Test
     public void testCreateNewPolMappingForRefTable_NullPolicyNoop() throws Exception {
-        updater.createNewPolMappingForRefTable(null, null, null, false);
+        updater.createNewPolMappingForRefTable(null, null, null, false, false);
     }
 
     @Test
@@ -164,7 +171,9 @@ public class TestPolicyRefUpdater {
         when(daoMgr.getXXResourceDef()).thenReturn(resDefDao);
         XXResourceDef xRes = new XXResourceDef();
         xRes.setId(1L);
-        when(resDefDao.findByNameAndPolicyId("db", 5L)).thenReturn(xRes);
+        Map<String, XXResourceDef> xxResourceDefMap = new HashMap<>();
+        xxResourceDefMap.put("db", xRes);
+        when(resDefDao.findXXResourceDefsByNameAndPolicyId(Mockito.anySet(), Mockito.eq(5L))).thenReturn(xxResourceDefMap);
         Mockito.lenient().when(rangerAuditFields.populateAuditFields(Mockito.any(), Mockito.any()))
                 .thenAnswer(inv -> inv.getArgument(0));
         XXPolicyRefResourceDao polResDao = mock(XXPolicyRefResourceDao.class);
@@ -179,21 +188,27 @@ public class TestPolicyRefUpdater {
         when(daoMgr.getXXAccessTypeDef()).thenReturn(accDefDao);
         XXAccessTypeDef xAcc = new XXAccessTypeDef();
         xAcc.setId(2L);
-        when(accDefDao.findByNameAndServiceId("select", 9L)).thenReturn(xAcc);
+        Map<String, XXAccessTypeDef> xAccMap = new HashMap<>();
+        xAccMap.put("select", xAcc);
+        when(accDefDao.findByNamesAndServiceId(Mockito.anySet(), Mockito.eq(9L))).thenReturn(xAccMap);
         XXPolicyRefAccessTypeDao polAccDao = mock(XXPolicyRefAccessTypeDao.class);
         when(daoMgr.getXXPolicyRefAccessType()).thenReturn(polAccDao);
         XXPolicyConditionDefDao condDefDao = mock(XXPolicyConditionDefDao.class);
         when(daoMgr.getXXPolicyConditionDef()).thenReturn(condDefDao);
         XXPolicyConditionDef xCond = new XXPolicyConditionDef();
         xCond.setId(3L);
-        when(condDefDao.findByServiceDefIdAndName(9L, "time")).thenReturn(xCond);
+        Map<String, XXPolicyConditionDef> xCondMap = new HashMap<>();
+        xCondMap.put("time", xCond);
+        when(condDefDao.findByServiceDefIdAndNames(Mockito.eq(9L), Mockito.anySet())).thenReturn(xCondMap);
         XXPolicyRefConditionDao polCondDao = mock(XXPolicyRefConditionDao.class);
         when(daoMgr.getXXPolicyRefCondition()).thenReturn(polCondDao);
         XXDataMaskTypeDefDao dmDefDao = mock(XXDataMaskTypeDefDao.class);
         when(daoMgr.getXXDataMaskTypeDef()).thenReturn(dmDefDao);
         XXDataMaskTypeDef xDm = new XXDataMaskTypeDef();
         xDm.setId(4L);
-        when(dmDefDao.findByNameAndServiceId("MASK", 9L)).thenReturn(xDm);
+        Map<String, XXDataMaskTypeDef> xxDataMaskTypeDefHashMap = new HashMap<>();
+        xxDataMaskTypeDefHashMap.put("MASK", xDm);
+        when(dmDefDao.findByNamesAndServiceId(Mockito.anySet(), Mockito.eq(9L))).thenReturn(xxDataMaskTypeDefHashMap);
         XXPolicyRefDataMaskTypeDao polDmDao = mock(XXPolicyRefDataMaskTypeDao.class);
         when(daoMgr.getXXPolicyRefDataMaskType()).thenReturn(polDmDao);
         when(rangerBizUtil.checkAdminAccess()).thenReturn(true);
@@ -215,7 +230,7 @@ public class TestPolicyRefUpdater {
         when(roleDao.findByRoleName("r1")).thenReturn(null);
         when(daoMgr.getXXPolicyRefRole()).thenReturn(polRoleDao);
 
-        updater.createNewPolMappingForRefTable(policy, xPolicy, xSvc, true);
+        updater.createNewPolMappingForRefTable(policy, xPolicy, xSvc, true, false);
         // no exceptions indicates success across branches
     }
 
@@ -231,18 +246,72 @@ public class TestPolicyRefUpdater {
         xPolicy.setId(6L);
         XXServiceDef xSvc = new XXServiceDef();
         xSvc.setId(9L);
-        // ensure cleanupRefTables() doesn't NPE before resource lookup
-        when(daoMgr.getXXPolicyRefResource()).thenReturn(mock(XXPolicyRefResourceDao.class));
-        when(daoMgr.getXXPolicyRefRole()).thenReturn(mock(XXPolicyRefRoleDao.class));
-        when(daoMgr.getXXPolicyRefGroup()).thenReturn(mock(XXPolicyRefGroupDao.class));
-        when(daoMgr.getXXPolicyRefUser()).thenReturn(mock(XXPolicyRefUserDao.class));
-        when(daoMgr.getXXPolicyRefAccessType()).thenReturn(mock(XXPolicyRefAccessTypeDao.class));
-        when(daoMgr.getXXPolicyRefCondition()).thenReturn(mock(XXPolicyRefConditionDao.class));
-        when(daoMgr.getXXPolicyRefDataMaskType()).thenReturn(mock(XXPolicyRefDataMaskTypeDao.class));
         XXResourceDefDao resDefDao = mock(XXResourceDefDao.class);
         when(daoMgr.getXXResourceDef()).thenReturn(resDefDao);
-        when(resDefDao.findByNameAndPolicyId("invalid", 6L)).thenReturn(null);
-        assertThrows(Exception.class, () -> updater.createNewPolMappingForRefTable(policy, xPolicy, xSvc, false));
+        when(resDefDao.findXXResourceDefsByNameAndPolicyId(Mockito.anySet(), Mockito.eq(6L))).thenReturn(null);
+        assertThrows(Exception.class, () -> updater.createNewPolMappingForRefTable(policy, xPolicy, xSvc, false, false));
+    }
+
+    @Test
+    public void testCleanupRefTablesForUpdate_SelectivePrincipalCleanup() {
+        final Long policyId = 100L;
+
+        Set<String> policyUsers  = new HashSet<>(Arrays.asList("alice", "bob", "carol"));
+        Set<String> policyRoles  = new HashSet<>(Arrays.asList("roleA", "roleB", "roleNew"));
+        Set<String> policyGroups = new HashSet<>(Arrays.asList("grp1", "grp2", "grpNew"));
+
+        Map<String, Long> existingUsers = new HashMap<>();
+        existingUsers.put("alice", 1L);
+        existingUsers.put("bob", 2L);
+        existingUsers.put("dave", 4L);
+
+        Map<String, Long> existingRoles = new HashMap<>();
+        existingRoles.put("roleA", 10L);
+        existingRoles.put("roleOld", 12L);
+
+        Map<String, Long> existingGroups = new HashMap<>();
+        existingGroups.put("grp1", 20L);
+        existingGroups.put("grpOld", 22L);
+
+        XXPolicyRefUserDao userDao = mock(XXPolicyRefUserDao.class);
+        XXPolicyRefRoleDao roleDao = mock(XXPolicyRefRoleDao.class);
+        XXPolicyRefGroupDao groupDao = mock(XXPolicyRefGroupDao.class);
+        XXPolicyRefResourceDao resourceDao = mock(XXPolicyRefResourceDao.class);
+        XXPolicyRefAccessTypeDao accessDao = mock(XXPolicyRefAccessTypeDao.class);
+        XXPolicyRefConditionDao conditionDao = mock(XXPolicyRefConditionDao.class);
+        XXPolicyRefDataMaskTypeDao dataMaskDao = mock(XXPolicyRefDataMaskTypeDao.class);
+
+        when(daoMgr.getXXPolicyRefUser()).thenReturn(userDao);
+        when(daoMgr.getXXPolicyRefRole()).thenReturn(roleDao);
+        when(daoMgr.getXXPolicyRefGroup()).thenReturn(groupDao);
+        when(daoMgr.getXXPolicyRefResource()).thenReturn(resourceDao);
+        when(daoMgr.getXXPolicyRefAccessType()).thenReturn(accessDao);
+        when(daoMgr.getXXPolicyRefCondition()).thenReturn(conditionDao);
+        when(daoMgr.getXXPolicyRefDataMaskType()).thenReturn(dataMaskDao);
+
+        when(userDao.findUserNameIdByPolicyId(policyId)).thenReturn(existingUsers);
+        when(roleDao.findRoleNameIdByPolicyId(policyId)).thenReturn(existingRoles);
+        when(groupDao.findGroupNameByPolicyId(policyId)).thenReturn(existingGroups);
+
+        assertTrue(updater.cleanupRefTablesForUpdate(policyId, policyUsers, policyRoles, policyGroups));
+
+        verify(userDao).deletePolicyRefUserByIds(Collections.singletonList(4L));
+        assertEquals(Collections.singleton("carol"), policyUsers);
+
+        verify(roleDao).deletePolicyRefRoleByIds(Collections.singletonList(12L));
+        assertEquals(new HashSet<>(Arrays.asList("roleB", "roleNew")), policyRoles);
+
+        verify(groupDao).deletePolicyRefGroupByIds(Collections.singletonList(22L));
+        assertEquals(new HashSet<>(Arrays.asList("grp2", "grpNew")), policyGroups);
+
+        verify(resourceDao).deleteByPolicyId(policyId);
+        verify(accessDao).deleteByPolicyId(policyId);
+        verify(conditionDao).deleteByPolicyId(policyId);
+        verify(dataMaskDao).deleteByPolicyId(policyId);
+
+        verify(userDao, never()).deleteByPolicyId(policyId);
+        verify(roleDao, never()).deleteByPolicyId(policyId);
+        verify(groupDao, never()).deleteByPolicyId(policyId);
     }
 
     @Test
@@ -268,9 +337,14 @@ public class TestPolicyRefUpdater {
         xPolicy.setId(10L);
         xPolicy.setService(100L);
 
+        // FIX: Mock policy DAO hierarchy to satisfy doesPolicyExist(xPolicy) checks
+        org.apache.ranger.db.XXPolicyDao policyDao = mock(org.apache.ranger.db.XXPolicyDao.class);
+        when(daoMgr.getXXPolicy()).thenReturn(policyDao);
+        when(policyDao.getById(xPolicy.getId())).thenReturn(xPolicy);
+
         // Mock audit population to be identity
         Mockito.lenient().when(rangerAuditFields.populateAuditFields(Mockito.any(), Mockito.any()))
-                .thenAnswer(inv -> inv.getArgument(0));
+            .thenAnswer(inv -> inv.getArgument(0));
 
         // USER path: user not found, xUserMgr creates, then XXUser lookup returns id
         XXUserDao userDao = mock(XXUserDao.class);
@@ -294,10 +368,21 @@ public class TestPolicyRefUpdater {
             }
         }
         assertNotNull(inner);
-        Constructor<?> ctor = inner.getDeclaredConstructor(PolicyRefUpdater.class,
-                PolicyRefUpdater.PRINCIPAL_TYPE.class, String.class, XXPolicy.class);
+        Constructor<?> ctor = inner.getDeclaredConstructor(
+                PolicyRefUpdater.class,
+                PolicyRefUpdater.PRINCIPAL_TYPE.class,
+                String.class,
+                XXPolicy.class,
+                Long.class,
+                List.class,
+                List.class,
+                List.class);
         ctor.setAccessible(true);
-        Object associatorUser = ctor.newInstance(updater, PolicyRefUpdater.PRINCIPAL_TYPE.USER, "uNew", xPolicy);
+        List<XXPolicyRefUser> mockPolUsers = new ArrayList<>();
+        List<XXPolicyRefGroup> mockPolGroups = new ArrayList<>();
+        List<XXPolicyRefRole> mockPolRoles = new ArrayList<>();
+
+        Object associatorUser = ctor.newInstance(updater, PolicyRefUpdater.PRINCIPAL_TYPE.USER, "uNew", xPolicy, null, mockPolUsers, mockPolGroups, mockPolRoles);
         Method doAssociate = inner.getDeclaredMethod("doAssociate", boolean.class);
         doAssociate.setAccessible(true);
         Object resultUser = doAssociate.invoke(associatorUser, true);
@@ -316,7 +401,7 @@ public class TestPolicyRefUpdater {
         XXPolicyRefGroupDao polGroupDao = mock(XXPolicyRefGroupDao.class);
         when(daoMgr.getXXPolicyRefGroup()).thenReturn(polGroupDao);
 
-        Object associatorGroup = ctor.newInstance(updater, PolicyRefUpdater.PRINCIPAL_TYPE.GROUP, "gNew", xPolicy);
+        Object associatorGroup = ctor.newInstance(updater, PolicyRefUpdater.PRINCIPAL_TYPE.GROUP, "gNew", xPolicy, null, mockPolUsers, mockPolGroups, mockPolRoles);
         Object resultGroup = doAssociate.invoke(associatorGroup, true);
         assertEquals(Boolean.TRUE, resultGroup);
         verify(daoMgr.getXXPolicyRefGroup(), Mockito.times(1))
@@ -333,7 +418,7 @@ public class TestPolicyRefUpdater {
         XXPolicyRefRoleDao polRoleDao = mock(XXPolicyRefRoleDao.class);
         when(daoMgr.getXXPolicyRefRole()).thenReturn(polRoleDao);
 
-        Object associatorRole = ctor.newInstance(updater, PolicyRefUpdater.PRINCIPAL_TYPE.ROLE, "rNew", xPolicy);
+        Object associatorRole = ctor.newInstance(updater, PolicyRefUpdater.PRINCIPAL_TYPE.ROLE, "rNew", xPolicy, null, mockPolUsers, mockPolGroups, mockPolRoles);
         Object resultRole = doAssociate.invoke(associatorRole, true);
         assertEquals(Boolean.TRUE, resultRole);
         verify(daoMgr.getXXPolicyRefRole(), Mockito.times(1)).create(Mockito.any(XXPolicyRefRole.class));

--- a/security-admin/src/test/java/org/apache/ranger/biz/TestPolicyRefUpdater.java
+++ b/security-admin/src/test/java/org/apache/ranger/biz/TestPolicyRefUpdater.java
@@ -36,14 +36,10 @@ import org.apache.ranger.db.XXPolicyRefUserDao;
 import org.apache.ranger.db.XXResourceDefDao;
 import org.apache.ranger.db.XXRoleDao;
 import org.apache.ranger.db.XXUserDao;
-import org.apache.ranger.entity.XXAccessTypeDef;
-import org.apache.ranger.entity.XXDataMaskTypeDef;
 import org.apache.ranger.entity.XXPolicy;
-import org.apache.ranger.entity.XXPolicyConditionDef;
 import org.apache.ranger.entity.XXPolicyRefGroup;
 import org.apache.ranger.entity.XXPolicyRefRole;
 import org.apache.ranger.entity.XXPolicyRefUser;
-import org.apache.ranger.entity.XXResourceDef;
 import org.apache.ranger.entity.XXServiceDef;
 import org.apache.ranger.entity.XXUser;
 import org.apache.ranger.plugin.model.RangerPolicy;
@@ -69,7 +65,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -169,11 +164,9 @@ public class TestPolicyRefUpdater {
         // Stubs for DAO lookups and batch create calls
         XXResourceDefDao resDefDao = mock(XXResourceDefDao.class);
         when(daoMgr.getXXResourceDef()).thenReturn(resDefDao);
-        XXResourceDef xRes = new XXResourceDef();
-        xRes.setId(1L);
-        Map<String, XXResourceDef> xxResourceDefMap = new HashMap<>();
-        xxResourceDefMap.put("db", xRes);
-        when(resDefDao.findXXResourceDefsByNameAndPolicyId(Mockito.anySet(), Mockito.eq(5L))).thenReturn(xxResourceDefMap);
+        Map<String, Long> xxResourceDefIdMap = new HashMap<>();
+        xxResourceDefIdMap.put("db", 1L);
+        when(resDefDao.findResourceDefIdsByNameAndPolicyId(Mockito.anySet(), Mockito.eq(5L))).thenReturn(xxResourceDefIdMap);
         Mockito.lenient().when(rangerAuditFields.populateAuditFields(Mockito.any(), Mockito.any()))
                 .thenAnswer(inv -> inv.getArgument(0));
         XXPolicyRefResourceDao polResDao = mock(XXPolicyRefResourceDao.class);
@@ -186,49 +179,42 @@ public class TestPolicyRefUpdater {
         when(daoMgr.getXXPolicyRefUser()).thenReturn(polUserDao);
         XXAccessTypeDefDao accDefDao = mock(XXAccessTypeDefDao.class);
         when(daoMgr.getXXAccessTypeDef()).thenReturn(accDefDao);
-        XXAccessTypeDef xAcc = new XXAccessTypeDef();
-        xAcc.setId(2L);
-        Map<String, XXAccessTypeDef> xAccMap = new HashMap<>();
-        xAccMap.put("select", xAcc);
-        when(accDefDao.findByNamesAndServiceId(Mockito.anySet(), Mockito.eq(9L))).thenReturn(xAccMap);
+        Map<String, Long> xAccMap = new HashMap<>();
+        xAccMap.put("select", 2L);
+        when(accDefDao.findAccessTypeDefIdsByNamesAndServiceId(Mockito.anySet(), Mockito.eq(9L))).thenReturn(xAccMap);
         XXPolicyRefAccessTypeDao polAccDao = mock(XXPolicyRefAccessTypeDao.class);
         when(daoMgr.getXXPolicyRefAccessType()).thenReturn(polAccDao);
         XXPolicyConditionDefDao condDefDao = mock(XXPolicyConditionDefDao.class);
         when(daoMgr.getXXPolicyConditionDef()).thenReturn(condDefDao);
-        XXPolicyConditionDef xCond = new XXPolicyConditionDef();
-        xCond.setId(3L);
-        Map<String, XXPolicyConditionDef> xCondMap = new HashMap<>();
-        xCondMap.put("time", xCond);
-        when(condDefDao.findByServiceDefIdAndNames(Mockito.eq(9L), Mockito.anySet())).thenReturn(xCondMap);
+        Map<String, Long> xCondMap = new HashMap<>();
+        xCondMap.put("time", 3L);
+        when(condDefDao.findConditionDefIdsByServiceDefIdAndNames(Mockito.eq(9L), Mockito.anySet())).thenReturn(xCondMap);
         XXPolicyRefConditionDao polCondDao = mock(XXPolicyRefConditionDao.class);
         when(daoMgr.getXXPolicyRefCondition()).thenReturn(polCondDao);
         XXDataMaskTypeDefDao dmDefDao = mock(XXDataMaskTypeDefDao.class);
         when(daoMgr.getXXDataMaskTypeDef()).thenReturn(dmDefDao);
-        XXDataMaskTypeDef xDm = new XXDataMaskTypeDef();
-        xDm.setId(4L);
-        Map<String, XXDataMaskTypeDef> xxDataMaskTypeDefHashMap = new HashMap<>();
-        xxDataMaskTypeDefHashMap.put("MASK", xDm);
-        when(dmDefDao.findByNamesAndServiceId(Mockito.anySet(), Mockito.eq(9L))).thenReturn(xxDataMaskTypeDefHashMap);
+        Map<String, Long> xxDataMaskTypeDefIdMap = new HashMap<>();
+        xxDataMaskTypeDefIdMap.put("MASK", 4L);
+        when(dmDefDao.findDataMaskTypeDefIdsByNamesAndServiceId(Mockito.anySet(), Mockito.eq(9L))).thenReturn(xxDataMaskTypeDefIdMap);
         XXPolicyRefDataMaskTypeDao polDmDao = mock(XXPolicyRefDataMaskTypeDao.class);
         when(daoMgr.getXXPolicyRefDataMaskType()).thenReturn(polDmDao);
         when(rangerBizUtil.checkAdminAccess()).thenReturn(true);
 
-        // Principal creation path (user, group, role) when not existing and
-        // createPrincipalsIfAbsent=true
+        org.apache.ranger.db.XXPolicyDao policyDao = mock(org.apache.ranger.db.XXPolicyDao.class);
+        when(daoMgr.getXXPolicy()).thenReturn(policyDao);
+        when(policyDao.getById(xPolicy.getId())).thenReturn(xPolicy);
+
         XXUserDao userDao = mock(XXUserDao.class);
         when(daoMgr.getXXUser()).thenReturn(userDao);
-        when(userDao.findByUserName("u1")).thenReturn(null);
-        when(daoMgr.getXXPolicyRefUser()).thenReturn(polUserDao);
+        when(userDao.getIdsByUserNames(Mockito.anySet())).thenReturn(Collections.singletonMap("u1", 30L));
 
         XXGroupDao groupDao = mock(XXGroupDao.class);
         when(daoMgr.getXXGroup()).thenReturn(groupDao);
-        when(groupDao.findByGroupName("g1")).thenReturn(null);
-        when(daoMgr.getXXPolicyRefGroup()).thenReturn(polGroupDao);
+        when(groupDao.getIdsByGroupNames(Mockito.anySet())).thenReturn(Collections.singletonMap("g1", 20L));
 
         XXRoleDao roleDao = mock(XXRoleDao.class);
         when(daoMgr.getXXRole()).thenReturn(roleDao);
-        when(roleDao.findByRoleName("r1")).thenReturn(null);
-        when(daoMgr.getXXPolicyRefRole()).thenReturn(polRoleDao);
+        when(roleDao.getIdsByRoleNames(Mockito.anySet())).thenReturn(Collections.singletonMap("r1", 10L));
 
         updater.createNewPolMappingForRefTable(policy, xPolicy, xSvc, true, false);
         // no exceptions indicates success across branches
@@ -248,7 +234,7 @@ public class TestPolicyRefUpdater {
         xSvc.setId(9L);
         XXResourceDefDao resDefDao = mock(XXResourceDefDao.class);
         when(daoMgr.getXXResourceDef()).thenReturn(resDefDao);
-        when(resDefDao.findXXResourceDefsByNameAndPolicyId(Mockito.anySet(), Mockito.eq(6L))).thenReturn(null);
+        when(resDefDao.findResourceDefIdsByNameAndPolicyId(Mockito.anySet(), Mockito.eq(6L))).thenReturn(Collections.emptyMap());
         assertThrows(Exception.class, () -> updater.createNewPolMappingForRefTable(policy, xPolicy, xSvc, false, false));
     }
 
@@ -359,34 +345,22 @@ public class TestPolicyRefUpdater {
         XXPolicyRefUserDao polUserDao = mock(XXPolicyRefUserDao.class);
         when(daoMgr.getXXPolicyRefUser()).thenReturn(polUserDao);
 
-        // Reflectively construct inner class PolicyPrincipalAssociator for USER
-        Class<?> inner = null;
+        // Reflectively construct inner class PolicyUserAssociator for USER
+        Class<?> userAssociatorClass = null;
         for (Class<?> c : PolicyRefUpdater.class.getDeclaredClasses()) {
-            if (c.getSimpleName().equals("PolicyPrincipalAssociator")) {
-                inner = c;
+            if (c.getSimpleName().equals("PolicyUserAssociator")) {
+                userAssociatorClass = c;
                 break;
             }
         }
-        assertNotNull(inner);
-        Constructor<?> ctor = inner.getDeclaredConstructor(
-                PolicyRefUpdater.class,
-                PolicyRefUpdater.PRINCIPAL_TYPE.class,
-                String.class,
-                XXPolicy.class,
-                Long.class,
-                List.class,
-                List.class,
-                List.class);
-        ctor.setAccessible(true);
-        List<XXPolicyRefUser> mockPolUsers = new ArrayList<>();
-        List<XXPolicyRefGroup> mockPolGroups = new ArrayList<>();
-        List<XXPolicyRefRole> mockPolRoles = new ArrayList<>();
-
-        Object associatorUser = ctor.newInstance(updater, PolicyRefUpdater.PRINCIPAL_TYPE.USER, "uNew", xPolicy, null, mockPolUsers, mockPolGroups, mockPolRoles);
-        Method doAssociate = inner.getDeclaredMethod("doAssociate", boolean.class);
-        doAssociate.setAccessible(true);
-        Object resultUser = doAssociate.invoke(associatorUser, true);
-        assertEquals(Boolean.TRUE, resultUser);
+        assertNotNull(userAssociatorClass);
+        Constructor<?> userCtor = userAssociatorClass.getDeclaredConstructor(
+                PolicyRefUpdater.class, String.class, Long.class, XXPolicy.class);
+        userCtor.setAccessible(true);
+        Object associatorUser = userCtor.newInstance(updater, "uNew", null, xPolicy);
+        Method runUser = userAssociatorClass.getDeclaredMethod("run");
+        runUser.setAccessible(true);
+        runUser.invoke(associatorUser);
         verify(daoMgr.getXXPolicyRefUser(), Mockito.times(1))
                 .create(Mockito.any(XXPolicyRefUser.class));
 
@@ -401,9 +375,21 @@ public class TestPolicyRefUpdater {
         XXPolicyRefGroupDao polGroupDao = mock(XXPolicyRefGroupDao.class);
         when(daoMgr.getXXPolicyRefGroup()).thenReturn(polGroupDao);
 
-        Object associatorGroup = ctor.newInstance(updater, PolicyRefUpdater.PRINCIPAL_TYPE.GROUP, "gNew", xPolicy, null, mockPolUsers, mockPolGroups, mockPolRoles);
-        Object resultGroup = doAssociate.invoke(associatorGroup, true);
-        assertEquals(Boolean.TRUE, resultGroup);
+        Class<?> groupAssociatorClass = null;
+        for (Class<?> c : PolicyRefUpdater.class.getDeclaredClasses()) {
+            if (c.getSimpleName().equals("PolicyGroupAssociator")) {
+                groupAssociatorClass = c;
+                break;
+            }
+        }
+        assertNotNull(groupAssociatorClass);
+        Constructor<?> groupCtor = groupAssociatorClass.getDeclaredConstructor(
+                PolicyRefUpdater.class, String.class, Long.class, XXPolicy.class);
+        groupCtor.setAccessible(true);
+        Object associatorGroup = groupCtor.newInstance(updater, "gNew", null, xPolicy);
+        Method runGroup = groupAssociatorClass.getDeclaredMethod("run");
+        runGroup.setAccessible(true);
+        runGroup.invoke(associatorGroup);
         verify(daoMgr.getXXPolicyRefGroup(), Mockito.times(1))
                 .create(Mockito.any(XXPolicyRefGroup.class));
 
@@ -418,9 +404,21 @@ public class TestPolicyRefUpdater {
         XXPolicyRefRoleDao polRoleDao = mock(XXPolicyRefRoleDao.class);
         when(daoMgr.getXXPolicyRefRole()).thenReturn(polRoleDao);
 
-        Object associatorRole = ctor.newInstance(updater, PolicyRefUpdater.PRINCIPAL_TYPE.ROLE, "rNew", xPolicy, null, mockPolUsers, mockPolGroups, mockPolRoles);
-        Object resultRole = doAssociate.invoke(associatorRole, true);
-        assertEquals(Boolean.TRUE, resultRole);
+        Class<?> roleAssociatorClass = null;
+        for (Class<?> c : PolicyRefUpdater.class.getDeclaredClasses()) {
+            if (c.getSimpleName().equals("PolicyRoleAssociator")) {
+                roleAssociatorClass = c;
+                break;
+            }
+        }
+        assertNotNull(roleAssociatorClass);
+        Constructor<?> roleCtor = roleAssociatorClass.getDeclaredConstructor(
+                PolicyRefUpdater.class, String.class, Long.class, XXPolicy.class);
+        roleCtor.setAccessible(true);
+        Object associatorRole = roleCtor.newInstance(updater, "rNew", null, xPolicy);
+        Method runRole = roleAssociatorClass.getDeclaredMethod("run");
+        runRole.setAccessible(true);
+        runRole.invoke(associatorRole);
         verify(daoMgr.getXXPolicyRefRole(), Mockito.times(1)).create(Mockito.any(XXPolicyRefRole.class));
     }
 }

--- a/security-admin/src/test/java/org/apache/ranger/biz/TestServiceDBStore.java
+++ b/security-admin/src/test/java/org/apache/ranger/biz/TestServiceDBStore.java
@@ -1425,7 +1425,7 @@ public class TestServiceDBStore {
 
         Mockito.when(daoMgr.getXXPolicy()).thenReturn(xPolicyDao);
         Mockito.when(xPolicyDao.getById(Id)).thenReturn(xPolicy);
-        Mockito.doNothing().when(policyRefUpdater).createNewPolMappingForRefTable(rangerPolicy, xPolicy, xServiceDef, false);
+        Mockito.doNothing().when(policyRefUpdater).createNewPolMappingForRefTable(rangerPolicy, xPolicy, xServiceDef, false, false);
         Mockito.when(policyService.getPopulatedViewObject(xPolicy)).thenReturn(rangerPolicy);
 
         Mockito.when(daoMgr.getXXService()).thenReturn(xServiceDao);
@@ -1550,7 +1550,9 @@ public class TestServiceDBStore {
         RangerPolicyResourceSignature signature = Mockito.mock(RangerPolicyResourceSignature.class);
         Mockito.when(factory.createPolicyResourceSignature(rangerPolicy)).thenReturn(signature);
         Mockito.when(!bizUtil.hasAccess(xService, null)).thenReturn(true);
-        Mockito.when(policyRefUpdater.cleanupRefTables(rangerPolicy)).thenReturn(true);
+        Mockito.doNothing().when(policyRefUpdater).createNewPolMappingForRefTable(
+                Mockito.eq(rangerPolicy), Mockito.eq(xPolicy), Mockito.eq(xServiceDef),
+                Mockito.anyBoolean(), Mockito.eq(true));
 
         RangerPolicy dbRangerPolicy = serviceDBStore.updatePolicy(rangerPolicy);
         Assertions.assertNotNull(dbRangerPolicy);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Optimized `PolicyRefUpdater` and related DAOs so policy create/update performs fewer database round-trips when a policy references many users, groups, and roles.

### Problem

When creating or updating a policy with a large number of principals (users, groups, roles), Ranger Admin was slow because:

1. **N+1 lookups** — Each user, group, role, resource, access type, condition, and data mask type was resolved with a separate DB query (`findByUserName`, `findByGroupName`, `findByRoleName`, etc.).
2. **Full ref-table rebuild on update** — On policy update, `cleanupRefTables()` deleted all rows from `x_policy_ref_user`, `x_policy_ref_group`, and `x_policy_ref_role` (and other ref tables), then re-inserted every principal even when nothing changed.

### Changes

1. **Batch lookups via named queries** — Added `IN (:names)` JPA named queries and DAO helpers to resolve principals and definitions in bulk:
   - `XXUser.getIdsByUserNames`
   - `XXGroup.getIdsByGroupNames`
   - `XXRole.getIdsByRoleNames`
   - `XXResourceDef.findByNamesAndPolicyId`
   - `XXAccessTypeDef.findByNamesAndServiceId`
   - `XXPolicyConditionDef.findByServiceDefIdAndNames`
   - `XXDataMaskTypeDef.findByNamesAndServiceId`

2. **Pre-resolved principal IDs** — `PolicyPrincipalAssociator` now accepts a pre-fetched principal ID from the bulk map, avoiding per-name lookups when the principal already exists.

3. **Selective cleanup on policy update** — Introduced `cleanupRefTablesForUpdate()` that:
   - Loads existing user/role/group ref rows for the policy
   - Deletes only principals removed from the policy
   - Skips re-insert for principals that are unchanged
   - Still performs full delete/rebuild for resources, access types, conditions, and data mask types (typically far fewer entries)

4. **Unified create/update flow** — `createNewPolMappingForRefTable()` takes a new `isCleanupRefTablesNeeded` flag:
   - **Create:** `false` (no prior ref rows)
   - **Update:** `true` (runs selective cleanup before insert)
   - `ServiceDBStore` no longer calls `cleanupRefTables()` separately before mapping

5. **Batch insert helper** — Added `batchInsert()` with bulk-mode handling and debug timing logs around `dao.batchCreate()`.

### Files changed (15)

| Area | Files |
|------|-------|
| Core logic | `PolicyRefUpdater.java`, `ServiceDBStore.java` |
| DAOs | `XXUserDao`, `XXGroupDao`, `XXRoleDao`, `XXResourceDefDao`, `XXAccessTypeDefDao`, `XXPolicyConditionDefDao`, `XXDataMaskTypeDefDao`, `XXPolicyRefUserDao`, `XXPolicyRefGroupDao`, `XXPolicyRefRoleDao` |
| Queries | `jpa_named_queries.xml` |
| Tests | `TestPolicyRefUpdater.java`, `TestServiceDBStore.java` |

---

## How was this patch tested?

### Unit tests

- [x] Updated `TestPolicyRefUpdater` for the new bulk-lookup APIs and `isCleanupRefTablesNeeded` parameter
- [x] Added `testCleanupRefTablesForUpdate_SelectivePrincipalCleanup` to verify selective delete/insert for users, roles, and groups on update
- [x] Updated `TestServiceDBStore` for the new `createNewPolMappingForRefTable` signature

```bash
mvn -pl security-admin test -Dtest=TestPolicyRefUpdater,TestServiceDBStore