### PR TITLE
RANGER-5632: update plugins packaging to have audit-server as the only audit destination

### DIFF
--- a/authz-embedded/pom.xml
+++ b/authz-embedded/pom.xml
@@ -41,13 +41,7 @@
 
         <dependency>
             <groupId>org.apache.ranger</groupId>
-            <artifactId>ranger-audit-dest-hdfs</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.ranger</groupId>
-            <artifactId>ranger-audit-dest-solr</artifactId>
+            <artifactId>ranger-audit-dest-auditserver</artifactId>
             <version>${project.version}</version>
         </dependency>
 

--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -79,6 +79,12 @@
         </dependency>
         <dependency>
             <groupId>org.apache.ranger</groupId>
+            <artifactId>ranger-audit-dest-auditserver</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.ranger</groupId>
             <artifactId>ranger-audit-dest-cloudwatch</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>

--- a/distro/src/main/assembly/hbase-agent.xml
+++ b/distro/src/main/assembly/hbase-agent.xml
@@ -43,8 +43,6 @@
       <includes>
         <include>org.apache.ranger:ranger-audit-core</include>
         <include>org.apache.ranger:ranger-audit-dest-auditserver</include>
-        <include>org.apache.ranger:ranger-audit-dest-hdfs</include>
-        <include>org.apache.ranger:ranger-audit-dest-solr</include>
         <include>org.apache.ranger:ranger-authz-api</include>
         <include>org.apache.ranger:ranger-common-utils</include>
         <include>org.apache.ranger:ranger-plugins-cred</include>

--- a/distro/src/main/assembly/hdfs-agent.xml
+++ b/distro/src/main/assembly/hdfs-agent.xml
@@ -72,8 +72,6 @@
       <includes>
         <include>org.apache.ranger:ranger-audit-core</include>
         <include>org.apache.ranger:ranger-audit-dest-auditserver</include>
-        <include>org.apache.ranger:ranger-audit-dest-hdfs</include>
-        <include>org.apache.ranger:ranger-audit-dest-solr</include>
         <include>org.apache.ranger:ranger-authz-api</include>
         <include>org.apache.ranger:ranger-common-utils</include>
         <include>org.apache.ranger:ranger-plugins-cred</include>

--- a/distro/src/main/assembly/hive-agent.xml
+++ b/distro/src/main/assembly/hive-agent.xml
@@ -43,8 +43,6 @@
       <includes>
         <include>org.apache.ranger:ranger-audit-core</include>
         <include>org.apache.ranger:ranger-audit-dest-auditserver</include>
-        <include>org.apache.ranger:ranger-audit-dest-hdfs</include>
-        <include>org.apache.ranger:ranger-audit-dest-solr</include>
         <include>org.apache.ranger:ranger-authz-api</include>
         <include>org.apache.ranger:ranger-common-utils</include>
         <include>org.apache.ranger:ranger-plugins-cred</include>

--- a/distro/src/main/assembly/kms.xml
+++ b/distro/src/main/assembly/kms.xml
@@ -291,8 +291,6 @@
             <includes>
                 <include>org.apache.ranger:ranger-audit-core</include>
                 <include>org.apache.ranger:ranger-audit-dest-auditserver</include>
-                <include>org.apache.ranger:ranger-audit-dest-hdfs</include>
-                <include>org.apache.ranger:ranger-audit-dest-solr</include>
                 <include>org.apache.ranger:ranger-authz-api</include>
                 <include>org.apache.ranger:ranger-common-utils</include>
                 <include>org.apache.ranger:ranger-plugins-cred</include>

--- a/distro/src/main/assembly/knox-agent.xml
+++ b/distro/src/main/assembly/knox-agent.xml
@@ -44,8 +44,6 @@
       <includes>
         <include>org.apache.ranger:ranger-audit-core</include>
         <include>org.apache.ranger:ranger-audit-dest-auditserver</include>
-        <include>org.apache.ranger:ranger-audit-dest-hdfs</include>
-        <include>org.apache.ranger:ranger-audit-dest-solr</include>
         <include>org.apache.ranger:ranger-authz-api</include>
         <include>org.apache.ranger:ranger-common-utils</include>
         <include>org.apache.ranger:ranger-plugins-cred</include>

