### PR TITLE
RANGER-5607 issue in  put plugins/services/id

### DIFF
--- a/security-admin/src/main/java/org/apache/ranger/rest/ServiceREST.java
+++ b/security-admin/src/main/java/org/apache/ranger/rest/ServiceREST.java
@@ -734,6 +734,26 @@ public class ServiceREST {
     @PreAuthorize("@rangerPreAuthSecurityHandler.isAPIAccessible(\"" + RangerAPIList.UPDATE_SERVICE + "\")")
     public RangerService updateService(RangerService service, @Context HttpServletRequest request) {
         LOG.debug("==> ServiceREST.updateService(): {}", service);
+        // if service.id and param 'id' are specified, service.id should be same as the param 'id'
+        // if service.id is null, then set param 'id' into service Object
+        if (request != null) {
+            String requestURI = request.getRequestURI();
+            if (requestURI != null) {
+                String[] parts = requestURI.split("/");
+                try {
+                    Long id = Long.parseLong(parts[parts.length - 1]);
+                    if (service.getId() == null) {
+                        service.setId(id);
+                    } else if (StringUtils.isBlank(service.getName()) || !service.getId().equals(id)) {
+                        throw restErrorUtil.createRESTException(HttpServletResponse.SC_BAD_REQUEST, "serviceDef Id mismatch or service name not provided", true);
+                    }
+                } catch (NumberFormatException e) {
+                    LOG.warn("Could not parse service id from request URI: {}", requestURI);
+                }
+            }
+        } else {
+            LOG.debug("HttpServletRequest is null, skipping URI-based ID validation");
+        }
 
         RangerService    ret;
         RangerPerfTracer perf = null;

--- a/security-admin/src/test/java/org/apache/ranger/rest/TestServiceREST.java
+++ b/security-admin/src/test/java/org/apache/ranger/rest/TestServiceREST.java
@@ -4544,6 +4544,8 @@ public class TestServiceREST {
                 "serviceDef Id mismatch",
                 true);
     }
+
+    @Test
     public void testUpdateService_IdMismatchBetweenPayloadAndURL() throws Exception {
         // service has id=8 in payload, but URL has id=99 — should trigger BAD_REQUEST
         RangerService service = rangerService();

--- a/security-admin/src/test/java/org/apache/ranger/rest/TestServiceREST.java
+++ b/security-admin/src/test/java/org/apache/ranger/rest/TestServiceREST.java
@@ -4544,4 +4544,53 @@ public class TestServiceREST {
                 "serviceDef Id mismatch",
                 true);
     }
+    public void testUpdateService_IdMismatchBetweenPayloadAndURL() throws Exception {
+        // service has id=8 in payload, but URL has id=99 — should trigger BAD_REQUEST
+        RangerService service = rangerService();
+        service.setId(8L);
+        service.setName("test-service");
+
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        Mockito.when(request.getRequestURI()).thenReturn("/ranger/plugins/services/99");
+
+        WebApplicationException expectedException = new WebApplicationException(HttpServletResponse.SC_BAD_REQUEST);
+        Mockito.when(restErrorUtil.createRESTException(
+                HttpServletResponse.SC_BAD_REQUEST,
+                "serviceDef Id mismatch or service name not provided",
+                true)).thenReturn(expectedException);
+
+        Assertions.assertThrows(WebApplicationException.class, () ->
+                serviceREST.updateService(service, request));
+
+        Mockito.verify(restErrorUtil).createRESTException(
+                HttpServletResponse.SC_BAD_REQUEST,
+                "serviceDef Id mismatch or service name not provided",
+                true);
+    }
+
+    @Test
+    public void testUpdateService_BlankNameWithIdInPayload() throws Exception {
+        // service has id set but name is blank — should trigger BAD_REQUEST
+        RangerService service = rangerService();
+        service.setId(8L);
+        service.setName(""); // blank name
+
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        Mockito.when(request.getRequestURI()).thenReturn("/ranger/plugins/services/8");
+
+        WebApplicationException expectedException = new WebApplicationException(HttpServletResponse.SC_BAD_REQUEST);
+        Mockito.when(restErrorUtil.createRESTException(
+                        HttpServletResponse.SC_BAD_REQUEST,
+                        "serviceDef Id mismatch or service name not provided",
+                        true))
+                .thenReturn(expectedException);
+
+        Assertions.assertThrows(WebApplicationException.class, () ->
+                serviceREST.updateService(service, request));
+
+        Mockito.verify(restErrorUtil).createRESTException(
+                HttpServletResponse.SC_BAD_REQUEST,
+                "serviceDef Id mismatch or service name not provided",
+                true);
+    }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

the api put plugins/services/{id}  implemented in ServiceREST updateService. do not appropriately throws error when the service name field is left  blank in the  payload  or mismatch between ids passed through  payload and request url  . 
I compared this with the put apis present in ServiceREST and other modules there appropriate id mismatch or name absent errors are handled .
I have made changes in the implementation to properly handle those scenarios . 


## How was this patch tested?
All the unit tests were passed locally and the  bulild (mvn clean install  , mvn clean test ) successfully passed 

2 unit tests have been implemented to simulate id mismatch and servicename absent in payload scenarios 
