### PR TITLE
RANGER-5601: Bump urllib3 to 2.7.0 and requests from 2.32.5 to 2.33.0

### DIFF
--- a/ranger-tools/src/main/python/requirements.txt
+++ b/ranger-tools/src/main/python/requirements.txt
@@ -15,8 +15,8 @@ Pillow==12.2.0
 pyparsing==3.0.9
 python-dateutil==2.8.2
 pytz==2022.2
-requests==2.32.5
+requests==2.33.0
 scipy==1.13.0
 seaborn==0.13.2
 six==1.16.0
-urllib3==2.6.3
+urllib3==2.7.0


### PR DESCRIPTION
## What changes were proposed in this pull request?
Bump urllib3 to 2.7.0 and requests from 2.32.5 to 2.33.0


## How was this patch tested?

Local Build passed and tested peformance analyser script
