### PR TITLE
RANGER-5630:Swagger UI requests non-existent swagger.json instead of generated openapi.json

### DIFF
--- a/docs/src/site/resources/index.js
+++ b/docs/src/site/resources/index.js
@@ -39,7 +39,7 @@ const rangerLogo = `<svg width="130" height="40" viewBox="0 0 130 40" fill="none
 
 window.onload = function() {
     const ui = SwaggerUIBundle({
-        url: getSwaggerBaseUrl(window.location.pathname) + "/swagger.json",
+        url: getSwaggerBaseUrl(window.location.pathname) + "/openapi.json",
         dom_id: '#swagger-ui',
         deepLinking: true,
         presets: [
@@ -51,7 +51,7 @@ window.onload = function() {
         ],
         layout: "StandaloneLayout",
         requestInterceptor: function(request) {
-              if (!request.url.includes("swagger.json")) {
+              if (!request.url.includes("openapi.json")) {
                     request.url = getAPIUrl(request.url);
               }
               if (request.method != "GET") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR fixes the Swagger UI API documentation page failing to load due to an incorrect reference to `swagger.json`. The UI has been updated to load `openapi.json`, which is the API specification file generated and packaged by the Ranger build process.

## How was this patch tested?

* Built and deployed Ranger Admin with the proposed changes.
* Opened `/apidocs/swagger.html`.
* Verified that `openapi.json` is loaded successfully (HTTP 200).
* Confirmed that the API documentation is displayed correctly without errors.
