### PR TITLE
RANGER-5625: User Sync UI fails to render when POST /xusers/ugsync/auditinfo returns invalid "null" strings for syncTime and lastModified

### DIFF
--- a/security-admin/src/main/java/org/apache/ranger/service/XUgsyncAuditInfoService.java
+++ b/security-admin/src/main/java/org/apache/ranger/service/XUgsyncAuditInfoService.java
@@ -115,14 +115,14 @@ public class XUgsyncAuditInfoService extends XUgsyncAuditInfoServiceBase<XXUgsyn
         vxUgsyncAuditInfo.setUserName(ContextUtil.getCurrentUserLoginId());
 
         // Process the sync source information
-        if (vxUgsyncAuditInfo.getUnixSyncSourceInfo() != null) {
+        if (vxUgsyncAuditInfo.getLdapSyncSourceInfo() != null) {
+            vxUgsyncAuditInfo.setSyncSourceInfo(jsonUtil.jsonToMap(vxUgsyncAuditInfo.getLdapSyncSourceInfo().toString()));
+        }
+        else if (vxUgsyncAuditInfo.getUnixSyncSourceInfo() != null) {
             vxUgsyncAuditInfo.setSyncSourceInfo(jsonUtil.jsonToMap(vxUgsyncAuditInfo.getUnixSyncSourceInfo().toString()));
         } else if (vxUgsyncAuditInfo.getFileSyncSourceInfo() != null) {
             vxUgsyncAuditInfo.setSyncSourceInfo(jsonUtil.jsonToMap(vxUgsyncAuditInfo.getFileSyncSourceInfo().toString()));
-        } else if (vxUgsyncAuditInfo.getLdapSyncSourceInfo() != null) {
-            vxUgsyncAuditInfo.setSyncSourceInfo(jsonUtil.jsonToMap(vxUgsyncAuditInfo.getLdapSyncSourceInfo().toString()));
         }
-
         return createResource(vxUgsyncAuditInfo);
     }
 

--- a/security-admin/src/main/java/org/apache/ranger/view/VXFileSyncSourceInfo.java
+++ b/security-admin/src/main/java/org/apache/ranger/view/VXFileSyncSourceInfo.java
@@ -27,8 +27,9 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import org.apache.ranger.json.JsonDateSerializer;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.apache.ranger.json.JsonDateSerializer;
+
 import java.sql.Date;
 import java.text.SimpleDateFormat;
 import java.util.TimeZone;
