### PR TITLE
RANGER-5620: Fix NPE in PolicyMgrUserGroupBuilder when LDAP returns empty result set on startup

### DIFF
--- a/ugsync/src/main/java/org/apache/ranger/unixusersync/process/PolicyMgrUserGroupBuilder.java
+++ b/ugsync/src/main/java/org/apache/ranger/unixusersync/process/PolicyMgrUserGroupBuilder.java
@@ -1958,4 +1958,3 @@ public class PolicyMgrUserGroupBuilder extends AbstractUserGroupSource implement
         }
     }
 }
-

--- a/ugsync/src/main/java/org/apache/ranger/unixusersync/process/PolicyMgrUserGroupBuilder.java
+++ b/ugsync/src/main/java/org/apache/ranger/unixusersync/process/PolicyMgrUserGroupBuilder.java
@@ -291,6 +291,7 @@ public class PolicyMgrUserGroupBuilder extends AbstractUserGroupSource implement
         noOfModifiedUsers    = 0;
         noOfModifiedGroups   = 0;
         computeRolesForUsers = new HashSet<>();
+        deltaGroupUsers      = new HashMap<>();
 
         if (!isStartupFlag && computeDeletes) {
             LOG.info("Computing deleted users/groups");
@@ -1957,3 +1958,4 @@ public class PolicyMgrUserGroupBuilder extends AbstractUserGroupSource implement
         }
     }
 }
+

--- a/ugsync/src/test/java/org/apache/ranger/unixusersync/process/TestPolicyMgrUserGroupBuilder.java
+++ b/ugsync/src/test/java/org/apache/ranger/unixusersync/process/TestPolicyMgrUserGroupBuilder.java
@@ -1131,4 +1131,3 @@ public class TestPolicyMgrUserGroupBuilder {
         }
     }
 }
-

--- a/ugsync/src/test/java/org/apache/ranger/unixusersync/process/TestPolicyMgrUserGroupBuilder.java
+++ b/ugsync/src/test/java/org/apache/ranger/unixusersync/process/TestPolicyMgrUserGroupBuilder.java
@@ -1051,6 +1051,44 @@ public class TestPolicyMgrUserGroupBuilder {
         }
     }
 
+    @Test
+    public void testAK_addOrUpdateUsersGroups_startup_emptyLdap_doesNotThrowNPE() throws Exception {
+        // Reproduces RANGER-XXXX: when LDAP returns 0 groups/users (e.g. connectivity failure),
+        // deltaGroupUsers is never initialised by addOrUpdateGroupUsers().
+        // On startup (isStartupFlag=true) the whiteListGroupMap loop falls through to
+        // deltaGroupUsers.get(groupName) which caused a NullPointerException and dropped
+        // all group associations for existing users.
+        PolicyMgrUserGroupBuilder builder = new PolicyMgrUserGroupBuilder();
+        setPrivate(builder, "ldapUgSyncClient", new FakeRest());
+
+        Map<String, String> wlGroupMap = new HashMap<>();
+        wlGroupMap.put("g1", "ROLE_KEY_ADMIN");
+        setPrivate(builder, "whiteListGroupMap", wlGroupMap);
+
+        // groupUsersCache is intentionally empty so the else-if branch (deltaGroupUsers) is reached
+        setPrivate(builder, "groupUsersCache", new HashMap<String, Set<String>>());
+        setPrivate(builder, "whiteListUserMap", new HashMap<String, String>());
+        setPrivate(builder, "userMap", new HashMap<String, String>());
+        setPrivate(builder, "groupMap", new HashMap<String, String>());
+        setPrivate(builder, "isStartupFlag", true);
+
+        // All source maps empty — simulates LDAP returning 0 groups and 0 users
+        assertDoesNotThrow(() -> {
+            try {
+                builder.addOrUpdateUsersGroups(
+                        Collections.emptyMap(),
+                        Collections.emptyMap(),
+                        Collections.emptyMap(),
+                        false);
+            } catch (NullPointerException e) {
+                throw e; // re-throw NPE so assertDoesNotThrow catches it as failure
+            } catch (Throwable ignored) {
+                // Other exceptions (e.g. REST returning null) are acceptable;
+                // only the NPE from deltaGroupUsers == null is the bug we are guarding against.
+            }
+        });
+    }
+
     // Helpers
     @SuppressWarnings("unchecked")
     private static <T> T getPrivate(Object target, String field, Class<T> type) throws Exception {
@@ -1093,3 +1131,4 @@ public class TestPolicyMgrUserGroupBuilder {
         }
     }
 }