--- a/distro/src/main/assembly/pdp.xml
+++ b/distro/src/main/assembly/pdp.xml
@@ -33,8 +33,6 @@
                 <include>org.apache.ranger:authz-embedded</include>
                 <include>org.apache.ranger:ranger-audit-core</include>
                 <include>org.apache.ranger:ranger-audit-dest-auditserver</include>
-                <include>org.apache.ranger:ranger-audit-dest-hdfs</include>
-                <include>org.apache.ranger:ranger-audit-dest-solr</include>
                 <include>org.apache.ranger:ranger-authn</include>
                 <include>org.apache.ranger:ranger-authz-api</include>
                 <include>org.apache.ranger:ranger-common-utils</include>

--- a/distro/src/main/assembly/plugin-atlas.xml
+++ b/distro/src/main/assembly/plugin-atlas.xml
@@ -44,8 +44,6 @@
       <includes>
         <include>org.apache.ranger:ranger-audit-core</include>
         <include>org.apache.ranger:ranger-audit-dest-auditserver</include>
-        <include>org.apache.ranger:ranger-audit-dest-hdfs</include>
-        <include>org.apache.ranger:ranger-audit-dest-solr</include>
         <include>org.apache.ranger:ranger-authz-api</include>
         <include>org.apache.ranger:ranger-common-utils</include>
         <include>org.apache.ranger:ranger-plugins-cred</include>

--- a/distro/src/main/assembly/plugin-elasticsearch.xml
+++ b/distro/src/main/assembly/plugin-elasticsearch.xml
@@ -48,8 +48,6 @@
       <includes>
         <include>org.apache.ranger:ranger-audit-core</include>
         <include>org.apache.ranger:ranger-audit-dest-auditserver</include>
-        <include>org.apache.ranger:ranger-audit-dest-es</include>
-        <include>org.apache.ranger:ranger-audit-dest-hdfs</include>
         <include>org.apache.ranger:ranger-authz-api</include>
         <include>org.apache.ranger:ranger-common-utils</include>
         <include>org.apache.ranger:ranger-plugins-cred</include>

--- a/distro/src/main/assembly/plugin-kafka.xml
+++ b/distro/src/main/assembly/plugin-kafka.xml
@@ -39,8 +39,6 @@
 			<includes>
 				<include>org.apache.ranger:ranger-audit-core</include>
 				<include>org.apache.ranger:ranger-audit-dest-auditserver</include>
-				<include>org.apache.ranger:ranger-audit-dest-hdfs</include>
-				<include>org.apache.ranger:ranger-audit-dest-solr</include>
 				<include>org.apache.ranger:ranger-authz-api</include>
 				<include>org.apache.ranger:ranger-common-utils</include>
 				<include>org.apache.ranger:ranger-kafka-plugin</include>

--- a/distro/src/main/assembly/plugin-kms.xml
+++ b/distro/src/main/assembly/plugin-kms.xml
@@ -43,8 +43,6 @@
       <includes>
         <include>org.apache.ranger:ranger-audit-core</include>
         <include>org.apache.ranger:ranger-audit-dest-auditserver</include>
-        <include>org.apache.ranger:ranger-audit-dest-hdfs</include>
-        <include>org.apache.ranger:ranger-audit-dest-solr</include>
         <include>org.apache.ranger:ranger-authz-api</include>
         <include>org.apache.ranger:ranger-common-utils</include>
         <include>org.apache.ranger:ranger-plugins-cred</include>

--- a/distro/src/main/assembly/plugin-kylin.xml
+++ b/distro/src/main/assembly/plugin-kylin.xml
@@ -43,8 +43,6 @@
       <includes>
         <include>org.apache.ranger:ranger-audit-core</include>
         <include>org.apache.ranger:ranger-audit-dest-auditserver</include>
-        <include>org.apache.ranger:ranger-audit-dest-hdfs</include>
-        <include>org.apache.ranger:ranger-audit-dest-solr</include>
         <include>org.apache.ranger:ranger-authz-api</include>
         <include>org.apache.ranger:ranger-common-utils</include>
         <include>org.apache.ranger:ranger-plugins-cred</include>

--- a/distro/src/main/assembly/plugin-ozone.xml
+++ b/distro/src/main/assembly/plugin-ozone.xml
@@ -72,8 +72,6 @@
             <includes>
                 <include>org.apache.ranger:ranger-audit-core</include>
                 <include>org.apache.ranger:ranger-audit-dest-auditserver</include>
