### PR TITLE
RANGER-5635: ranger.admin.allow.unauthenticated.download.access is honored only when Kerberos is enabled

### DIFF
--- a/security-admin/src/main/java/org/apache/ranger/biz/RangerBizUtil.java
+++ b/security-admin/src/main/java/org/apache/ranger/biz/RangerBizUtil.java
@@ -23,7 +23,6 @@ import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOCase;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.ranger.authorization.hadoop.config.RangerAdminConfig;
 import org.apache.ranger.common.AppConstants;
 import org.apache.ranger.common.ContextUtil;
@@ -546,22 +545,16 @@ public class RangerBizUtil {
     }
 
     public void failUnauthenticatedIfNotAllowed() throws Exception {
-        if (UserGroupInformation.isSecurityEnabled()) {
-            UserSessionBase currentUserSession = ContextUtil.getCurrentUserSession();
-
-            if (currentUserSession == null && !allowUnauthenticatedAccessInSecureEnvironment) {
-                throw new Exception("Unauthenticated access not allowed");
-            }
+        UserSessionBase currentUserSession = ContextUtil.getCurrentUserSession();
+        if (currentUserSession == null && !allowUnauthenticatedAccessInSecureEnvironment) {
+            throw new Exception("Unauthenticated access not allowed");
         }
     }
 
     public void failUnauthenticatedDownloadIfNotAllowed() throws Exception {
-        if (UserGroupInformation.isSecurityEnabled()) {
-            UserSessionBase currentUserSession = ContextUtil.getCurrentUserSession();
-
-            if (currentUserSession == null && !allowUnauthenticatedDownloadAccessInSecureEnvironment) {
-                throw new Exception("Unauthenticated access not allowed");
-            }
+        UserSessionBase currentUserSession = ContextUtil.getCurrentUserSession();
+        if (currentUserSession == null && !allowUnauthenticatedDownloadAccessInSecureEnvironment) {
+            throw new Exception("Unauthenticated access not allowed");
         }
     }
 

--- a/security-admin/src/test/java/org/apache/ranger/biz/TestRangerBizUtil.java
+++ b/security-admin/src/test/java/org/apache/ranger/biz/TestRangerBizUtil.java
@@ -1191,4 +1191,46 @@ public class TestRangerBizUtil {
         VXResponse vXResponse = new VXResponse();
         Assertions.assertTrue(rangerBizUtil.matchHbasePolicy("t/f/c", resList, vXResponse, 115L, permission));
     }
+
+    @Test
+    void testFailUnauthenticatedDownload_blocksWhenNoSessionAndFlagFalse() {
+        RangerContextHolder.setSecurityContext(null);
+        Assertions.assertThrows(Exception.class, () -> rangerBizUtil.failUnauthenticatedDownloadIfNotAllowed());
+    }
+
+    @Test
+    void testFailUnauthenticatedDownload_allowsWhenSessionPresent() {
+        Assertions.assertDoesNotThrow(() -> rangerBizUtil.failUnauthenticatedDownloadIfNotAllowed());
+    }
+
+    @Test
+    void testFailUnauthenticatedDownload_allowsWhenFlagTrue() throws Exception {
+        RangerContextHolder.setSecurityContext(null);
+        setField("allowUnauthenticatedDownloadAccessInSecureEnvironment", true);
+        Assertions.assertDoesNotThrow(() -> rangerBizUtil.failUnauthenticatedDownloadIfNotAllowed());
+    }
+
+    @Test
+    void testFailUnauthenticated_blocksWhenNoSessionAndFlagFalse() {
+        RangerContextHolder.setSecurityContext(null);
+        Assertions.assertThrows(Exception.class, () -> rangerBizUtil.failUnauthenticatedIfNotAllowed());
+    }
+
+    @Test
+    void testFailUnauthenticated_allowsWhenSessionPresent() {
+        Assertions.assertDoesNotThrow(() -> rangerBizUtil.failUnauthenticatedIfNotAllowed());
+    }
+
+    @Test
+    void testFailUnauthenticated_allowsWhenFlagTrue() throws Exception {
+        RangerContextHolder.setSecurityContext(null);
+        setField("allowUnauthenticatedAccessInSecureEnvironment", true);
+        Assertions.assertDoesNotThrow(() -> rangerBizUtil.failUnauthenticatedIfNotAllowed());
+    }
+
+    private void setField(String name, Object value) throws Exception {
+        Field f = RangerBizUtil.class.getDeclaredField(name);
+        f.setAccessible(true);
+        f.set(rangerBizUtil, value);
+    }
 }

--- a/security-admin/src/test/java/org/apache/ranger/rest/TestServiceREST.java
+++ b/security-admin/src/test/java/org/apache/ranger/rest/TestServiceREST.java
@@ -3837,6 +3837,28 @@ public class TestServiceREST {
         Mockito.verify(restErrorUtil).createRESTException(Mockito.anyInt(), Mockito.anyString(), Mockito.anyBoolean());
     }
 
+    @Test
+    void test155DownloadBlockedWhenUnauthenticatedAndFlagFalse() throws Exception {
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        RangerContextHolder.setSecurityContext(null);                       // no session; flag=false (mock default)
+        Mockito.doCallRealMethod().when(bizUtil).failUnauthenticatedDownloadIfNotAllowed();
+        Mockito.when(restErrorUtil.createRESTException(Mockito.anyInt(), Mockito.anyString(), Mockito.anyBoolean()))
+                .thenReturn(new WebApplicationException());
+        Assertions.assertThrows(WebApplicationException.class, () -> serviceREST.getServicePoliciesIfUpdated("HDFS_1",
+                1L, 0L, "1", "", "", false, capabilityVector, request));
+    }
+
+    @Test
+    void test156GrantBlockedWhenUnauthenticatedAndFlagFalse() throws Exception {
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        GrantRevokeRequest grantRequest = createValidGrantRevokeRequest();
+        Mockito.when(serviceUtil.isValidateHttpsAuthentication("HDFS_1", request)).thenReturn(true); // enter the guarded block
+        Mockito.doCallRealMethod().when(bizUtil).failUnauthenticatedIfNotAllowed();
+        RangerContextHolder.setSecurityContext(null);
+        Mockito.when(restErrorUtil.createRESTException(Mockito.anyString())).thenReturn(new WebApplicationException());
+        Assertions.assertThrows(WebApplicationException.class, () -> serviceREST.grantAccess("HDFS_1", grantRequest, request));
+    }
+
     RangerPolicy rangerPolicy() {
         List<RangerPolicyItemAccess>    accesses         = new ArrayList<>();
         List<String>                    users            = new ArrayList<>();


### PR DESCRIPTION


## What changes were proposed in this pull request?

Enforce ranger.admin.allow.unauthenticated.access and ranger.admin.allow.unauthenticated.download.access regardless of whether Ranger Admin runs with Kerberos, so the configured value is applied consistently. 


## How was this patch tested?

unit tests added