@@ -120,8 +121,8 @@ public class VXFileSyncSourceInfo implements java.io.Serializable {
         dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
 
         sb.append("{\"fileName\":\"").append(fileName);
-        sb.append("\", \"syncTime\":\"").append(dateFormat.format(syncTime == null? new java.util.Date() : syncTime));
-        sb.append("\", \"lastModified\":\"").append(dateFormat.format(lastModified == null? new java.util.Date() : lastModified));
+        sb.append("\", \"syncTime\":\"").append(dateFormat.format(syncTime == null ? new java.util.Date() : syncTime));
+        sb.append("\", \"lastModified\":\"").append(dateFormat.format(lastModified == null ? new java.util.Date() : lastModified));
         sb.append("\", \"totalUsersSynced\":\"").append(totalUsersSynced);
         sb.append("\", \"totalGroupsSynced\":\"").append(totalGroupsSynced);
         sb.append("\", \"totalUsersDeleted\":\"").append(totalUsersDeleted);

--- a/security-admin/src/main/java/org/apache/ranger/view/VXFileSyncSourceInfo.java
+++ b/security-admin/src/main/java/org/apache/ranger/view/VXFileSyncSourceInfo.java
@@ -27,6 +27,11 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import org.apache.ranger.json.JsonDateSerializer;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.sql.Date;
+import java.text.SimpleDateFormat;
+import java.util.TimeZone;
 
 @JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE, fieldVisibility = Visibility.ANY)
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -35,8 +40,10 @@ public class VXFileSyncSourceInfo implements java.io.Serializable {
     private static final long serialVersionUID = 1L;
 
     private String fileName;
-    private String syncTime;
-    private String lastModified;
+    @JsonSerialize(using = JsonDateSerializer.class)
+    private Date syncTime;
+    @JsonSerialize(using = JsonDateSerializer.class)
+    private Date lastModified;
     private long   totalUsersSynced;
     private long   totalGroupsSynced;
     private long   totalUsersDeleted;
@@ -53,19 +60,19 @@ public class VXFileSyncSourceInfo implements java.io.Serializable {
         this.fileName = fileName;
     }
 
-    public String getSyncTime() {
+    public Date getSyncTime() {
         return syncTime;
     }
 
-    public void setSyncTime(String syncTime) {
+    public void setSyncTime(Date syncTime) {
         this.syncTime = syncTime;
     }
 
-    public String getLastModified() {
+    public Date getLastModified() {
         return lastModified;
     }
 
-    public void setLastModified(String lastModified) {
+    public void setLastModified(Date lastModified) {
         this.lastModified = lastModified;
     }
 
@@ -109,9 +116,12 @@ public class VXFileSyncSourceInfo implements java.io.Serializable {
     }
 
     public StringBuilder toString(StringBuilder sb) {
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+        dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
         sb.append("{\"fileName\":\"").append(fileName);
-        sb.append("\", \"syncTime\":\"").append(syncTime);
-        sb.append("\", \"lastModified\":\"").append(lastModified);
+        sb.append("\", \"syncTime\":\"").append(dateFormat.format(syncTime == null? new java.util.Date() : syncTime));
+        sb.append("\", \"lastModified\":\"").append(dateFormat.format(lastModified == null? new java.util.Date() : lastModified));
         sb.append("\", \"totalUsersSynced\":\"").append(totalUsersSynced);
         sb.append("\", \"totalGroupsSynced\":\"").append(totalGroupsSynced);
         sb.append("\", \"totalUsersDeleted\":\"").append(totalUsersDeleted);

--- a/security-admin/src/main/java/org/apache/ranger/view/VXUnixSyncSourceInfo.java
+++ b/security-admin/src/main/java/org/apache/ranger/view/VXUnixSyncSourceInfo.java
@@ -27,13 +27,12 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import org.apache.ranger.json.JsonDateSerializer;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.apache.ranger.json.JsonDateSerializer;
 
 import java.sql.Date;
 import java.text.SimpleDateFormat;
 import java.util.TimeZone;
-
 
 @JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE, fieldVisibility = Visibility.ANY)
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -150,8 +149,8 @@ public class VXUnixSyncSourceInfo implements java.io.Serializable {
 
         sb.append("{\"unixBackend\":\"").append(unixBackend);
         sb.append("\", \"fileName\":\"").append(fileName);
-        sb.append("\", \"syncTime\":\"").append(dateFormat.format(syncTime == null? new java.util.Date() : syncTime));
-        sb.append("\", \"lastModified\":\"").append(dateFormat.format(lastModified == null? new java.util.Date() : lastModified));
+        sb.append("\", \"syncTime\":\"").append(dateFormat.format(syncTime == null ? new java.util.Date() : syncTime));
+        sb.append("\", \"lastModified\":\"").append(dateFormat.format(lastModified == null ? new java.util.Date() : lastModified));
         sb.append("\", \"minUserId\":\"").append(minUserId);
         sb.append("\", \"minGroupId\":\"").append(minGroupId);
         sb.append("\", \"totalUsersSynced\":\"").append(totalUsersSynced);

--- a/security-admin/src/main/java/org/apache/ranger/view/VXUnixSyncSourceInfo.java
+++ b/security-admin/src/main/java/org/apache/ranger/view/VXUnixSyncSourceInfo.java
@@ -27,6 +27,13 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import org.apache.ranger.json.JsonDateSerializer;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+import java.sql.Date;
+import java.text.SimpleDateFormat;
+import java.util.TimeZone;
+
 
 @JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE, fieldVisibility = Visibility.ANY)
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -36,8 +43,10 @@ public class VXUnixSyncSourceInfo implements java.io.Serializable {
 
     private String unixBackend;
     private String fileName;
-    private String syncTime;
-    private String lastModified;
+    @JsonSerialize(using = JsonDateSerializer.class)
+    private Date syncTime;
+    @JsonSerialize(using = JsonDateSerializer.class)
+    private Date lastModified;
     private String minUserId;
     private String minGroupId;
     private long   totalUsersSynced;
@@ -56,19 +65,19 @@ public class VXUnixSyncSourceInfo implements java.io.Serializable {
         this.fileName = fileName;
     }
 
-    public String getSyncTime() {
+    public Date getSyncTime() {
         return syncTime;
     }
 
-    public void setSyncTime(String syncTime) {
+    public void setSyncTime(Date syncTime) {
         this.syncTime = syncTime;
     }
 
-    public String getLastModified() {
+    public Date getLastModified() {
         return lastModified;
     }
 
-    public void setLastModified(String lastModified) {
+    public void setLastModified(Date lastModified) {
         this.lastModified = lastModified;
     }
 
@@ -136,10 +145,13 @@ public class VXUnixSyncSourceInfo implements java.io.Serializable {
     }
 
     public StringBuilder toString(StringBuilder sb) {
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+        dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
         sb.append("{\"unixBackend\":\"").append(unixBackend);
         sb.append("\", \"fileName\":\"").append(fileName);
-        sb.append("\", \"syncTime\":\"").append(syncTime);
-        sb.append("\", \"lastModified\":\"").append(lastModified);
+        sb.append("\", \"syncTime\":\"").append(dateFormat.format(syncTime == null? new java.util.Date() : syncTime));
+        sb.append("\", \"lastModified\":\"").append(dateFormat.format(lastModified == null? new java.util.Date() : lastModified));
         sb.append("\", \"minUserId\":\"").append(minUserId);
         sb.append("\", \"minGroupId\":\"").append(minGroupId);
         sb.append("\", \"totalUsersSynced\":\"").append(totalUsersSynced);


### PR DESCRIPTION
When invoking the POST /xusers/ugsync/auditinfo API with an empty fileSyncSourceInfo object in the payload, the backend serializes the missing date values as the string literal "null" (e.g., "syncTime": "null") instead of a valid JSON null or omitting the field entirely. While the backend successfully logs the audit, navigating to the UI's "Audits > User Sync" tab and attempting to view the sync details causes the application to crash with an "Oops! Something went wrong..." error.

This indicates an improper backend serialization strategy for empty properties, compounded by a missing frontend fallback or type-check within the "Sync Details" modal component when parsing dates.

This is solved by 
1. Changing the data type of time related fields to "date"
2. Update the StringBuilder toString() to handle null value to return current timestamp
3. Rearrange the priority order when multiple syncsource were mentioned (LDAP > UNIX > FILE)