### PR TITLE
RANGER-5640: Bump Docker Ozone to 2.1 and package audit-server JARs in ozone plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,7 @@ jobs:
   # archive.apache.org mirror does not consume the docker-build job budget.
   plugins-download-archives:
     runs-on: ubuntu-24.04
-    timeout-minutes: 120
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v6
 

--- a/dev-support/ranger-docker/.env
+++ b/dev-support/ranger-docker/.env
@@ -75,11 +75,12 @@ ORACLE_VERSION=23.6
 SQLSERVER_VERSION=2022-latest
 
 # Ozone Configuration
-OZONE_VERSION=1.4.0
+# Align runtime with Ranger plugin compile target (pom.xml ozone.version=2.1.0); avoids getSessionPolicy() mismatch on OM.
+OZONE_VERSION=2.1.0
 OZONE_PLUGIN_VERSION=3.0.0-SNAPSHOT
 OZONE_RUNNER_IMAGE=apache/ozone-runner
-# JDK 17 runner for Ranger 3.0 / Ozone 1.4; 20241108-jdk17-1 has arm64+amd64 (20241022-jdk17-1 is amd64-only).
-OZONE_RUNNER_VERSION=20241108-jdk17-1
+# Ozone 2.0+ requires jdk21 runner (jdk11/jdk17 tags are for Ozone 1.x). Multi-arch arm64+amd64.
+OZONE_RUNNER_VERSION=20260106-1-jdk21
 
 # Trino Configuration
 TRINO_VERSION=latest

--- a/dev-support/ranger-docker/.env
+++ b/dev-support/ranger-docker/.env
@@ -75,7 +75,7 @@ ORACLE_VERSION=23.6
 SQLSERVER_VERSION=2022-latest
 
 # Ozone Configuration
-# Align runtime with Ranger plugin compile target (pom.xml ozone.version=2.1.0); avoids getSessionPolicy() mismatch on OM.
+# Align runtime with Ranger plugin compile target (pom.xml ozone.version=2.1.0)
 OZONE_VERSION=2.1.0
 OZONE_PLUGIN_VERSION=3.0.0-SNAPSHOT
 OZONE_RUNNER_IMAGE=apache/ozone-runner

--- a/dev-support/ranger-docker/Dockerfile.ranger-ozone
+++ b/dev-support/ranger-docker/Dockerfile.ranger-ozone
@@ -15,8 +15,8 @@
 # limitations under the License.
 
 ARG OZONE_RUNNER_IMAGE=apache/ozone-runner
-# Keep in sync with .env; 20241108-jdk17-1 is multi-arch (arm64+amd64), 20241022-jdk17-1 is amd64-only.
-ARG OZONE_RUNNER_VERSION=20241108-jdk17-1
+# Keep in sync with .env; Ozone 2.0+ needs jdk21 runner (20260106-1-jdk21 is multi-arch arm64+amd64).
+ARG OZONE_RUNNER_VERSION=20260106-1-jdk21
 FROM ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
 
 ARG OZONE_HOME

--- a/dev-support/ranger-docker/docker-compose.ranger-ozone.yml
+++ b/dev-support/ranger-docker/docker-compose.ranger-ozone.yml
@@ -42,14 +42,14 @@ services:
       ranger-solr:
         condition: service_started
     environment:
-      ENSURE_OM_INITIALIZED: /data/metadata/om/current/VERSION
       OZONE_OPTS: -XX:-UseContainerSupport -Dcom.sun.net.ssl.checkRevocation=false
       OZONE_HOME: /opt/hadoop
       OZONE_PLUGIN_VERSION: ${OZONE_PLUGIN_VERSION}
       OZONE_VERSION: ${OZONE_VERSION}
     env_file:
       - ./scripts/ozone/docker-config
-    command: bash -c "/opt/hadoop/ranger-ozone-plugin/ranger-ozone-setup.sh && /opt/hadoop/bin/ozone om"
+    # Ozone 2.1 entrypoint init uses obsolete -createObjectStore fallback; use --init explicitly.
+    command: bash -c "/opt/hadoop/ranger-ozone-plugin/ranger-ozone-setup.sh && (test -f /data/metadata/om/current/VERSION || /opt/hadoop/bin/ozone om --init) && exec /opt/hadoop/bin/ozone om"
   scm:
     image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
     container_name: ozone-scm
@@ -64,9 +64,8 @@ services:
     env_file:
       - ./scripts/ozone/docker-config
     environment:
-      ENSURE_SCM_INITIALIZED: /data/metadata/scm/current/VERSION
       OZONE-SITE.XML_hdds.scm.safemode.min.datanode: "${OZONE_SAFEMODE_MIN_DATANODES:-1}"
-    command: ["/opt/hadoop/bin/ozone","scm"]
+    command: bash -c "(test -f /data/metadata/scm/current/VERSION || /opt/hadoop/bin/ozone scm --init) && exec /opt/hadoop/bin/ozone scm"
 
 networks:
   ranger:

--- a/dev-support/ranger-docker/docker-compose.ranger-ozone.yml
+++ b/dev-support/ranger-docker/docker-compose.ranger-ozone.yml
@@ -9,7 +9,7 @@ services:
       - ranger
     ports:
       - 9864
