### PR TITLE
RANGER-5621: Fix CI build-17 timeout due to oversized schema-registry plugin assembly

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -33,31 +33,13 @@
             <groupId>org.apache.ranger</groupId>
             <artifactId>audit-dispatcher-hdfs</artifactId>
             <version>${project.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.ranger</groupId>
             <artifactId>audit-dispatcher-solr</artifactId>
             <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.ranger</groupId>
-            <artifactId>ranger-audit-dest-hdfs</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.ranger</groupId>
-            <artifactId>ranger-audit-dest-solr</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.ranger</groupId>
-            <artifactId>ranger-audit-dispatcher-common</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.ranger</groupId>
-            <artifactId>ranger-audit-server-common</artifactId>
-            <version>${project.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.ranger</groupId>
@@ -109,6 +91,12 @@
         </dependency>
         <dependency>
             <groupId>org.apache.ranger</groupId>
+            <artifactId>ranger-audit-dest-hdfs</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.ranger</groupId>
             <artifactId>ranger-audit-dest-kafka</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
@@ -121,6 +109,12 @@
         </dependency>
         <dependency>
             <groupId>org.apache.ranger</groupId>
+            <artifactId>ranger-audit-dest-solr</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.ranger</groupId>
             <artifactId>ranger-audit-dispatcher-app</artifactId>
             <version>${project.version}</version>
             <type>war</type>
@@ -128,9 +122,21 @@
         </dependency>
         <dependency>
             <groupId>org.apache.ranger</groupId>
+            <artifactId>ranger-audit-dispatcher-common</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.ranger</groupId>
             <artifactId>ranger-audit-ingestor</artifactId>
             <version>${project.version}</version>
             <type>war</type>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.ranger</groupId>
+            <artifactId>ranger-audit-server-common</artifactId>
+            <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?
The GitHub Actions CI `build-17` job started timing out during the final target-17 artifact upload.
 
The failure is not caused by Maven test/build failure. The job reaches the Upload artifacts step, but upload-artifact reports hundreds of thousands of files, for example ~841,939 files, and the job hits the 60-minute timeout.

[RANGER-5520](https://issues.apache.org/jira/browse/RANGER-5520) added new audit dispatcher / audit destination dependencies to distro/pom.xml without an explicit scope. Maven defaults these dependencies to compile scope, which also makes them runtime dependencies of the distro module.
 
The existing schema-registry plugin assembly is defined with:
 ```
<scope>runtime</scope>
<unpack>true</unpack>
 ```
Because this assembly runs from the distro module, the new audit-related runtime dependencies and their transitive dependency trees became eligible for unpacking into the schema-registry plugin assembly. This pulled in large dependency trees, including Hadoop/Hive/Kafka/AWS SDK generated classes.
 
As a result, `target/ranger-3.0.0-SNAPSHOT-schema-registry-plugin.jar` became extremely large. In local verification it had:
 
size: 822 MB
zip entries: 497,417
 
`coverage.sh` then picked up this root target/ranger-*-schema-registry-plugin.jar, unzipped it into target/coverage-classes, and JaCoCo generated a huge target/coverage/all tree. That caused the target-17 artifact upload to include hundreds of thousands of generated coverage files and time out.

The fix adds <scope>provided</scope> for:
 
audit-dispatcher-hdfs
audit-dispatcher-solr
ranger-audit-dest-hdfs
ranger-audit-dest-solr
ranger-audit-dispatcher-common
ranger-audit-server-common

## How was this patch tested?

CI build-17 job is successful: https://github.com/apache/ranger/actions/runs/26673478069/job/78621010424?pr=989, log entry:
```
With the provided path, there will be 1991 files uploaded
```
