### PR TITLE
RANGER-5617: Set PDP header authn config values to null

### DIFF
--- a/dev-support/ranger-docker/scripts/pdp/ranger-pdp-site.xml
+++ b/dev-support/ranger-docker/scripts/pdp/ranger-pdp-site.xml
@@ -109,6 +109,7 @@
     <value>true</value>
   </property>
 
+  <!-- docker deployment uses this by default, generally must be explicitly set -->
   <property>
     <name>ranger.pdp.authn.header.username</name>
     <value>X-Forwarded-User</value>

--- a/intg/src/main/python/README.md
+++ b/intg/src/main/python/README.md
@@ -141,8 +141,8 @@ Authentication options:
   - install dependency: `pip install requests-kerberos`
   - use `HTTPKerberosAuth()` as `auth` in `RangerPDPClient`
 - **Trusted header**
-  - pass caller header (default `X-Forwarded-User`, configurable by `ranger.pdp.authn.header.username`)
-  - recommended only behind a trusted proxy
+  - pass caller header (must be configured using `ranger.pdp.authn.header.username`)
+  - only behind a trusted proxy
 - **JWT bearer**
   - pass `Authorization: Bearer <token>` in request headers
 

--- a/pdp/conf.dist/ranger-pdp-site.xml
+++ b/pdp/conf.dist/ranger-pdp-site.xml
@@ -138,9 +138,10 @@
     </description>
   </property>
 
+  <!-- must be explicitly set -->
   <property>
     <name>ranger.pdp.authn.header.username</name>
-    <value>X-Forwarded-User</value>
+    <value></value>
     <description>HTTP header name from which the authenticated username is read.</description>
   </property>
 

--- a/pdp/src/main/java/org/apache/ranger/pdp/config/RangerPdpConfig.java
+++ b/pdp/src/main/java/org/apache/ranger/pdp/config/RangerPdpConfig.java
@@ -140,7 +140,7 @@ public class RangerPdpConfig {
     }
 
     public String getHeaderAuthnUsername() {
-        return get(RangerPdpConstants.PROP_AUTHN_HEADER_USERNAME, "X-Forwarded-User");
+        return get(RangerPdpConstants.PROP_AUTHN_HEADER_USERNAME, "");
     }
 
     // --- JWT bearer token auth ---

--- a/pdp/src/main/java/org/apache/ranger/pdp/security/HttpHeaderAuthNHandler.java
+++ b/pdp/src/main/java/org/apache/ranger/pdp/security/HttpHeaderAuthNHandler.java
@@ -50,7 +50,7 @@ public class HttpHeaderAuthNHandler implements PdpAuthNHandler {
 
     @Override
     public void init(Properties config) {
-        usernameHeader = config.getProperty(RangerPdpConstants.PROP_AUTHN_HEADER_USERNAME, "X-Forwarded-User");
+        usernameHeader = config.getProperty(RangerPdpConstants.PROP_AUTHN_HEADER_USERNAME);
 
         LOG.info("HttpHeaderAuthHandler initialized; username header={}", usernameHeader);
     }

--- a/pdp/src/main/java/org/apache/ranger/pdp/security/RangerPdpAuthNFilter.java
+++ b/pdp/src/main/java/org/apache/ranger/pdp/security/RangerPdpAuthNFilter.java
@@ -150,7 +150,9 @@ public class RangerPdpAuthNFilter implements Filter {
 
         switch (type) {
             case "header":
-                ret = getBoolean(filterConfig, RangerPdpConstants.PROP_AUTHN_HEADER_ENABLED) ? new HttpHeaderAuthNHandler() : null;
+                ret = getBoolean(filterConfig, RangerPdpConstants.PROP_AUTHN_HEADER_ENABLED) &&
+                        StringUtils.isNotBlank(filterConfig.getInitParameter(RangerPdpConstants.PROP_AUTHN_HEADER_USERNAME))
+                        ? new HttpHeaderAuthNHandler() : null;
                 break;
             case "jwt":
                 ret = getBoolean(filterConfig, RangerPdpConstants.PROP_AUTHN_JWT_ENABLED) ? new JwtAuthNHandler() : null;

--- a/pdp/src/main/resources/ranger-pdp-default.xml
+++ b/pdp/src/main/resources/ranger-pdp-default.xml
@@ -138,9 +138,10 @@
     </description>
   </property>
 
+  <!-- must be explicitly set -->
   <property>
     <name>ranger.pdp.authn.header.username</name>
-    <value>X-Forwarded-User</value>
+    <value></value>
     <description>HTTP header name from which the authenticated username is read.</description>
   </property>
 

--- a/pdp/src/test/java/org/apache/ranger/pdp/security/HttpHeaderAuthNHandlerTest.java
+++ b/pdp/src/test/java/org/apache/ranger/pdp/security/HttpHeaderAuthNHandlerTest.java
@@ -29,10 +29,11 @@ import java.lang.reflect.Proxy;
 import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class HttpHeaderAuthNHandlerTest {
     @Test
-    public void testAuthenticate_usesDefaultHeaderName() {
+    public void testAuthenticate_usesNoHeaderName() {
         HttpHeaderAuthNHandler handler = new HttpHeaderAuthNHandler();
         Properties             config  = new Properties();
 
@@ -41,9 +42,9 @@ public class HttpHeaderAuthNHandlerTest {
         HttpServletRequest     request = requestWithHeader("X-Forwarded-User", "alice");
         PdpAuthNHandler.Result result  = handler.authenticate(request, null);
 
-        assertEquals(PdpAuthNHandler.Result.Status.AUTHENTICATED, result.getStatus());
-        assertEquals("alice", result.getUserName());
-        assertEquals(HttpHeaderAuthNHandler.AUTH_TYPE, result.getAuthType());
+        assertEquals(PdpAuthNHandler.Result.Status.SKIP, result.getStatus());
+        assertNull(result.getUserName());
+        assertNull(result.getAuthType());
     }
 
     @Test

--- a/pdp/src/test/java/org/apache/ranger/pdp/security/RangerPdpAuthNFilterTest.java
+++ b/pdp/src/test/java/org/apache/ranger/pdp/security/RangerPdpAuthNFilterTest.java
@@ -55,6 +55,7 @@ public class RangerPdpAuthNFilterTest {
 
         params.put(RangerPdpConstants.PROP_AUTHN_TYPES, "header");
         params.put(RangerPdpConstants.PROP_AUTHN_HEADER_ENABLED, "true");
+        params.put(RangerPdpConstants.PROP_AUTHN_HEADER_USERNAME, "Some-X-Header");
 
         filter.init(new TestFilterConfig(params));
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The header based authentication configs must be set explicitly when Ranger PDP is deployed in an environment with trusted proxy.

## How was this patch tested?

Pending CI
