### PR TITLE
RANGER-5636: Configure GitHub workflows to use concurrency cancel-in-progress for pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,10 @@ on:
 env:
   MAVEN_OPTS: -Xmx5g -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build-17:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
see recommended best practices at Apache
https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=INFRA&title=GitHub+Actions+Recommended+Practices

## What changes were proposed in this pull request?

When a new commit is pushed to a PR branch, the runs triggered by earlier commits keep going, even though their results are no longer relevant. A concurrency group scoped to the PR cancels those stale runs as soon as a newer commit arrives.

Scope the group by PR number so each PR only cancels its own runs, and limit cancel-in-progress to pull_request events so pushes to release branches are never interrupted.

concurrency:
  # One group per PR, or per ref for branch pushes.
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
  # Cancel in-progress runs for PRs only, so release branch builds always complete.
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}


## How was this patch tested?

same change applied to several other reprositories
