### PR TITLE
RANGER-5610:getResourceACLs for a principal should consider validitySchedule of principal for ACL creation

### DIFF
--- a/hive-agent/src/main/java/org/apache/ranger/authorization/hive/authorizer/RangerHiveAuthorizer.java
+++ b/hive-agent/src/main/java/org/apache/ranger/authorization/hive/authorizer/RangerHiveAuthorizer.java
@@ -58,6 +58,7 @@ import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.thirdparty.com.google.common.collect.Sets;
 import org.apache.ranger.authorization.hadoop.constants.RangerHadoopConstants;
 import org.apache.ranger.authorization.utils.StringUtil;
+import org.apache.ranger.plugin.conditionevaluator.RangerValidityScheduleConditionEvaluator;
 import org.apache.ranger.plugin.model.RangerPolicy;
 import org.apache.ranger.plugin.model.RangerPolicy.RangerPolicyItemAccess;
 import org.apache.ranger.plugin.model.RangerRole;
@@ -2843,9 +2844,129 @@ public class RangerHiveAuthorizer extends RangerHiveAuthorizerBase {
 
         ret = hivePlugin.getResourceACLs(request);
 
+        if (ret != null && principal != null && request != null) {
+            filterAclsByValiditySchedule(ret, principal, request);
+        }
+
         LOG.debug("<== RangerHivePolicyProvider.getRangerResourceACLs:[{}], principal=[{}], Computed ACLS:[{}]", hiveObject, principal, ret);
 
         return ret;
+    }
+
+    private void filterAclsByValiditySchedule(RangerResourceACLs acls, HivePrincipal principal, RangerAccessRequest request) {
+        if (acls == null || principal == null || request == null) {
+            return;
+        }
+
+        Map<String, Map<String, RangerResourceACLs.AccessResult>> principalACLs = null;
+        switch (principal.getType()) {
+            case USER:
+                principalACLs = acls.getUserACLs();
+                break;
+            case GROUP:
+                principalACLs = acls.getGroupACLs();
+                break;
+            case ROLE:
+                principalACLs = acls.getRoleACLs();
+                break;
+            default:
+                break;
+        }
+
+        if (principalACLs != null) {
+            Map<String, RangerResourceACLs.AccessResult> accessMap = principalACLs.get(principal.getName());
+            if (accessMap != null) {
+                List<String> keysToRemove = new ArrayList<>();
+                for (Map.Entry<String, RangerResourceACLs.AccessResult> entry : accessMap.entrySet()) {
+                    RangerResourceACLs.AccessResult accessResult = entry.getValue();
+                    if (accessResult != null && accessResult.getResult() == RangerPolicyEvaluator.ACCESS_CONDITIONAL) {
+                        RangerPolicy policy = accessResult.getPolicy();
+                        if (policy != null) {
+                            boolean hasActiveItem = false;
+
+                            List<RangerPolicy.RangerPolicyItem> policyItems = new ArrayList<>();
+                            if (CollectionUtils.isNotEmpty(policy.getPolicyItems())) {
+                                policyItems.addAll(policy.getPolicyItems());
+                            }
+                            if (CollectionUtils.isNotEmpty(policy.getDenyPolicyItems())) {
+                                policyItems.addAll(policy.getDenyPolicyItems());
+                            }
+                            if (CollectionUtils.isNotEmpty(policy.getAllowExceptions())) {
+                                policyItems.addAll(policy.getAllowExceptions());
+                            }
+                            if (CollectionUtils.isNotEmpty(policy.getDenyExceptions())) {
+                                policyItems.addAll(policy.getDenyExceptions());
+                            }
+
+                            for (RangerPolicy.RangerPolicyItem policyItem : policyItems) {
+                                if (isPolicyItemApplicable(policyItem, principal, entry.getKey()) && isPolicyItemValidityActive(policyItem, request)) {
+                                    hasActiveItem = true;
+                                    break;
+                                }
+                            }
+                            if (!hasActiveItem) {
+                                keysToRemove.add(entry.getKey());
+                            }
+                        }
+                    }
+                }
+                for (String key : keysToRemove) {
+                    accessMap.remove(key);
+                }
+                if (accessMap.isEmpty()) {
+                    principalACLs.remove(principal.getName());
+                }
+            }
+        }
+    }
+
+    private boolean isPolicyItemApplicable(RangerPolicy.RangerPolicyItem policyItem, HivePrincipal principal, String accessType) {
+        if (policyItem == null || principal == null || StringUtils.isBlank(accessType)) {
+            return false;
+        }
+
+        if (CollectionUtils.isEmpty(policyItem.getAccesses())) {
+            return false;
+        }
+
+        boolean hasAccessType = false;
+        for (RangerPolicy.RangerPolicyItemAccess access : policyItem.getAccesses()) {
+            if (StringUtils.equalsIgnoreCase(accessType, access.getType()) || StringUtils.equalsIgnoreCase(access.getType(), RangerPolicyEngine.ANY_ACCESS)) {
+                hasAccessType = true;
+                break;
+            }
+        }
+        if (!hasAccessType) {
+            return false;
+        }
+
+        switch (principal.getType()) {
+            case USER:
+                return CollectionUtils.isNotEmpty(policyItem.getUsers()) && (policyItem.getUsers().contains(principal.getName()) || policyItem.getUsers().contains(RangerPolicyEngine.USER_CURRENT));
+            case GROUP:
+                return CollectionUtils.isNotEmpty(policyItem.getGroups()) && (policyItem.getGroups().contains(principal.getName()) || policyItem.getGroups().contains(RangerPolicyEngine.GROUP_PUBLIC));
+            case ROLE:
+                return CollectionUtils.isNotEmpty(policyItem.getRoles()) && policyItem.getRoles().contains(principal.getName());
+        }
+        return false;
+    }
+
+    private boolean isPolicyItemValidityActive(RangerPolicy.RangerPolicyItem policyItem, RangerAccessRequest request) {
+        if (policyItem == null || request == null || CollectionUtils.isEmpty(policyItem.getConditions())) {
+            return true;
+        }
+        for (RangerPolicy.RangerPolicyItemCondition condition : policyItem.getConditions()) {
+            if (!StringUtils.equalsIgnoreCase(condition.getType(), "validitySchedule")) {
+                continue;
+            }
+            RangerValidityScheduleConditionEvaluator evaluator = new org.apache.ranger.plugin.conditionevaluator.RangerValidityScheduleConditionEvaluator();
+            evaluator.setPolicyItemCondition(condition);
+            evaluator.init();
+            if (!evaluator.isMatched(request)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private Map<String, Map<Privilege, AccessResult>> convertRangerACLsToHiveACLs(Map<String, Map<String, RangerResourceACLs.AccessResult>> rangerACLs) {

--- a/hive-agent/src/main/java/org/apache/ranger/authorization/hive/authorizer/RangerHiveAuthorizer.java
+++ b/hive-agent/src/main/java/org/apache/ranger/authorization/hive/authorizer/RangerHiveAuthorizer.java
@@ -70,6 +70,7 @@ import org.apache.ranger.plugin.policyengine.RangerAccessRequestImpl;
 import org.apache.ranger.plugin.policyengine.RangerAccessResult;
 import org.apache.ranger.plugin.policyengine.RangerPolicyEngine;
 import org.apache.ranger.plugin.policyengine.RangerResourceACLs;
+import org.apache.ranger.plugin.policyengine.gds.GdsPolicyEngine;
 import org.apache.ranger.plugin.policyevaluator.RangerPolicyEvaluator;
 import org.apache.ranger.plugin.service.RangerBasePlugin;
 import org.apache.ranger.plugin.util.GrantRevokeRequest;
@@ -78,6 +79,7 @@ import org.apache.ranger.plugin.util.RangerAccessRequestUtil;
 import org.apache.ranger.plugin.util.RangerPerfTracer;
 import org.apache.ranger.plugin.util.RangerRequestedResources;
 import org.apache.ranger.plugin.util.RangerRoles;
+import org.apache.ranger.plugin.util.ServiceDefUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -2876,6 +2878,25 @@ public class RangerHiveAuthorizer extends RangerHiveAuthorizerBase {
         if (principalACLs != null) {
             Map<String, RangerResourceACLs.AccessResult> accessMap = principalACLs.get(principal.getName());
             if (accessMap != null) {
+                Map<String, Collection<String>> impliedGrants    = null;
+                Map<String, Collection<String>> gdsImpliedGrants = null;
+
+                if (hivePlugin != null) {
+                    RangerServiceDef serviceDef = hivePlugin.getServiceDef();
+                    if (serviceDef != null) {
+                        impliedGrants = ServiceDefUtil.getExpandedImpliedGrants(serviceDef);
+                    }
+
+                    GdsPolicyEngine gdsPolicyEngine = hivePlugin.getGdsPolicyEngine();
+                    if (gdsPolicyEngine != null && gdsPolicyEngine.getGdsInfo() != null) {
+                        RangerServiceDef gdsServiceDef = gdsPolicyEngine.getGdsInfo().getGdsServiceDef();
+                        if (gdsServiceDef != null) {
+                            gdsImpliedGrants = ServiceDefUtil.getExpandedImpliedGrants(gdsServiceDef);
+                        }
+                    }
+                }
+
+                Map<RangerPolicy.RangerPolicyItem, Boolean> policyItemActiveCache = new HashMap<>();
                 List<String> keysToRemove = new ArrayList<>();
                 for (Map.Entry<String, RangerResourceACLs.AccessResult> entry : accessMap.entrySet()) {
                     RangerResourceACLs.AccessResult accessResult = entry.getValue();
@@ -2899,9 +2920,16 @@ public class RangerHiveAuthorizer extends RangerHiveAuthorizerBase {
                             }
 
                             for (RangerPolicy.RangerPolicyItem policyItem : policyItems) {
-                                if (isPolicyItemApplicable(policyItem, principal, entry.getKey()) && isPolicyItemValidityActive(policyItem, request)) {
-                                    hasActiveItem = true;
-                                    break;
+                                if (isPolicyItemApplicable(policyItem, principal, entry.getKey(), impliedGrants, gdsImpliedGrants)) {
+                                    Boolean isActive = policyItemActiveCache.get(policyItem);
+                                    if (isActive == null) {
+                                        isActive = isPolicyItemValidityActive(policyItem, request);
+                                        policyItemActiveCache.put(policyItem, isActive);
+                                    }
+                                    if (isActive) {
+                                        hasActiveItem = true;
+                                        break;
+                                    }
                                 }
                             }
                             if (!hasActiveItem) {
@@ -2920,7 +2948,7 @@ public class RangerHiveAuthorizer extends RangerHiveAuthorizerBase {
         }
     }
 
-    private boolean isPolicyItemApplicable(RangerPolicy.RangerPolicyItem policyItem, HivePrincipal principal, String accessType) {
+    private boolean isPolicyItemApplicable(RangerPolicy.RangerPolicyItem policyItem, HivePrincipal principal, String accessType, Map<String, Collection<String>> impliedGrants, Map<String, Collection<String>> gdsImpliedGrants) {
         if (policyItem == null || principal == null || StringUtils.isBlank(accessType)) {
             return false;
         }
@@ -2930,12 +2958,42 @@ public class RangerHiveAuthorizer extends RangerHiveAuthorizerBase {
         }
 
         boolean hasAccessType = false;
+
         for (RangerPolicy.RangerPolicyItemAccess access : policyItem.getAccesses()) {
             if (StringUtils.equalsIgnoreCase(accessType, access.getType()) || StringUtils.equalsIgnoreCase(access.getType(), RangerPolicyEngine.ANY_ACCESS)) {
                 hasAccessType = true;
                 break;
             }
+            if (impliedGrants != null) {
+                Collection<String> impliedAccessTypes = impliedGrants.get(access.getType());
+                if (impliedAccessTypes != null) {
+                    for (String impliedAccessType : impliedAccessTypes) {
+                        if (StringUtils.equalsIgnoreCase(accessType, impliedAccessType)) {
+                            hasAccessType = true;
+                            break;
+                        }
+                    }
+                }
+            }
+            if (hasAccessType) {
+                break;
+            }
+            if (gdsImpliedGrants != null) {
+                Collection<String> impliedAccessTypes = gdsImpliedGrants.get(access.getType());
+                if (impliedAccessTypes != null) {
+                    for (String impliedAccessType : impliedAccessTypes) {
+                        if (StringUtils.equalsIgnoreCase(accessType, impliedAccessType)) {
+                            hasAccessType = true;
+                            break;
+                        }
+                    }
+                }
+            }
+            if (hasAccessType) {
+                break;
+            }
         }
+
         if (!hasAccessType) {
             return false;
         }
@@ -2959,7 +3017,7 @@ public class RangerHiveAuthorizer extends RangerHiveAuthorizerBase {
             if (!StringUtils.equalsIgnoreCase(condition.getType(), "validitySchedule")) {
                 continue;
             }
-            RangerValidityScheduleConditionEvaluator evaluator = new org.apache.ranger.plugin.conditionevaluator.RangerValidityScheduleConditionEvaluator();
+            RangerValidityScheduleConditionEvaluator evaluator = new RangerValidityScheduleConditionEvaluator();
             evaluator.setPolicyItemCondition(condition);
             evaluator.init();
             if (!evaluator.isMatched(request)) {

--- a/hive-agent/src/test/java/org/apache/ranger/authorization/hive/authorizer/TestRangerHiveAuthorizer.java
+++ b/hive-agent/src/test/java/org/apache/ranger/authorization/hive/authorizer/TestRangerHiveAuthorizer.java
@@ -1450,6 +1450,128 @@ public class TestRangerHiveAuthorizer {
         }
     }
 
+    @Test
+    void test70_getRangerResourceACLs_filtersExpiredValiditySchedule() throws Exception {
+        RangerBasePlugin   plugin = (RangerBasePlugin) Mockito.spy(newInstanceRangerHivePlugin("hiveCLI"));
+        RangerResourceACLs acls   = new RangerResourceACLs();
+
+        RangerPolicy pUser = new RangerPolicy();
+        RangerPolicy.RangerPolicyItem item = new RangerPolicy.RangerPolicyItem();
+        item.setAccesses(Collections.singletonList(new RangerPolicy.RangerPolicyItemAccess("select", true)));
+        item.setUsers(Collections.singletonList("alice"));
+
+        RangerPolicy.RangerPolicyItemCondition condition = new RangerPolicy.RangerPolicyItemCondition();
+        condition.setType("validitySchedule");
+        condition.setValues(Collections.singletonList("{\"endTime\":\"2000/01/01 00:00:00\"}"));
+        item.setConditions(Collections.singletonList(condition));
+
+        pUser.setPolicyItems(Collections.singletonList(item));
+
+        acls.setUserAccessInfo("alice", "select", RangerPolicyEvaluator.ACCESS_CONDITIONAL, pUser);
+
+        Mockito.doReturn(acls).when(plugin).getResourceACLs(Mockito.any(RangerAccessRequestImpl.class));
+        setStaticHivePlugin(plugin);
+
+        HiveMetastoreClientFactory msFactory = Mockito.mock(HiveMetastoreClientFactory.class);
+        IMetaStoreClient           ms        = Mockito.mock(IMetaStoreClient.class);
+        Mockito.when(msFactory.getHiveMetastoreClient()).thenReturn(ms);
+        RangerHiveAuthorizer authorizer = new RangerHiveAuthorizer(msFactory, null, null, null);
+
+        Method m = RangerHiveAuthorizer.class.getDeclaredMethod("getRangerResourceACLs", HivePrivilegeObject.class, HivePrincipal.class);
+        m.setAccessible(true);
+
+        HivePrivilegeObject obj       = new HivePrivilegeObject(HivePrivilegeObjectType.TABLE_OR_VIEW, "db1", "t1");
+        HivePrincipal       principal = new HivePrincipal("alice", HivePrincipal.HivePrincipalType.USER);
+
+        Object out = m.invoke(authorizer, obj, principal);
+        assertInstanceOf(RangerResourceACLs.class, out);
+        RangerResourceACLs resultAcls = (RangerResourceACLs) out;
+
+        assertTrue(resultAcls.getUserACLs().isEmpty() || !resultAcls.getUserACLs().containsKey("alice"));
+    }
+
+    @Test
+    void test71_getRangerResourceACLs_keepsActiveValiditySchedule() throws Exception {
+        RangerBasePlugin   plugin = (RangerBasePlugin) Mockito.spy(newInstanceRangerHivePlugin("hiveCLI"));
+        RangerResourceACLs acls   = new RangerResourceACLs();
+
+        RangerPolicy pUser = new RangerPolicy();
+        RangerPolicy.RangerPolicyItem item = new RangerPolicy.RangerPolicyItem();
+        item.setAccesses(Collections.singletonList(new RangerPolicy.RangerPolicyItemAccess("select", true)));
+        item.setUsers(Collections.singletonList("bob"));
+
+        RangerPolicy.RangerPolicyItemCondition condition = new RangerPolicy.RangerPolicyItemCondition();
+        condition.setType("validitySchedule");
+        condition.setValues(Collections.singletonList("{\"endTime\":\"2100/01/01 00:00:00\"}"));
+        item.setConditions(Collections.singletonList(condition));
+
+        pUser.setPolicyItems(Collections.singletonList(item));
+
+        acls.setUserAccessInfo("bob", "select", RangerPolicyEvaluator.ACCESS_CONDITIONAL, pUser);
+
+        Mockito.doReturn(acls).when(plugin).getResourceACLs(Mockito.any(RangerAccessRequestImpl.class));
+        setStaticHivePlugin(plugin);
+
+        HiveMetastoreClientFactory msFactory = Mockito.mock(HiveMetastoreClientFactory.class);
+        IMetaStoreClient           ms        = Mockito.mock(IMetaStoreClient.class);
+        Mockito.when(msFactory.getHiveMetastoreClient()).thenReturn(ms);
+        RangerHiveAuthorizer authorizer = new RangerHiveAuthorizer(msFactory, null, null, null);
+
+        Method m = RangerHiveAuthorizer.class.getDeclaredMethod("getRangerResourceACLs", HivePrivilegeObject.class, HivePrincipal.class);
+        m.setAccessible(true);
+
+        HivePrivilegeObject obj       = new HivePrivilegeObject(HivePrivilegeObjectType.TABLE_OR_VIEW, "db1", "t1");
+        HivePrincipal       principal = new HivePrincipal("bob", HivePrincipal.HivePrincipalType.USER);
+
+        Object out = m.invoke(authorizer, obj, principal);
+        assertInstanceOf(RangerResourceACLs.class, out);
+        RangerResourceACLs resultAcls = (RangerResourceACLs) out;
+
+        assertFalse(resultAcls.getUserACLs().isEmpty());
+        assertTrue(resultAcls.getUserACLs().containsKey("bob"));
+        assertNotNull(resultAcls.getUserACLs().get("bob").get("select"));
+    }
+
+    @Test
+    void test72_getRangerResourceACLs_filtersExpiredValidityScheduleForGroup() throws Exception {
+        RangerBasePlugin   plugin = (RangerBasePlugin) Mockito.spy(newInstanceRangerHivePlugin("hiveCLI"));
+        RangerResourceACLs acls   = new RangerResourceACLs();
+
+        RangerPolicy pGroup = new RangerPolicy();
+        RangerPolicy.RangerPolicyItem item = new RangerPolicy.RangerPolicyItem();
+        item.setAccesses(Collections.singletonList(new RangerPolicy.RangerPolicyItemAccess("update", true)));
+        item.setGroups(Collections.singletonList("dev_group"));
+
+        RangerPolicy.RangerPolicyItemCondition condition = new RangerPolicy.RangerPolicyItemCondition();
+        condition.setType("validitySchedule");
+        condition.setValues(Collections.singletonList("{\"endTime\":\"2000/01/01 00:00:00\"}"));
+        item.setConditions(Collections.singletonList(condition));
+
+        pGroup.setPolicyItems(Collections.singletonList(item));
+
+        acls.setGroupAccessInfo("dev_group", "update", RangerPolicyEvaluator.ACCESS_CONDITIONAL, pGroup);
+
+        Mockito.doReturn(acls).when(plugin).getResourceACLs(Mockito.any(RangerAccessRequestImpl.class));
+        setStaticHivePlugin(plugin);
+
+        HiveMetastoreClientFactory msFactory = Mockito.mock(HiveMetastoreClientFactory.class);
+        IMetaStoreClient           ms        = Mockito.mock(IMetaStoreClient.class);
+        Mockito.when(msFactory.getHiveMetastoreClient()).thenReturn(ms);
+        RangerHiveAuthorizer authorizer = new RangerHiveAuthorizer(msFactory, null, null, null);
+
+        Method m = RangerHiveAuthorizer.class.getDeclaredMethod("getRangerResourceACLs", HivePrivilegeObject.class, HivePrincipal.class);
+        m.setAccessible(true);
+
+        HivePrivilegeObject obj       = new HivePrivilegeObject(HivePrivilegeObjectType.TABLE_OR_VIEW, "db1", "t1");
+        HivePrincipal       principal = new HivePrincipal("dev_group", HivePrincipal.HivePrincipalType.GROUP);
+
+        Object out = m.invoke(authorizer, obj, principal);
+        assertInstanceOf(RangerResourceACLs.class, out);
+        RangerResourceACLs resultAcls = (RangerResourceACLs) out;
+
+        assertTrue(resultAcls.getGroupACLs().isEmpty() || !resultAcls.getGroupACLs().containsKey("dev_group"));
+    }
+
     private static RangerAccessResult allowedResult() {
         RangerAccessResult res = new RangerAccessResult(RangerPolicy.POLICY_TYPE_ACCESS, "svc", null, new RangerAccessRequestImpl());
         res.setIsAudited(true);

--- a/hive-agent/src/test/java/org/apache/ranger/authorization/hive/authorizer/TestRangerHiveAuthorizer.java
+++ b/hive-agent/src/test/java/org/apache/ranger/authorization/hive/authorizer/TestRangerHiveAuthorizer.java
@@ -50,6 +50,7 @@ import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.ranger.plugin.model.RangerPolicy;
 import org.apache.ranger.plugin.model.RangerPolicy.RangerPolicyItemAccess;
 import org.apache.ranger.plugin.model.RangerRole;
+import org.apache.ranger.plugin.model.RangerServiceDef;
 import org.apache.ranger.plugin.policyengine.RangerAccessRequestImpl;
 import org.apache.ranger.plugin.policyengine.RangerAccessResult;
 import org.apache.ranger.plugin.policyengine.RangerResourceACLs;
@@ -1570,6 +1571,161 @@ public class TestRangerHiveAuthorizer {
         RangerResourceACLs resultAcls = (RangerResourceACLs) out;
 
         assertTrue(resultAcls.getGroupACLs().isEmpty() || !resultAcls.getGroupACLs().containsKey("dev_group"));
+    }
+
+    @Test
+    void test73_getRangerResourceACLs_keepsActiveValidityScheduleWithImpliedGrants() throws Exception {
+        RangerBasePlugin   plugin = (RangerBasePlugin) Mockito.spy(newInstanceRangerHivePlugin("hiveCLI"));
+        RangerResourceACLs acls   = new RangerResourceACLs();
+
+        RangerServiceDef serviceDef = new RangerServiceDef();
+        RangerServiceDef.RangerAccessTypeDef allAccessDef = new RangerServiceDef.RangerAccessTypeDef(1L, "all", "all", "all", null);
+        allAccessDef.setImpliedGrants(Arrays.asList("select", "update", "drop"));
+        serviceDef.setAccessTypes(Collections.singletonList(allAccessDef));
+        Mockito.doReturn(serviceDef).when(plugin).getServiceDef();
+
+        RangerPolicy pUser = new RangerPolicy();
+        RangerPolicy.RangerPolicyItem item = new RangerPolicy.RangerPolicyItem();
+        item.setAccesses(Collections.singletonList(new RangerPolicy.RangerPolicyItemAccess("all", true)));
+        item.setUsers(Collections.singletonList("bob"));
+
+        RangerPolicy.RangerPolicyItemCondition condition = new RangerPolicy.RangerPolicyItemCondition();
+        condition.setType("validitySchedule");
+        condition.setValues(Collections.singletonList("{\"endTime\":\"2100/01/01 00:00:00\"}"));
+        item.setConditions(Collections.singletonList(condition));
+
+        pUser.setPolicyItems(Collections.singletonList(item));
+
+        // The policy engine would have expanded "all" into "select", "update", "drop", etc.
+        // We will test if the filtering correctly identifies "all" as granting "select"
+        acls.setUserAccessInfo("bob", "select", RangerPolicyEvaluator.ACCESS_CONDITIONAL, pUser);
+
+        Mockito.doReturn(acls).when(plugin).getResourceACLs(Mockito.any(RangerAccessRequestImpl.class));
+        setStaticHivePlugin(plugin);
+
+        HiveMetastoreClientFactory msFactory = Mockito.mock(HiveMetastoreClientFactory.class);
+        IMetaStoreClient           ms        = Mockito.mock(IMetaStoreClient.class);
+        Mockito.when(msFactory.getHiveMetastoreClient()).thenReturn(ms);
+        RangerHiveAuthorizer authorizer = new RangerHiveAuthorizer(msFactory, null, null, null);
+
+        Method m = RangerHiveAuthorizer.class.getDeclaredMethod("getRangerResourceACLs", HivePrivilegeObject.class, HivePrincipal.class);
+        m.setAccessible(true);
+
+        HivePrivilegeObject obj       = new HivePrivilegeObject(HivePrivilegeObjectType.TABLE_OR_VIEW, "db1", "t1");
+        HivePrincipal       principal = new HivePrincipal("bob", HivePrincipal.HivePrincipalType.USER);
+
+        Object out = m.invoke(authorizer, obj, principal);
+        assertInstanceOf(RangerResourceACLs.class, out);
+        RangerResourceACLs resultAcls = (RangerResourceACLs) out;
+
+        assertFalse(resultAcls.getUserACLs().isEmpty());
+        assertTrue(resultAcls.getUserACLs().containsKey("bob"));
+        assertNotNull(resultAcls.getUserACLs().get("bob").get("select"));
+    }
+
+    @Test
+    void test74_getRangerResourceACLs_filtersExpiredValidityScheduleWithGdsImpliedGrants() throws Exception {
+        RangerBasePlugin   plugin = (RangerBasePlugin) Mockito.spy(newInstanceRangerHivePlugin("hiveCLI"));
+        RangerResourceACLs acls   = new RangerResourceACLs();
+
+        org.apache.ranger.plugin.policyengine.gds.GdsPolicyEngine gdsPolicyEngine = Mockito.mock(org.apache.ranger.plugin.policyengine.gds.GdsPolicyEngine.class);
+        org.apache.ranger.plugin.util.ServiceGdsInfo gdsInfo = new org.apache.ranger.plugin.util.ServiceGdsInfo();
+        RangerServiceDef gdsServiceDef = new RangerServiceDef();
+        RangerServiceDef.RangerAccessTypeDef readAccessDef = new RangerServiceDef.RangerAccessTypeDef(1L, "_READ", "_READ", "_READ", null);
+        readAccessDef.setImpliedGrants(Arrays.asList("select", "read"));
+        gdsServiceDef.setAccessTypes(Collections.singletonList(readAccessDef));
+        gdsInfo.setGdsServiceDef(gdsServiceDef);
+        Mockito.when(gdsPolicyEngine.getGdsInfo()).thenReturn(gdsInfo);
+        Mockito.doReturn(gdsPolicyEngine).when(plugin).getGdsPolicyEngine();
+
+        RangerPolicy pUser = new RangerPolicy();
+        RangerPolicy.RangerPolicyItem item = new RangerPolicy.RangerPolicyItem();
+        item.setAccesses(Collections.singletonList(new RangerPolicy.RangerPolicyItemAccess("_READ", true)));
+        item.setUsers(Collections.singletonList("bob"));
+
+        RangerPolicy.RangerPolicyItemCondition condition = new RangerPolicy.RangerPolicyItemCondition();
+        condition.setType("validitySchedule");
+        // Use an expired schedule (year 2000)
+        condition.setValues(Collections.singletonList("{\"endTime\":\"2000/01/01 00:00:00\"}"));
+        item.setConditions(Collections.singletonList(condition));
+
+        pUser.setPolicyItems(Collections.singletonList(item));
+
+        // The ACL comes in as 'select', but the policy item says '_READ'
+        acls.setUserAccessInfo("bob", "select", RangerPolicyEvaluator.ACCESS_CONDITIONAL, pUser);
+
+        Mockito.doReturn(acls).when(plugin).getResourceACLs(Mockito.any(RangerAccessRequestImpl.class));
+        setStaticHivePlugin(plugin);
+
+        HiveMetastoreClientFactory msFactory = Mockito.mock(HiveMetastoreClientFactory.class);
+        IMetaStoreClient           ms        = Mockito.mock(IMetaStoreClient.class);
+        Mockito.when(msFactory.getHiveMetastoreClient()).thenReturn(ms);
+        RangerHiveAuthorizer authorizer = new RangerHiveAuthorizer(msFactory, null, null, null);
+
+        Method m = RangerHiveAuthorizer.class.getDeclaredMethod("getRangerResourceACLs", HivePrivilegeObject.class, HivePrincipal.class);
+        m.setAccessible(true);
+
+        HivePrivilegeObject obj       = new HivePrivilegeObject(HivePrivilegeObjectType.TABLE_OR_VIEW, "db1", "t1");
+        HivePrincipal       principal = new HivePrincipal("bob", HivePrincipal.HivePrincipalType.USER);
+
+        Object out = m.invoke(authorizer, obj, principal);
+        assertInstanceOf(RangerResourceACLs.class, out);
+        RangerResourceACLs resultAcls = (RangerResourceACLs) out;
+
+        assertTrue(resultAcls.getUserACLs().isEmpty() || !resultAcls.getUserACLs().containsKey("bob"));
+    }
+
+    @Test
+    void test75_getRangerResourceACLs_keepsActiveValidityScheduleWithGdsImpliedGrants() throws Exception {
+        RangerBasePlugin   plugin = (RangerBasePlugin) Mockito.spy(newInstanceRangerHivePlugin("hiveCLI"));
+        RangerResourceACLs acls   = new RangerResourceACLs();
+
+        org.apache.ranger.plugin.policyengine.gds.GdsPolicyEngine gdsPolicyEngine = Mockito.mock(org.apache.ranger.plugin.policyengine.gds.GdsPolicyEngine.class);
+        org.apache.ranger.plugin.util.ServiceGdsInfo gdsInfo = new org.apache.ranger.plugin.util.ServiceGdsInfo();
+        RangerServiceDef gdsServiceDef = new RangerServiceDef();
+        RangerServiceDef.RangerAccessTypeDef readAccessDef = new RangerServiceDef.RangerAccessTypeDef(1L, "_READ", "_READ", "_READ", null);
+        readAccessDef.setImpliedGrants(Arrays.asList("select", "read"));
+        gdsServiceDef.setAccessTypes(Collections.singletonList(readAccessDef));
+        gdsInfo.setGdsServiceDef(gdsServiceDef);
+        Mockito.when(gdsPolicyEngine.getGdsInfo()).thenReturn(gdsInfo);
+        Mockito.doReturn(gdsPolicyEngine).when(plugin).getGdsPolicyEngine();
+
+        RangerPolicy pUser = new RangerPolicy();
+        RangerPolicy.RangerPolicyItem item = new RangerPolicy.RangerPolicyItem();
+        item.setAccesses(Collections.singletonList(new RangerPolicy.RangerPolicyItemAccess("_READ", true)));
+        item.setUsers(Collections.singletonList("bob"));
+
+        RangerPolicy.RangerPolicyItemCondition condition = new RangerPolicy.RangerPolicyItemCondition();
+        condition.setType("validitySchedule");
+        // Use an active schedule (year 2100)
+        condition.setValues(Collections.singletonList("{\"endTime\":\"2100/01/01 00:00:00\"}"));
+        item.setConditions(Collections.singletonList(condition));
+
+        pUser.setPolicyItems(Collections.singletonList(item));
+
+        acls.setUserAccessInfo("bob", "select", RangerPolicyEvaluator.ACCESS_CONDITIONAL, pUser);
+
+        Mockito.doReturn(acls).when(plugin).getResourceACLs(Mockito.any(RangerAccessRequestImpl.class));
+        setStaticHivePlugin(plugin);
+
+        HiveMetastoreClientFactory msFactory = Mockito.mock(HiveMetastoreClientFactory.class);
+        IMetaStoreClient           ms        = Mockito.mock(IMetaStoreClient.class);
+        Mockito.when(msFactory.getHiveMetastoreClient()).thenReturn(ms);
+        RangerHiveAuthorizer authorizer = new RangerHiveAuthorizer(msFactory, null, null, null);
+
+        Method m = RangerHiveAuthorizer.class.getDeclaredMethod("getRangerResourceACLs", HivePrivilegeObject.class, HivePrincipal.class);
+        m.setAccessible(true);
+
+        HivePrivilegeObject obj       = new HivePrivilegeObject(HivePrivilegeObjectType.TABLE_OR_VIEW, "db1", "t1");
+        HivePrincipal       principal = new HivePrincipal("bob", HivePrincipal.HivePrincipalType.USER);
+
+        Object out = m.invoke(authorizer, obj, principal);
+        assertInstanceOf(RangerResourceACLs.class, out);
+        RangerResourceACLs resultAcls = (RangerResourceACLs) out;
+
+        assertFalse(resultAcls.getUserACLs().isEmpty());
+        assertTrue(resultAcls.getUserACLs().containsKey("bob"));
+        assertNotNull(resultAcls.getUserACLs().get("bob").get("select"));
     }
 
     private static RangerAccessResult allowedResult() {


### PR DESCRIPTION

## What changes were proposed in this pull request?
getResourceACLs for a principal should consider validitySchedule of principal for ACL creation. Currently getResourceACLs returns a set of ACLs for the principal but if the principal is has a validity period which is expired, it is giving the ACLs which are there which is not correct.

This scenario occurs in GDS where a principal validity period is expired and ACL still show the access given, even though there is no access.

Show Privileges in RangerHiveAuthorizer uses the getResourceACLs which also result in wrong permission sets shown when the principal validity period expired. Fix will filter the getResourceACLs for the Prinicipal in RangerHiveAuthorizer if the validitySchedule is not allowing the access for the resource.

## How was this patch tested?

Tested in Local VM and Unit Tests.
