### PR TITLE
RANGER-5499: Set ranger-admin header authn cfg values to null

### DIFF
--- a/security-admin/src/main/java/org/apache/ranger/security/web/filter/RangerHeaderPreAuthFilter.java
+++ b/security-admin/src/main/java/org/apache/ranger/security/web/filter/RangerHeaderPreAuthFilter.java
@@ -61,8 +61,17 @@ public class RangerHeaderPreAuthFilter extends GenericFilterBean {
 
     @PostConstruct
     protected void initialize() {
-        headerAuthEnabled  = PropertiesUtil.getBooleanProperty(PROP_HEADER_AUTH_ENABLED, false);
-        userNameHeaderName = PropertiesUtil.getProperty(PROP_USERNAME_HEADER_NAME);
+        headerAuthEnabled = PropertiesUtil.getBooleanProperty(PROP_HEADER_AUTH_ENABLED, false);
+    
+        if (headerAuthEnabled) {
+            userNameHeaderName = PropertiesUtil.getProperty(PROP_USERNAME_HEADER_NAME);
+    
+            if (StringUtils.isBlank(userNameHeaderName)) {
+                LOG.warn("Disabling header-based authentication, as configuration {} is not set", PROP_USERNAME_HEADER_NAME);
+    
+                headerAuthEnabled = false;
+            }
+        }
     }
 
     @Override

--- a/security-admin/src/main/resources/conf.dist/ranger-admin-site.xml
+++ b/security-admin/src/main/resources/conf.dist/ranger-admin-site.xml
@@ -278,11 +278,11 @@
 	</property>
 	<property>
 		<name>ranger.admin.authn.header.username</name>
-		<value>x-awc-username</value>
+		<value></value>
 	</property>
 	<property>
 		<name>ranger.admin.authn.header.requestid</name>
-		<value>x-awc-requestid</value>
+		<value></value>
 	</property>
 	<!-- Trusted header auth properties end -->
 	<!-- Kerberos Properties starts-->	


### PR DESCRIPTION
## What changes were proposed in this pull request?

The header based authentication configs must be set explicitly when Ranger is deployed in an environment with trusted proxy.

## How was this patch tested?

CI