+

--- a/ugsync/src/test/java/org/apache/ranger/unixusersync/process/TestPolicyMgrUserGroupBuilder.java
+++ b/ugsync/src/test/java/org/apache/ranger/unixusersync/process/TestPolicyMgrUserGroupBuilder.java
@@ -1053,7 +1053,7 @@ public class TestPolicyMgrUserGroupBuilder {
 
     @Test
     public void testAK_addOrUpdateUsersGroups_startup_emptyLdap_doesNotThrowNPE() throws Exception {
-        // Reproduces RANGER-XXXX: when LDAP returns 0 groups/users (e.g. connectivity failure),
+        // Reproduces RANGER-5620: when LDAP returns 0 groups/users (e.g. connectivity failure),
         // deltaGroupUsers is never initialised by addOrUpdateGroupUsers().
         // On startup (isStartupFlag=true) the whiteListGroupMap loop falls through to
         // deltaGroupUsers.get(groupName) which caused a NullPointerException and dropped


### PR DESCRIPTION
## Problem

When the LDAP/AD source returns **0 groups and 0 users** (e.g. due to a connectivity failure, firewall block, or misconfigured DC endpoint), `addOrUpdateGroupUsers()` is never called because it is guarded by `MapUtils.isNotEmpty(sourceGroupUsers)`. This means `deltaGroupUsers` is never initialised and stays `null`.

On the **first sync cycle after startup** (`isStartupFlag = true`), the `whiteListGroupMap` and `groupMap` iteration loops fall through to the `else-if` branch:

```java
} else if (CollectionUtils.isNotEmpty(deltaGroupUsers.get(groupName))) {
```

Because `deltaGroupUsers` is `null`, this line throws:

```
java.lang.NullPointerException: Cannot invoke "java.util.Map.get(Object)"
    because "this.deltaGroupUsers" is null
  at PolicyMgrUserGroupBuilder.addOrUpdateUsersGroups(PolicyMgrUserGroupBuilder.java:372)
```

The NPE propagates as a misleading `"Failed to addOrUpdate users to ranger admin"` error and causes Ranger to **drop all existing group associations** for users on restart rather than preserving the last-known-good state.

Note: `MapUtils.isNotEmpty(deltaGroupUsers)` at the cache-update step (line ~391) is already null-safe, so only the two `else-if` call sites are affected.

## Fix

Initialise `deltaGroupUsers` to an empty `HashMap` at the top of `addOrUpdateUsersGroups()`, alongside the existing initialisations of `computeRolesForUsers` and the `noOf*` counters. An empty map is the correct "nothing synced yet" state — `deltaGroupUsers.get(groupName)` will return `null`, `CollectionUtils.isNotEmpty(null)` returns `false`, and the branch is safely skipped.

```java
computeRolesForUsers = new HashSet<>();
deltaGroupUsers      = new HashMap<>();   // ← added
```

## Test

Added `testAK_addOrUpdateUsersGroups_startup_emptyLdap_doesNotThrowNPE` to `TestPolicyMgrUserGroupBuilder`:

- Sets `isStartupFlag = true`
- Populates `whiteListGroupMap` with one group (`g1`) **not present** in `groupUsersCache` (forces the `else-if` / `deltaGroupUsers` branch)
- Calls `addOrUpdateUsersGroups` with all-empty source maps (simulates LDAP returning 0 results)
- Asserts **no `NullPointerException`** is thrown

## Impact

Observed in production with Apache Ranger UserSync 2.7.0 (Kubernetes deployment, LDAP/AD source). The connectivity issue was resolved via a workaround, but the NPE recurs on every restart until this code path is hardened.