-                <include>org.apache.ranger:ranger-audit-dest-hdfs</include>
-                <include>org.apache.ranger:ranger-audit-dest-solr</include>
                 <include>org.apache.ranger:ranger-authz-api</include>
                 <include>org.apache.ranger:ranger-common-utils</include>
                 <include>org.apache.ranger:ranger-plugins-cred</include>

--- a/distro/src/main/assembly/plugin-presto.xml
+++ b/distro/src/main/assembly/plugin-presto.xml
@@ -54,8 +54,6 @@
             <includes>
                 <include>org.apache.ranger:ranger-audit-core</include>
                 <include>org.apache.ranger:ranger-audit-dest-auditserver</include>
-                <include>org.apache.ranger:ranger-audit-dest-hdfs</include>
-                <include>org.apache.ranger:ranger-audit-dest-solr</include>
                 <include>org.apache.ranger:ranger-authz-api</include>
                 <include>org.apache.ranger:ranger-common-utils</include>
                 <include>org.apache.ranger:ranger-plugins-cred</include>

--- a/distro/src/main/assembly/plugin-solr.xml
+++ b/distro/src/main/assembly/plugin-solr.xml
@@ -38,8 +38,6 @@
       <includes>
         <include>org.apache.ranger:ranger-audit-core</include>
         <include>org.apache.ranger:ranger-audit-dest-auditserver</include>
-        <include>org.apache.ranger:ranger-audit-dest-hdfs</include>
-        <include>org.apache.ranger:ranger-audit-dest-solr</include>
         <include>org.apache.ranger:ranger-authz-api</include>
         <include>org.apache.ranger:ranger-common-utils</include>
         <include>org.apache.ranger:ranger-plugins-cred</include>

--- a/distro/src/main/assembly/plugin-sqoop.xml
+++ b/distro/src/main/assembly/plugin-sqoop.xml
@@ -43,8 +43,6 @@
       <includes>
         <include>org.apache.ranger:ranger-audit-core</include>
         <include>org.apache.ranger:ranger-audit-dest-auditserver</include>
-        <include>org.apache.ranger:ranger-audit-dest-hdfs</include>
-        <include>org.apache.ranger:ranger-audit-dest-solr</include>
         <include>org.apache.ranger:ranger-authz-api</include>
         <include>org.apache.ranger:ranger-common-utils</include>
         <include>org.apache.ranger:ranger-plugins-cred</include>

--- a/distro/src/main/assembly/plugin-trino.xml
+++ b/distro/src/main/assembly/plugin-trino.xml
@@ -28,8 +28,6 @@
             <includes>
                 <include>org.apache.ranger:ranger-audit-core</include>
                 <include>org.apache.ranger:ranger-audit-dest-auditserver</include>
-                <include>org.apache.ranger:ranger-audit-dest-hdfs</include>
-                <include>org.apache.ranger:ranger-audit-dest-solr</include>
                 <include>org.apache.ranger:ranger-authz-api</include>
                 <include>org.apache.ranger:ranger-common-utils</include>
                 <include>org.apache.ranger:ranger-plugins-cred</include>

--- a/distro/src/main/assembly/plugin-yarn.xml
+++ b/distro/src/main/assembly/plugin-yarn.xml
@@ -43,8 +43,6 @@
       <includes>
         <include>org.apache.ranger:ranger-audit-core</include>
         <include>org.apache.ranger:ranger-audit-dest-auditserver</include>
-        <include>org.apache.ranger:ranger-audit-dest-hdfs</include>
-        <include>org.apache.ranger:ranger-audit-dest-solr</include>
         <include>org.apache.ranger:ranger-authz-api</include>
         <include>org.apache.ranger:ranger-common-utils</include>
         <include>org.apache.ranger:ranger-plugins-cred</include>

--- a/distro/src/main/assembly/storm-agent.xml
+++ b/distro/src/main/assembly/storm-agent.xml
@@ -43,8 +43,6 @@
       <includes>
         <include>org.apache.ranger:ranger-audit-core</include>
         <include>org.apache.ranger:ranger-audit-dest-auditserver</include>
