### PR TITLE
RANGER-5611 : Support TLSv1.3 Encryption for all Communications for R…

### DIFF
--- a/agents-audit/core/src/main/java/org/apache/ranger/audit/provider/BaseAuditHandler.java
+++ b/agents-audit/core/src/main/java/org/apache/ranger/audit/provider/BaseAuditHandler.java
@@ -51,7 +51,7 @@ public abstract class BaseAuditHandler implements AuditHandler {
     public static final String RANGER_POLICYMGR_TRUSTSTORE_FILE_TYPE_DEFAULT     = "jks";
     public static final String RANGER_SSL_KEYMANAGER_ALGO_TYPE                   = KeyManagerFactory.getDefaultAlgorithm();
     public static final String RANGER_SSL_TRUSTMANAGER_ALGO_TYPE                 = TrustManagerFactory.getDefaultAlgorithm();
-    public static final String RANGER_SSL_CONTEXT_ALGO_TYPE                      = "TLSv1.2";
+    public static final String RANGER_SSL_CONTEXT_ALGO_TYPE                      = "TLS";
     public static final String PROP_CONFIG                                       = "config";
     public static final String FAILED_TO_LOG_AUDIT_EVENT                         = "failed to log audit event: {}";
     public static final String PROP_NAME                                         = "name";

--- a/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerRESTClient.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerRESTClient.java
@@ -101,7 +101,7 @@ public class RangerRESTClient {
     public static final String RANGER_POLICYMGR_TRUSTSTORE_FILE_TYPE_DEFAULT     = "jks";
     public static final String RANGER_SSL_KEYMANAGER_ALGO_TYPE                   = KeyManagerFactory.getDefaultAlgorithm();
     public static final String RANGER_SSL_TRUSTMANAGER_ALGO_TYPE                 = TrustManagerFactory.getDefaultAlgorithm();
-    public static final String RANGER_SSL_CONTEXT_ALGO_TYPE                      = "TLSv1.2";
+    public static final String RANGER_SSL_CONTEXT_ALGO_TYPE                      = "TLS";
     public static final String JWT_HEADER_PREFIX                                 = "Bearer ";
 
     public static final String RANGER_PROP_JWT_TOKEN_RETRIEVER_CLASS         = "ranger.common.auth.jwt.retriever.class";

--- a/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerSslHelper.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerSslHelper.java
@@ -59,7 +59,7 @@ public class RangerSslHelper {
     static final String           RANGER_POLICYMGR_TRUSTSTORE_FILE_TYPE_DEFAULT     = "jks";
     static final String           RANGER_SSL_KEYMANAGER_ALGO_TYPE                   = KeyManagerFactory.getDefaultAlgorithm();
     static final String           RANGER_SSL_TRUSTMANAGER_ALGO_TYPE                 = TrustManagerFactory.getDefaultAlgorithm();
-    static final String           RANGER_SSL_CONTEXT_ALGO_TYPE                      = "TLSv1.2";
+    static final String           RANGER_SSL_CONTEXT_ALGO_TYPE                      = "TLS";
     static final HostnameVerifier _Hv                                               = (urlHostName, session) -> session.getPeerHost().equals(urlHostName);
 
     final   String mSslConfigFileName;

--- a/audit-server/audit-dispatcher/dispatcher-common/src/main/java/org/apache/ranger/audit/dispatcher/EmbeddedServer.java
+++ b/audit-server/audit-dispatcher/dispatcher-common/src/main/java/org/apache/ranger/audit/dispatcher/EmbeddedServer.java
@@ -42,6 +42,7 @@ import org.apache.ranger.audit.server.AuditConfig;
 import org.apache.ranger.audit.server.AuditServerConstants;
 import org.apache.ranger.audit.utils.AuditServerLogFormatter;
 import org.apache.ranger.authorization.hadoop.utils.RangerCredentialProvider;
+import org.apache.tomcat.util.net.SSLHostConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -84,7 +85,8 @@ public class EmbeddedServer {
     public  static final String DEFAULT_NAME_RULE                   = "DEFAULT";
     private static final String RANGER_KEYSTORE_FILE_TYPE_DEFAULT   = "jks";
     private static final String RANGER_TRUSTSTORE_FILE_TYPE_DEFAULT = "jks";
-    private static final String RANGER_SSL_CONTEXT_ALGO_TYPE        = "TLSv1.2";
+    private static final String RANGER_SSL_CONTEXT_ALGO_TYPE        = "TLS";
+    private static final String DEFAULT_SSL_PROTOCOL                = "TLS";
     private static final String RANGER_SSL_KEYMANAGER_ALGO_TYPE     = KeyManagerFactory.getDefaultAlgorithm();
     private static final String RANGER_SSL_TRUSTMANAGER_ALGO_TYPE   = TrustManagerFactory.getDefaultAlgorithm();
     public static final  String KEYSTORE_FILE_TYPE_DEFAULT          = KeyStore.getDefaultType();
@@ -181,7 +183,7 @@ public class EmbeddedServer {
             ssl.setSecure(true);
             ssl.setScheme("https");
             ssl.setAttribute("SSLEnabled", "true");
-            ssl.setAttribute("sslProtocol", getConfig("https.attrib.ssl.protocol", "TLSv1.2"));
+            ssl.setAttribute("sslProtocol", getConfig("https.attrib.ssl.protocol", DEFAULT_SSL_PROTOCOL));
             ssl.setAttribute("clientAuth", clientAuth);
             if (StringUtils.isNotBlank(sslKeystoreKeyAlias)) {
                 ssl.setAttribute("keyAlias", sslKeystoreKeyAlias);
@@ -194,6 +196,14 @@ public class EmbeddedServer {
 
             if (StringUtils.isNotBlank(ciphers)) {
                 ssl.setAttribute("ciphers", ciphers);
+                SSLHostConfig[] configs = ssl.findSslHostConfigs();
+                if (configs != null) {
+                    for (SSLHostConfig hostConfig : configs) {
+                        if (hostConfig != null) {
+                            hostConfig.setCipherSuites(ciphers);
+                        }
+                    }
+                }
             }
 
             server.getService().addConnector(ssl);

--- a/audit-server/audit-ingestor/src/main/java/org/apache/ranger/audit/server/EmbeddedServer.java
+++ b/audit-server/audit-ingestor/src/main/java/org/apache/ranger/audit/server/EmbeddedServer.java
@@ -40,6 +40,7 @@ import org.apache.hadoop.security.alias.LocalBouncyCastleFipsKeyStoreProvider;
 import org.apache.ranger.audit.provider.MiscUtil;
 import org.apache.ranger.audit.utils.AuditServerLogFormatter;
 import org.apache.ranger.authorization.hadoop.utils.RangerCredentialProvider;
+import org.apache.tomcat.util.net.SSLHostConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -82,7 +83,8 @@ public class EmbeddedServer {
     public  static final String DEFAULT_NAME_RULE                   = "DEFAULT";
     private static final String RANGER_KEYSTORE_FILE_TYPE_DEFAULT   = "jks";
     private static final String RANGER_TRUSTSTORE_FILE_TYPE_DEFAULT = "jks";
-    private static final String RANGER_SSL_CONTEXT_ALGO_TYPE        = "TLSv1.2";
+    private static final String RANGER_SSL_CONTEXT_ALGO_TYPE        = "TLS";
+    private static final String DEFAULT_SSL_PROTOCOL                = "TLS";
     private static final String RANGER_SSL_KEYMANAGER_ALGO_TYPE     = KeyManagerFactory.getDefaultAlgorithm();
     private static final String RANGER_SSL_TRUSTMANAGER_ALGO_TYPE   = TrustManagerFactory.getDefaultAlgorithm();
     public static final  String KEYSTORE_FILE_TYPE_DEFAULT          = KeyStore.getDefaultType();
@@ -180,7 +182,7 @@ public class EmbeddedServer {
             ssl.setSecure(true);
             ssl.setScheme("https");
             ssl.setAttribute("SSLEnabled", "true");
-            ssl.setAttribute("sslProtocol", getConfig("https.attrib.ssl.protocol", "TLSv1.2"));
+            ssl.setAttribute("sslProtocol", getConfig("https.attrib.ssl.protocol", DEFAULT_SSL_PROTOCOL));
             ssl.setAttribute("clientAuth", clientAuth);
             if (StringUtils.isNotBlank(sslKeystoreKeyAlias)) {
                 ssl.setAttribute("keyAlias", sslKeystoreKeyAlias);
@@ -193,6 +195,14 @@ public class EmbeddedServer {
 
             if (StringUtils.isNotBlank(ciphers)) {
                 ssl.setAttribute("ciphers", ciphers);
+                SSLHostConfig[] configs = ssl.findSslHostConfigs();
+                if (configs != null) {
+                    for (SSLHostConfig hostConfig : configs) {
+                        if (hostConfig != null) {
+                            hostConfig.setCipherSuites(ciphers);
+                        }
+                    }
+                }
             }
 
             server.getService().addConnector(ssl);

--- a/embeddedwebserver/src/main/java/org/apache/ranger/server/tomcat/EmbeddedServer.java
+++ b/embeddedwebserver/src/main/java/org/apache/ranger/server/tomcat/EmbeddedServer.java
@@ -28,6 +28,7 @@ import org.apache.catalina.valves.ErrorReportValve;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.security.SecureClientLogin;
 import org.apache.ranger.credentialapi.CredentialReader;
+import org.apache.tomcat.util.net.SSLHostConfig;
 
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
@@ -58,10 +59,12 @@ public class EmbeddedServer {
 
     public  static final String RANGER_KEYSTORE_FILE_TYPE_DEFAULT   = KeyStore.getDefaultType();
     public  static final String RANGER_TRUSTSTORE_FILE_TYPE_DEFAULT = KeyStore.getDefaultType();
-    public  static final String RANGER_SSL_CONTEXT_ALGO_TYPE        = "TLSv1.2";
+    public  static final String RANGER_SSL_CONTEXT_ALGO_TYPE        = "TLS";
     public  static final String RANGER_SSL_KEYMANAGER_ALGO_TYPE     = KeyManagerFactory.getDefaultAlgorithm();
     public  static final String RANGER_SSL_TRUSTMANAGER_ALGO_TYPE   = TrustManagerFactory.getDefaultAlgorithm();
     private static final String DEFAULT_NAME_RULE                   = "DEFAULT";
+    private static final String DEFAULT_ENABLED_PROTOCOLS           = "TLSv1.2";
+    private static final String DEFAULT_SSL_PROTOCOL                = "TLS";
     private static final String DEFAULT_WEBAPPS_ROOT_FOLDER         = "webapps";
     private static final String AUTH_TYPE_KERBEROS                  = "kerberos";
     private static final String AUTHENTICATION_TYPE                 = "hadoop.security.authentication";
@@ -158,7 +161,7 @@ public class EmbeddedServer {
             ssl.setSecure(true);
             ssl.setScheme("https");
             ssl.setAttribute("SSLEnabled", "true");
-            ssl.setAttribute("sslProtocol", EmbeddedServerUtil.getConfig("ranger.service.https.attrib.ssl.protocol", "TLSv1.2"));
+            ssl.setAttribute("sslProtocol", EmbeddedServerUtil.getConfig("ranger.service.https.attrib.ssl.protocol", DEFAULT_SSL_PROTOCOL));
             ssl.setAttribute("keystoreType", EmbeddedServerUtil.getConfig("ranger.keystore.file.type", RANGER_KEYSTORE_FILE_TYPE_DEFAULT));
             ssl.setAttribute("truststoreType", EmbeddedServerUtil.getConfig("ranger.truststore.file.type", RANGER_TRUSTSTORE_FILE_TYPE_DEFAULT));
 
@@ -186,8 +189,7 @@ public class EmbeddedServer {
             ssl.setAttribute("keystorePass", keystorePass);
             ssl.setAttribute("keystoreFile", getKeystoreFile());
 
-            String defaultEnabledProtocols = "TLSv1.2";
-            String enabledProtocols        = EmbeddedServerUtil.getConfig("ranger.service.https.attrib.ssl.enabled.protocols", defaultEnabledProtocols);
+            String enabledProtocols        = EmbeddedServerUtil.getConfig("ranger.service.https.attrib.ssl.enabled.protocols", DEFAULT_ENABLED_PROTOCOLS);
 
             ssl.setAttribute("sslEnabledProtocols", enabledProtocols);
 
@@ -195,6 +197,14 @@ public class EmbeddedServer {
 
             if (StringUtils.isNotBlank(ciphers)) {
                 ssl.setAttribute("ciphers", ciphers);
+                SSLHostConfig[] configs = ssl.findSslHostConfigs();
+                if (configs != null) {
+                    for (SSLHostConfig hostConfig : configs) {
+                        if (hostConfig != null) {
+                            hostConfig.setCipherSuites(ciphers);
+                        }
+                    }
+                }
             }
 
             server.getService().addConnector(ssl);

--- a/plugin-nifi-registry/src/main/java/org/apache/ranger/services/nifi/registry/client/NiFiRegistryConnectionMgr.java
+++ b/plugin-nifi-registry/src/main/java/org/apache/ranger/services/nifi/registry/client/NiFiRegistryConnectionMgr.java
@@ -47,7 +47,7 @@ import java.util.Map;
  */
 public class NiFiRegistryConnectionMgr {
     private static final Logger LOG           = LoggerFactory.getLogger(NiFiRegistryConnectionMgr.class);
-    private static final String SSL_ALGORITHM = "TLSv1.2";
+    private static final String SSL_ALGORITHM = "TLS";
 
     private static final String API_RESOURCES_PATH = "/nifi-registry-api/policies/resources";
     static final         String INVALID_URL_MSG    = "NiFi Registry URL must be a valid URL of the form http(s)://<hostname>(:<port>)" + API_RESOURCES_PATH;

--- a/plugin-schema-registry/src/main/java/org/apache/ranger/services/schema/registry/client/connection/DefaultSchemaRegistryClient.java
+++ b/plugin-schema-registry/src/main/java/org/apache/ranger/services/schema/registry/client/connection/DefaultSchemaRegistryClient.java
@@ -55,7 +55,7 @@ public class DefaultSchemaRegistryClient implements ISchemaRegistryClient {
     private static final String SCHEMA_REGISTRY_PATH         = "/api/v1/schemaregistry";
     private static final String SCHEMAS_PATH                 = SCHEMA_REGISTRY_PATH + "/schemas/";
     private static final String SCHEMA_REGISTRY_VERSION_PATH = SCHEMA_REGISTRY_PATH + "/version";
-    private static final String SSL_ALGORITHM                = "TLSv1.2";
+    private static final String SSL_ALGORITHM                = "TLS";
 
     private final Client                             client;
     private final Login                              login;

--- a/security-admin/src/main/resources/conf.dist/ranger-admin-default-site.xml
+++ b/security-admin/src/main/resources/conf.dist/ranger-admin-default-site.xml
@@ -322,7 +322,7 @@
 
 	<property>
 		<name>ranger.service.https.attrib.ssl.protocol</name>
-		<value>TLSv1.2</value>
+		<value>TLS</value>
 	</property>
 
 	<property>

--- a/ugsync/src/main/java/org/apache/ranger/ldapusersync/process/CustomSSLSocketFactory.java
+++ b/ugsync/src/main/java/org/apache/ranger/ldapusersync/process/CustomSSLSocketFactory.java
@@ -98,7 +98,7 @@ public class CustomSSLSocketFactory extends SSLSocketFactory {
                 }
             }
 
-            sslContext = SSLContext.getInstance("TLSv1.2");
+            sslContext = SSLContext.getInstance("TLS");
 
             sslContext.init(kmList, tmList, new SecureRandom());
 

--- a/unixauthclient/src/main/java/org/apache/ranger/authentication/unix/jaas/RemoteUnixLoginModule.java
+++ b/unixauthclient/src/main/java/org/apache/ranger/authentication/unix/jaas/RemoteUnixLoginModule.java
@@ -62,7 +62,7 @@ public class RemoteUnixLoginModule implements LoginModule {
     private static final String SSL_ENABLED_PARAM                    = "ranger.unixauth.ssl.enabled";
     private static final String SERVER_CERT_VALIDATION_PARAM         = "ranger.unixauth.server.cert.validation";
     private static final String JAAS_ENABLED_PARAM                   = "ranger.unixauth.remote.login.enabled";
-    private static final String SSL_ALGORITHM                        = "TLSv1.2";
+    private static final String SSL_ALGORITHM                        = "TLS";
 
     private String userName;
     private String remoteHostName;

--- a/unixauthservice/src/main/java/org/apache/ranger/authentication/UnixAuthenticationService.java
+++ b/unixauthservice/src/main/java/org/apache/ranger/authentication/UnixAuthenticationService.java
@@ -56,7 +56,7 @@ public class UnixAuthenticationService {
     private static final Logger LOG = LoggerFactory.getLogger(UnixAuthenticationService.class);
 
     private static final String serviceName                          = "UnixAuthenticationService";
-    private static final String SSL_ALGORITHM                        = "TLSv1.2";
+    private static final String SSL_ALGORITHM                        = "TLS";
     private static final String REMOTE_LOGIN_AUTH_SERVICE_PORT_PARAM = "ranger.usersync.port";
     private static final String SSL_KEYSTORE_PATH_PARAM              = "ranger.usersync.keystore.file";
     private static final String SSL_TRUSTSTORE_PATH_PARAM            = "ranger.usersync.truststore.file";

--- a/unixauthservice/src/test/java/org/apache/ranger/authentication/TestUnixAuthenticationService.java
+++ b/unixauthservice/src/test/java/org/apache/ranger/authentication/TestUnixAuthenticationService.java
@@ -162,7 +162,7 @@ public class TestUnixAuthenticationService {
             SSLServerSocketFactory sf           = mock(SSLServerSocketFactory.class);
             SSLServerSocket        secureSocket = mock(SSLServerSocket.class);
 
-            when(SSLContext.getInstance("TLSv1.2")).thenReturn(sslContext);
+            when(SSLContext.getInstance("TLS")).thenReturn(sslContext);
             when(sslContext.getServerSocketFactory()).thenReturn(sf);
             when(sf.createServerSocket(anyInt())).thenReturn(secureSocket);
             when(secureSocket.getEnabledProtocols()).thenReturn(new String[] {"TLSv1.2"});
@@ -239,7 +239,7 @@ public class TestUnixAuthenticationService {
             SSLServerSocketFactory sf           = mock(SSLServerSocketFactory.class);
             SSLServerSocket        secureSocket = mock(SSLServerSocket.class);
 
-            when(SSLContext.getInstance("TLSv1.2")).thenReturn(sslContext);
+            when(SSLContext.getInstance("TLS")).thenReturn(sslContext);
             when(sslContext.getServerSocketFactory()).thenReturn(sf);
             when(sf.createServerSocket(anyInt())).thenReturn(secureSocket);
             when(secureSocket.getEnabledProtocols()).thenReturn(new String[] {"TLSv1.2"});
@@ -287,7 +287,7 @@ public class TestUnixAuthenticationService {
             SSLServerSocketFactory sf           = mock(SSLServerSocketFactory.class);
             SSLServerSocket        secureSocket = mock(SSLServerSocket.class);
 
-            when(SSLContext.getInstance("TLSv1.2")).thenReturn(sslContext);
+            when(SSLContext.getInstance("TLS")).thenReturn(sslContext);
             when(sslContext.getServerSocketFactory()).thenReturn(sf);
             when(sf.createServerSocket(anyInt())).thenReturn(secureSocket);
             when(secureSocket.getEnabledProtocols()).thenReturn(new String[] {"TLSv1.2"});
@@ -324,7 +324,7 @@ public class TestUnixAuthenticationService {
             SSLServerSocket        secureSocket = mock(SSLServerSocket.class);
             Socket                 client       = mock(Socket.class);
 
-            when(SSLContext.getInstance("TLSv1.2")).thenReturn(sslContext);
+            when(SSLContext.getInstance("TLS")).thenReturn(sslContext);
             when(sslContext.getServerSocketFactory()).thenReturn(sf);
             when(sf.createServerSocket(anyInt())).thenReturn(secureSocket);
             when(secureSocket.getEnabledProtocols()).thenReturn(new String[] {"TLSV1.2"});


### PR DESCRIPTION

## What changes were proposed in this pull request?
RANGER-5611 : Support TLSv1.3 Encryption for all Communications for Ranger services.
As we have now upgraded to jdk 17, Enabling the support for TLSv1.3 for security by keeing the TLS v1.2 as default. 
Protocols are still configurable using properties in site.xml for embedded tomcat server
Also making sure the provided ciphers are being set appropriately in embedded tomcat server using SSLHostConfig


## How was this patch tested?
=> Successful build using unit tests
=> Manual testing