-    command: ["/opt/hadoop/bin/ozone","datanode"]
+    command: bash -c "sudo mkdir -p /data/hdds /data/metadata && sudo chown -R hadoop:hadoop /data && exec /opt/hadoop/bin/ozone datanode"
     env_file:
       - ./scripts/ozone/docker-config
   om:

--- a/distro/src/main/assembly/plugin-ozone.xml
+++ b/distro/src/main/assembly/plugin-ozone.xml
@@ -116,6 +116,7 @@
                     <include>joda-time:joda-time</include>
                     <include>com.carrotsearch:hppc</include>
                     <include>io.airlift:aircompressor:jar:${aircompressor.version}</include>
+                    <include>javax.annotation:javax.annotation-api</include>
                     <include>javax.inject:javax.inject</include>
                     <include>javax.ws.rs:javax.ws.rs-api</include>
                     <include>org.apache.hadoop.thirdparty:hadoop-shaded-guava:jar:${hadoop-shaded-guava.version}</include>

--- a/distro/src/main/assembly/plugin-ozone.xml
+++ b/distro/src/main/assembly/plugin-ozone.xml
@@ -116,7 +116,7 @@
                     <include>joda-time:joda-time</include>
                     <include>com.carrotsearch:hppc</include>
                     <include>io.airlift:aircompressor:jar:${aircompressor.version}</include>
-                    <include>javax.annotation:javax.annotation-api</include>
+                    <include>javax.annotation:javax.annotation-api:jar:${javax.annotation-api.version}</include>
                     <include>javax.inject:javax.inject</include>
                     <include>javax.ws.rs:javax.ws.rs-api</include>
                     <include>org.apache.hadoop.thirdparty:hadoop-shaded-guava:jar:${hadoop-shaded-guava.version}</include>

--- a/distro/src/main/assembly/plugin-ozone.xml
+++ b/distro/src/main/assembly/plugin-ozone.xml
@@ -86,14 +86,6 @@
                 <directoryMode>755</directoryMode>
                 <fileMode>644</fileMode>
                 <includes>
-                    <include>org.apache.ranger:ranger-audit-core:jar</include>
-                    <include>org.apache.ranger:ranger-audit-dest-auditserver:jar</include>
-                    <include>org.apache.ranger:ranger-authz-api:jar</include>
-                    <include>org.apache.ranger:ranger-common-utils:jar</include>
-                    <include>org.apache.ranger:ranger-ozone-plugin:jar</include>
-                    <include>org.apache.ranger:ranger-plugins-common:jar</include>
-                    <include>org.apache.ranger:ranger-plugins-cred:jar</include>
-                    <include>org.apache.ranger:ugsync-util:jar</include>
                     <include>commons-collections:commons-collections</include>
 		            <include>org.apache.commons:commons-configuration2:jar:${commons.configuration.version}</include>
                     <include>org.eclipse.jetty:jetty-client:jar:${jetty-client.version}</include>

--- a/distro/src/main/assembly/plugin-ozone.xml
+++ b/distro/src/main/assembly/plugin-ozone.xml
@@ -86,6 +86,14 @@
                 <directoryMode>755</directoryMode>
                 <fileMode>644</fileMode>
                 <includes>
+                    <include>org.apache.ranger:ranger-audit-core:jar</include>
+                    <include>org.apache.ranger:ranger-audit-dest-auditserver:jar</include>
+                    <include>org.apache.ranger:ranger-authz-api:jar</include>
+                    <include>org.apache.ranger:ranger-common-utils:jar</include>
+                    <include>org.apache.ranger:ranger-ozone-plugin:jar</include>
+                    <include>org.apache.ranger:ranger-plugins-common:jar</include>
+                    <include>org.apache.ranger:ranger-plugins-cred:jar</include>
+                    <include>org.apache.ranger:ugsync-util:jar</include>
                     <include>commons-collections:commons-collections</include>
 		            <include>org.apache.commons:commons-configuration2:jar:${commons.configuration.version}</include>
                     <include>org.eclipse.jetty:jetty-client:jar:${jetty-client.version}</include>