-        <include>org.apache.ranger:ranger-audit-dest-hdfs</include>
-        <include>org.apache.ranger:ranger-audit-dest-solr</include>
         <include>org.apache.ranger:ranger-authz-api</include>
         <include>org.apache.ranger:ranger-common-utils</include>
         <include>org.apache.ranger:ranger-plugins-cred</include>

--- a/hbase-agent/pom.xml
+++ b/hbase-agent/pom.xml
@@ -228,22 +228,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.ranger</groupId>
-            <artifactId>ranger-audit-dest-hdfs</artifactId>
-            <version>${project.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.hadoop</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.ranger</groupId>
-            <artifactId>ranger-audit-dest-solr</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.ranger</groupId>
             <artifactId>ranger-hbase-plugin-shim</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/hdfs-agent/pom.xml
+++ b/hdfs-agent/pom.xml
@@ -190,16 +190,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.ranger</groupId>
-            <artifactId>ranger-audit-dest-hdfs</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.ranger</groupId>
-            <artifactId>ranger-audit-dest-solr</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.ranger</groupId>
             <artifactId>ranger-plugins-common</artifactId>
             <version>${project.version}</version>
             <exclusions>

--- a/hive-agent/pom.xml
+++ b/hive-agent/pom.xml
@@ -285,16 +285,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.ranger</groupId>
-            <artifactId>ranger-audit-dest-hdfs</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.ranger</groupId>
-            <artifactId>ranger-audit-dest-solr</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.ranger</groupId>
             <artifactId>ranger-plugins-common</artifactId>
             <version>${project.version}</version>
             <exclusions>

--- a/knox-agent/pom.xml
+++ b/knox-agent/pom.xml
@@ -123,22 +123,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.ranger</groupId>
-            <artifactId>ranger-audit-dest-hdfs</artifactId>
-            <version>${project.version}</version>
-            <!-- TO DEBUG JERSEY2 code: uncomment this exclusion
-       <exclusions><exclusion><artifactId>*</artifactId><groupId>*</groupId></exclusion></exclusions>
- -->
-        </dependency>
-        <dependency>
-            <groupId>org.apache.ranger</groupId>
-            <artifactId>ranger-audit-dest-solr</artifactId>
-            <version>${project.version}</version>
-            <!-- TO DEBUG JERSEY2 code: uncomment this exclusion
-       <exclusions><exclusion><artifactId>*</artifactId><groupId>*</groupId></exclusion></exclusions>
- -->
-        </dependency>
-        <dependency>
-            <groupId>org.apache.ranger</groupId>
             <artifactId>ranger-plugins-common</artifactId>
             <version>${project.version}</version>
             <exclusions>

--- a/plugin-atlas/pom.xml
+++ b/plugin-atlas/pom.xml
@@ -109,16 +109,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.ranger</groupId>
-            <artifactId>ranger-audit-dest-hdfs</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.ranger</groupId>
-            <artifactId>ranger-audit-dest-solr</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.ranger</groupId>
             <artifactId>ranger-plugins-common</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/plugin-elasticsearch/pom.xml
+++ b/plugin-elasticsearch/pom.xml
@@ -53,16 +53,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.ranger</groupId>
-            <artifactId>ranger-audit-dest-hdfs</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.ranger</groupId>
-            <artifactId>ranger-audit-dest-solr</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.ranger</groupId>
             <artifactId>ranger-plugins-common</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/plugin-kafka/pom.xml
+++ b/plugin-kafka/pom.xml
@@ -83,16 +83,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.ranger</groupId>
-            <artifactId>ranger-audit-dest-hdfs</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.ranger</groupId>
-            <artifactId>ranger-audit-dest-solr</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.ranger</groupId>
             <artifactId>ranger-plugins-common</artifactId>
             <version>${project.version}</version>
             <exclusions>

--- a/plugin-kms/pom.xml
+++ b/plugin-kms/pom.xml
@@ -58,16 +58,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.ranger</groupId>
-            <artifactId>ranger-audit-dest-hdfs</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.ranger</groupId>
-            <artifactId>ranger-audit-dest-solr</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.ranger</groupId>
             <artifactId>ranger-kms</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/plugin-kudu/pom.xml
+++ b/plugin-kudu/pom.xml
@@ -43,16 +43,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.ranger</groupId>
-            <artifactId>ranger-audit-dest-hdfs</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.ranger</groupId>
-            <artifactId>ranger-audit-dest-solr</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.ranger</groupId>
             <artifactId>ranger-plugins-common</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/plugin-kylin/pom.xml
+++ b/plugin-kylin/pom.xml
@@ -64,16 +64,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.ranger</groupId>
-            <artifactId>ranger-audit-dest-hdfs</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.ranger</groupId>
-            <artifactId>ranger-audit-dest-solr</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.ranger</groupId>
             <artifactId>ranger-plugins-common</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/plugin-nifi-registry/pom.xml
+++ b/plugin-nifi-registry/pom.xml
@@ -74,16 +74,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.ranger</groupId>
-            <artifactId>ranger-audit-dest-hdfs</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.ranger</groupId>
-            <artifactId>ranger-audit-dest-solr</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.ranger</groupId>
             <artifactId>ranger-plugins-common</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/plugin-nifi/pom.xml
+++ b/plugin-nifi/pom.xml
@@ -64,16 +64,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.ranger</groupId>
-            <artifactId>ranger-audit-dest-hdfs</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.ranger</groupId>
-            <artifactId>ranger-audit-dest-solr</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.ranger</groupId>
             <artifactId>ranger-plugins-common</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/plugin-ozone/pom.xml
+++ b/plugin-ozone/pom.xml
@@ -117,16 +117,6 @@ limitations under the License.
         </dependency>
         <dependency>
             <groupId>org.apache.ranger</groupId>
-            <artifactId>ranger-audit-dest-hdfs</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.ranger</groupId>
-            <artifactId>ranger-audit-dest-solr</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.ranger</groupId>
             <artifactId>ranger-plugins-common</artifactId>
             <version>${project.version}</version>
             <exclusions>

--- a/plugin-presto/pom.xml
+++ b/plugin-presto/pom.xml
@@ -68,16 +68,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.ranger</groupId>
-            <artifactId>ranger-audit-dest-hdfs</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.ranger</groupId>
-            <artifactId>ranger-audit-dest-solr</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.ranger</groupId>
             <artifactId>ranger-plugins-common</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/plugin-solr/pom.xml
+++ b/plugin-solr/pom.xml
@@ -74,16 +74,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.ranger</groupId>
-            <artifactId>ranger-audit-dest-hdfs</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.ranger</groupId>
-            <artifactId>ranger-audit-dest-solr</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.ranger</groupId>
             <artifactId>ranger-plugins-common</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/plugin-sqoop/pom.xml
+++ b/plugin-sqoop/pom.xml
@@ -64,16 +64,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.ranger</groupId>
-            <artifactId>ranger-audit-dest-hdfs</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.ranger</groupId>
-            <artifactId>ranger-audit-dest-solr</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.ranger</groupId>
             <artifactId>ranger-plugins-common</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/plugin-trino/pom.xml
+++ b/plugin-trino/pom.xml
@@ -109,16 +109,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.ranger</groupId>
-            <artifactId>ranger-audit-dest-hdfs</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.ranger</groupId>
-            <artifactId>ranger-audit-dest-solr</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.ranger</groupId>
             <artifactId>ranger-plugins-common</artifactId>
             <version>${project.version}</version>
             <exclusions>

--- a/plugin-yarn/pom.xml
+++ b/plugin-yarn/pom.xml
@@ -106,16 +106,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.ranger</groupId>
-            <artifactId>ranger-audit-dest-hdfs</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.ranger</groupId>
-            <artifactId>ranger-audit-dest-solr</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.ranger</groupId>
             <artifactId>ranger-plugins-common</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/ranger-examples/plugin-sampleapp/pom.xml
+++ b/ranger-examples/plugin-sampleapp/pom.xml
@@ -89,16 +89,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.ranger</groupId>
-            <artifactId>ranger-audit-dest-hdfs</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.ranger</groupId>
-            <artifactId>ranger-audit-dest-solr</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.ranger</groupId>
             <artifactId>ranger-plugins-common</artifactId>
             <version>${project.version}</version>
         </dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?

updated plugins packaging to remove all audit destinations other than audit-server destination.

## How was this patch tested?

Verified the following using docker setup:
- verified successful Ranger build
- verified successful startup of all Ranger services
- verified all plugins successfully download policies from Ranger