--- a/plugin-ozone/pom.xml
+++ b/plugin-ozone/pom.xml
@@ -149,6 +149,12 @@ limitations under the License.
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>${javax.annotation-api.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
             <version>${javax.inject.version}</version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Ranger’s Ozone plugin compiles against **Ozone 2.1.0** (`pom.xml`, RANGER-5393 / AssumeRole), but `dev-support/ranger-docker` still ran **Ozone 1.4.0** at runtime after RANGER-5637 (#1006). That mismatch breaks the Ozone Docker / `plugins-docker-build` smoke path:

- **`NoSuchMethodError: RequestContext.getSessionPolicy()`** — plugin bytecode references a 2.1 API; Ozone 1.4 OM classpath has no such method.
- **Missing audit-server destination JARs** — `plugin-ozone.xml` moduleSet must include `ranger-audit-core` / `ranger-audit-dest-auditserver` so they are packaged into `lib/libext/ranger-ozone-plugin-impl/`.
- **Ozone 2.1 compose init** — `ENSURE_*_INITIALIZED` triggers runner entrypoint fallback to obsolete `-createObjectStore` (removed in Ozone 2.1).
- **`javax.annotation.Priority` CNFE** — audit-server JAX-RS on OM needs `javax.annotation-api` as a **runtime Maven dependency** on `plugin-ozone` plus assembly include (assembly `<include>` alone is insufficient).
- **`/data: Operation not permitted` on datanode** — jdk21 `ozone-runner` requires pre-create/chown of `/data` before `ozone datanode`.

This PR:

1. **Bumps Docker Ozone runtime to 2.1.0** — `OZONE_VERSION=2.1.0` in `.env`, aligned with the plugin compile target.
2. **Switches `ozone-runner` to JDK 21** — `OZONE_RUNNER_VERSION=20260106-1-jdk21` (Ozone 2.0+ requires jdk21 runner; multi-arch arm64+amd64). `Dockerfile.ranger-ozone` default ARG kept in sync.
3. **Packages audit-server JARs via moduleSet** — adds `ranger-audit-core`, `ranger-audit-dest-auditserver`, and related Ranger modules to the impl `moduleSet` in `distro/src/main/assembly/plugin-ozone.xml` (same pattern as `hdfs-agent.xml`; redundant duplicate entries in `binaries <includes>` removed).
4. **Fixes Ozone 2.1 Docker compose** — explicit `ozone scm --init` / `ozone om --init`; datanode command pre-creates and `chown`s `/data` for jdk21 runner.
5. **Adds `javax.annotation-api`** — `runtime` dependency in `plugin-ozone/pom.xml` and version-qualified assembly include.

## Commits

| Commit | Summary |
|--------|---------|
| `764b513e2` | Ozone 2.1 `.env`, audit modules in moduleSet, compose `--init` |
| `33c1bd600` | `javax.annotation-api` assembly include |
| `c10983219` | `javax.annotation-api` **pom** runtime dep; datanode `/data` chown |
| `008c88667` | Drop redundant Ranger `:jar` lines from `binaries <includes>` (hdfs-agent parity) |

## Files changed

| File | Change |
|------|--------|
| `dev-support/ranger-docker/.env` | `OZONE_VERSION` 1.4.0 → 2.1.0; runner → `20260106-1-jdk21` |
| `dev-support/ranger-docker/Dockerfile.ranger-ozone` | Sync default `OZONE_RUNNER_VERSION` |
| `dev-support/ranger-docker/docker-compose.ranger-ozone.yml` | Ozone 2.1 `--init`; datanode `/data` chown |
| `plugin-ozone/pom.xml` | `javax.annotation-api` runtime dependency |
| `distro/src/main/assembly/plugin-ozone.xml` | Audit modules in moduleSet; `javax.annotation-api`; hdfs-style binaries filter |

## How was this patch tested?

- **GitHub Actions `plugins-docker-build`** — **pass** (`ozone-scm`, `ozone-datanode`, `ozone-om` up with Ozone 2.1 / jdk21 runner).
- **Local CI-style smoke** (committed non-Kerberos `docker-config`) — all five containers (`ranger`, `ranger-solr`, `ozone-scm`, `ozone-datanode`, `ozone-om`) running; no `javax.annotation.Priority` / `ClassNotFoundException` on OM start.

## Manual testing

Performed on **macOS (Apple Silicon)**:

```bash
cd dev-support/ranger-docker
./download-archives.sh ozone
docker pull apache/ozone-runner:20260106-1-jdk21
export RANGER_DB_TYPE=postgres OZONE_VERSION=2.1.0 OZONE_RUNNER_VERSION=20260106-1-jdk21
./scripts/ozone/ozone-plugin-docker-setup.sh
docker compose -f docker-compose.ranger.yml -f docker-compose.ranger-ozone.yml up -d scm datanode om
```

| Check | Result |
|-------|--------|
| `ozone-scm` / `ozone-om` | **Up** — Ozone **2.1.0**, JDK 21 |
| `ozone-datanode` | **Up** after `/data` chown fix |
| `NoSuchMethodError: getSessionPolicy()` | **Not observed** |
| `ClassNotFoundException: javax.annotation.Priority` | **Not observed** after pom + assembly fix |
| `plugins-docker-build` (CI) | **Pass** |

**Note:** Export `OZONE_VERSION` and `OZONE_RUNNER_VERSION` explicitly if shell env overrides `.env`.

## Test plan (CI / reviewers)

- [x] GitHub Actions `plugins-docker-build` — `ozone-scm`, `ozone-datanode`, `ozone-om` start with Ozone 2.1 / jdk21
- [x] `javax.annotation-api-*.jar` packaged under `lib/libext/ranger-ozone-plugin-impl/` (via `plugin-ozone` pom + assembly)
- [ ] `mvn clean verify` — confirm fat `ranger-*-ozone-plugin.tar.gz` contains `ranger-audit-core-*.jar` and `ranger-audit-dest-auditserver-*.jar` (full reactor build; `-pl distro` alone produces a stub tarball)