### PR TITLE
RANGER-5614 : Performance improvement for role create/update with man…

### DIFF
--- a/agents-common/src/main/java/org/apache/ranger/plugin/store/RoleStore.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/store/RoleStore.java
@@ -33,6 +33,15 @@ public interface RoleStore {
 
     RangerRole       updateRole(RangerRole role, Boolean createNonExistUserGroup) throws Exception;
 
+    default RangerRole createRole(RangerRole role, Boolean createNonExistUserGroup, Boolean isRefTableCleanupRequired) throws Exception {
+        return createRole(role, createNonExistUserGroup);
+    }
+
+    default RangerRole updateRole(RangerRole role, Boolean createNonExistUserGroup, Boolean isRefTableCleanupRequired) throws Exception {
+        return updateRole(role, createNonExistUserGroup);
+    }
+
+
     void             deleteRole(String roleName) throws Exception;
 
     void             deleteRole(Long roleId) throws Exception;

--- a/security-admin/src/main/java/org/apache/ranger/biz/PolicyRefUpdater.java
+++ b/security-admin/src/main/java/org/apache/ranger/biz/PolicyRefUpdater.java
@@ -210,6 +210,9 @@ public class PolicyRefUpdater {
             createPrincipalsIfAbsent = false;
         }
 
+        final boolean policyExists = xPolicy != null && xPolicy.getId() != null
+                && daoMgr.getXXPolicy().getCountById(xPolicy.getId()) > 0;
+
         if (CollectionUtils.isNotEmpty(roleNames)) {
             LOG.debug("x_policy_ref_role - New role entries to insert for policy ID {}: {}", policyId, roleNames);
 
@@ -222,7 +225,7 @@ public class PolicyRefUpdater {
 
             for (String roleName : filteredRoleNames) {
                 Long                 roleId     = nameToId.get(roleName);
-                PolicyRoleAssociator associator = new PolicyRoleAssociator(roleName, roleId, xPolicy);
+                PolicyRoleAssociator associator = new PolicyRoleAssociator(roleName, roleId, xPolicy, policyExists);
 
                 if (roleId != null) {
                     XXPolicyRefRole roleRef = associator.getPolicyRef();
@@ -257,7 +260,7 @@ public class PolicyRefUpdater {
 
             for (String groupName : filteredGroupNames) {
                 Long                  groupId    = nameToId.get(groupName);
-                PolicyGroupAssociator associator = new PolicyGroupAssociator(groupName, groupId, xPolicy);
+                PolicyGroupAssociator associator = new PolicyGroupAssociator(groupName, groupId, xPolicy, policyExists);
 
                 if (groupId != null) {
                     XXPolicyRefGroup groupRef = associator.getPolicyRef();
@@ -292,7 +295,7 @@ public class PolicyRefUpdater {
 
             for (String userName : filteredUserNames) {
                 Long                 userId     = nameToId.get(userName);
-                PolicyUserAssociator associator = new PolicyUserAssociator(userName, userId, xPolicy);
+                PolicyUserAssociator associator = new PolicyUserAssociator(userName, userId, xPolicy, policyExists);
 
                 if (userId != null) {
                     XXPolicyRefUser userRef = associator.getPolicyRef();
@@ -551,39 +554,35 @@ public class PolicyRefUpdater {
 
     public enum PRINCIPAL_TYPE { USER, GROUP, ROLE }
 
-    private boolean doesPolicyExist(XXPolicy policy) {
-        return daoMgr.getXXPolicy().getById(policy.getId()) != null;
-    }
-
     private class PolicyRoleAssociator implements Runnable {
         private final String   name;
         private final Long     roleId;
         private final XXPolicy xPolicy;
+        private final boolean  policyExists;
 
-        PolicyRoleAssociator(String name, Long roleId, XXPolicy xPolicy) {
-            this.name    = name;
-            this.roleId  = roleId;
-            this.xPolicy = xPolicy;
+        PolicyRoleAssociator(String name, Long roleId, XXPolicy xPolicy, boolean policyExists) {
+            this.name         = name;
+            this.roleId       = roleId;
+            this.xPolicy      = xPolicy;
+            this.policyExists = policyExists;
         }
 
         public XXPolicyRefRole getPolicyRef() {
-            Long id = resolveRoleId(false);
-
-            if (id != null && doesPolicyExist(xPolicy)) {
-                XXPolicyRefRole xPolRole = new XXPolicyRefRole();
-
-                xPolRole.setPolicyId(xPolicy.getId());
-                xPolRole.setRoleId(id);
-                xPolRole.setRoleName(name);
-
-                return xPolRole;
+            if (!policyExists || roleId == null) {
+                return null;
             }
 
-            return null;
+            XXPolicyRefRole xPolRole = new XXPolicyRefRole();
+
+            xPolRole.setPolicyId(xPolicy.getId());
+            xPolRole.setRoleId(roleId);
+            xPolRole.setRoleName(name);
+
+            return xPolRole;
         }
 
         public void createPolicyRef(Long id) {
-            if (doesPolicyExist(xPolicy)) {
+            if (policyExists) {
                 XXPolicyRefRole xPolRole = new XXPolicyRefRole();
 
                 xPolRole.setPolicyId(xPolicy.getId());
@@ -632,7 +631,7 @@ public class PolicyRefUpdater {
 
             try {
                 RangerRole rRole       = new RangerRole(name, null, null, null, null);
-                RangerRole createdRole = roleStore.createRole(rRole, false);
+                RangerRole createdRole = roleStore.createRole(rRole, false, false);
 
                 return createdRole.getId();
             } catch (Exception e) {
@@ -645,31 +644,31 @@ public class PolicyRefUpdater {
         private final String   name;
         private final Long     groupId;
         private final XXPolicy xPolicy;
+        private final boolean  policyExists;
 
-        PolicyGroupAssociator(String name, Long groupId, XXPolicy xPolicy) {
-            this.name     = name;
-            this.groupId  = groupId;
-            this.xPolicy  = xPolicy;
+        PolicyGroupAssociator(String name, Long groupId, XXPolicy xPolicy, boolean policyExists) {
+            this.name         = name;
+            this.groupId      = groupId;
+            this.xPolicy      = xPolicy;
+            this.policyExists = policyExists;
         }
 
         public XXPolicyRefGroup getPolicyRef() {
-            Long id = resolveGroupId(false);
-
-            if (id != null && doesPolicyExist(xPolicy)) {
-                XXPolicyRefGroup xPolGroup = new XXPolicyRefGroup();
-
-                xPolGroup.setPolicyId(xPolicy.getId());
-                xPolGroup.setGroupId(id);
-                xPolGroup.setGroupName(name);
-
-                return xPolGroup;
+            if (!policyExists || groupId == null) {
+                return null;
             }
 
-            return null;
+            XXPolicyRefGroup xPolGroup = new XXPolicyRefGroup();
+
+            xPolGroup.setPolicyId(xPolicy.getId());
+            xPolGroup.setGroupId(groupId);
+            xPolGroup.setGroupName(name);
+
+            return xPolGroup;
         }
 
         public void createPolicyRef(Long id) {
-            if (doesPolicyExist(xPolicy)) {
+            if (policyExists) {
                 XXPolicyRefGroup xPolGroup = new XXPolicyRefGroup();
 
                 xPolGroup.setPolicyId(xPolicy.getId());
@@ -736,31 +735,31 @@ public class PolicyRefUpdater {
         private final String   name;
         private final Long     userId;
         private final XXPolicy xPolicy;
+        private final boolean  policyExists;
 
-        PolicyUserAssociator(String name, Long userId, XXPolicy xPolicy) {
-            this.name    = name;
-            this.userId  = userId;
-            this.xPolicy = xPolicy;
+        PolicyUserAssociator(String name, Long userId, XXPolicy xPolicy, boolean policyExists) {
+            this.name         = name;
+            this.userId       = userId;
+            this.xPolicy      = xPolicy;
+            this.policyExists = policyExists;
         }
 
         public XXPolicyRefUser getPolicyRef() {
-            Long id = resolveUserId(false);
-
-            if (id != null && doesPolicyExist(xPolicy)) {
-                XXPolicyRefUser xPolUser = new XXPolicyRefUser();
-
-                xPolUser.setPolicyId(xPolicy.getId());
-                xPolUser.setUserId(id);
-                xPolUser.setUserName(name);
-
-                return xPolUser;
+            if (!policyExists || userId == null) {
+                return null;
             }
 
-            return null;
+            XXPolicyRefUser xPolUser = new XXPolicyRefUser();
+
+            xPolUser.setPolicyId(xPolicy.getId());
+            xPolUser.setUserId(userId);
+            xPolUser.setUserName(name);
+
+            return xPolUser;
         }
 
         public void createPolicyRef(Long id) {
-            if (doesPolicyExist(xPolicy)) {
+            if (policyExists) {
                 XXPolicyRefUser xPolUser = new XXPolicyRefUser();
 
                 xPolUser.setPolicyId(xPolicy.getId());

--- a/security-admin/src/main/java/org/apache/ranger/biz/RoleDBStore.java
+++ b/security-admin/src/main/java/org/apache/ranger/biz/RoleDBStore.java
@@ -109,6 +109,16 @@ public class RoleDBStore implements RoleStore {
 
     @Override
     public RangerRole createRole(RangerRole role, Boolean createNonExistUserGroupRole) throws Exception {
+        return createRole(role, createNonExistUserGroupRole, false);
+    }
+
+    @Override
+    public RangerRole updateRole(RangerRole role, Boolean createNonExistUserGroupRole) throws Exception {
+        return updateRole(role, createNonExistUserGroupRole, true);
+    }
+
+    @Override
+    public RangerRole createRole(RangerRole role, Boolean createNonExistUserGroupRole, Boolean isRefTableCleanupRequired) throws Exception {
         if (LOG.isDebugEnabled()) {
             LOG.debug("==> RoleDBStore.createRole()");
         }
@@ -128,14 +138,14 @@ public class RoleDBStore implements RoleStore {
             throw new Exception("Cannot create role:[" + role + "]");
         }
 
-        roleRefUpdater.createNewRoleMappingForRefTable(createdRole, createNonExistUserGroupRole);
+        roleRefUpdater.createNewRoleMappingForRefTable(createdRole, createNonExistUserGroupRole, isRefTableCleanupRequired);
 
         roleService.createTransactionLog(createdRole, null, RangerBaseModelService.OPERATION_CREATE_CONTEXT);
         return createdRole;
     }
 
     @Override
-    public RangerRole updateRole(RangerRole role, Boolean createNonExistUserGroupRole) throws Exception {
+    public RangerRole updateRole(RangerRole role, Boolean createNonExistUserGroupRole, Boolean isRefTableCleanupRequired) throws Exception {
         XXRole xxRole = daoMgr.getXXRole().findByRoleId(role.getId());
         if (xxRole == null) {
             throw restErrorUtil.createRESTException("role with id: " + role.getId() + " does not exist");
@@ -158,7 +168,7 @@ public class RoleDBStore implements RoleStore {
             throw new Exception("Cannot update role:[" + role + "]");
         }
 
-        roleRefUpdater.createNewRoleMappingForRefTable(updatedRole, createNonExistUserGroupRole);
+        roleRefUpdater.createNewRoleMappingForRefTable(updatedRole, createNonExistUserGroupRole, isRefTableCleanupRequired);
 
         roleService.updatePolicyVersions(updatedRole.getId());
 

--- a/security-admin/src/main/java/org/apache/ranger/biz/RoleRefUpdater.java
+++ b/security-admin/src/main/java/org/apache/ranger/biz/RoleRefUpdater.java
@@ -19,15 +19,12 @@
 
 package org.apache.ranger.biz;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.ranger.common.MessageEnums;
 import org.apache.ranger.common.RESTErrorUtil;
 import org.apache.ranger.common.RangerCommonEnums;
+import org.apache.ranger.common.db.BaseDao;
 import org.apache.ranger.common.db.RangerTransactionSynchronizationAdapter;
 import org.apache.ranger.db.RangerDaoManager;
 import org.apache.ranger.db.XXRoleRefGroupDao;
@@ -48,19 +45,27 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import static org.apache.ranger.service.RangerBaseModelService.OPERATION_CREATE_CONTEXT;
 
 @Component
 public class RoleRefUpdater {
-	private static final Logger LOG = LoggerFactory.getLogger(RoleRefUpdater.class);
+    private static final Logger LOG = LoggerFactory.getLogger(RoleRefUpdater.class);
 
-	@Autowired
-	RangerDaoManager daoMgr;
+    @Autowired
+    RangerDaoManager daoMgr;
 
-	@Autowired
-	RESTErrorUtil restErrorUtil;
+    @Autowired
+    RESTErrorUtil restErrorUtil;
 
-	@Autowired
+    @Autowired
     XUserMgr xUserMgr;
 
     @Autowired
@@ -69,315 +74,619 @@ public class RoleRefUpdater {
     @Autowired
     RangerTransactionSynchronizationAdapter rangerTransactionSynchronizationAdapter;
 
-	@Autowired
-	RoleDBStore roleStore;
+    @Autowired
+    RoleDBStore roleStore;
 
-	@Autowired
-	RangerBizUtil xaBizUtil;
-	public RangerDaoManager getRangerDaoManager() {
-		return daoMgr;
-	}
-	public void createNewRoleMappingForRefTable(RangerRole rangerRole, Boolean createNonExistUserGroupRole) {
-		if (rangerRole == null) {
-			return;
-		}
+    @Autowired
+    RangerBizUtil xaBizUtil;
 
-		cleanupRefTables(rangerRole);
-		final Long roleId = rangerRole.getId();
+    public RangerDaoManager getRangerDaoManager() {
+        return daoMgr;
+    }
 
-		final Set<String> roleUsers = new HashSet<>();
-		final Set<String> roleGroups = new HashSet<>();
-		final Set<String> roleRoles = new HashSet<>();
+    public void createNewRoleMappingForRefTable(RangerRole rangerRole, Boolean createNonExistUserGroupRole, Boolean isRefTableCleanupRequired) {
+        if (rangerRole == null) {
+            return;
+        }
 
-		for (RangerRole.RoleMember user : rangerRole.getUsers()) {
-			roleUsers.add(user.getName());
-		}
-		for (RangerRole.RoleMember group : rangerRole.getGroups()) {
-			roleGroups.add(group.getName());
-		}
-		for (RangerRole.RoleMember role : rangerRole.getRoles()) {
-			roleRoles.add(role.getName());
-		}
+        boolean oldBulkMode = RangerBizUtil.isBulkMode();
 
-		final boolean isCreateNonExistentUGRs = createNonExistUserGroupRole && xaBizUtil.checkAdminAccess();
+        final Long        roleId      = rangerRole.getId();
+        final boolean     roleExists  = roleId != null;
+        final Set<String> roleUsers   = new HashSet<>();
+        final Set<String> roleGroups = new HashSet<>();
+        final Set<String> roleRoles  = new HashSet<>();
 
-		if (CollectionUtils.isNotEmpty(roleUsers)) {
-			for (String roleUser : roleUsers) {
+        for (RangerRole.RoleMember user : rangerRole.getUsers()) {
+            roleUsers.add(user.getName());
+        }
 
-				if (StringUtils.isBlank(roleUser)) {
-					continue;
-				}
-				RolePrincipalAssociator associator = new RolePrincipalAssociator(PolicyRefUpdater.PRINCIPAL_TYPE.USER, roleUser, roleId);
+        for (RangerRole.RoleMember group : rangerRole.getGroups()) {
+            roleGroups.add(group.getName());
+        }
 
-				if (!associator.doAssociate(false)) {
-					if (isCreateNonExistentUGRs) {
-						rangerTransactionSynchronizationAdapter.executeOnTransactionCommit(associator);
-					} else {
-						throw restErrorUtil.createRESTException("user with name: " + roleUser + " does not exist ", MessageEnums.INVALID_INPUT_DATA);
-					}
-				}
-			}
-		}
+        for (RangerRole.RoleMember role : rangerRole.getRoles()) {
+            roleRoles.add(role.getName());
+        }
 
-		if (CollectionUtils.isNotEmpty(roleGroups)) {
-			for (String roleGroup : roleGroups) {
+        if (isRefTableCleanupRequired) {
+            cleanupRefTablesForUpdate(rangerRole, roleUsers, roleGroups, roleRoles);
+        }
 
-				if (StringUtils.isBlank(roleGroup)) {
-					continue;
-				}
-				RolePrincipalAssociator associator = new RolePrincipalAssociator(PolicyRefUpdater.PRINCIPAL_TYPE.GROUP, roleGroup, roleId);
+        final boolean isCreateNonExistentUGRs = createNonExistUserGroupRole && xaBizUtil.checkAdminAccess();
 
-				if (!associator.doAssociate(false)) {
-					if (isCreateNonExistentUGRs) {
-						rangerTransactionSynchronizationAdapter.executeOnTransactionCommit(associator);
-					} else {
-						throw restErrorUtil.createRESTException("Group with name: " + roleGroup + " does not exist ", MessageEnums.INVALID_INPUT_DATA);
-					}
-				}
-			}
-		}
+        if (CollectionUtils.isNotEmpty(roleUsers)) {
+            LOG.debug("New user entries to be inserted into x_role_ref_user for role ID {}: {}", roleId, roleUsers);
 
-		if (CollectionUtils.isNotEmpty(roleRoles)) {
-			for (String roleRole : roleRoles) {
+            Set<String> filteredUserNames = roleUsers.stream()
+                    .filter(StringUtils::isNotBlank)
+                    .collect(Collectors.toSet());
 
-				if (StringUtils.isBlank(roleRole)) {
-					continue;
-				}
+            List<XXRoleRefUser> xxRoleRefUsers = new ArrayList<>();
+            Map<String, Long>   userNameIdMap  = daoMgr.getXXUser().getIdsByUserNames(filteredUserNames);
 
-				RolePrincipalAssociator associator = new RolePrincipalAssociator(PolicyRefUpdater.PRINCIPAL_TYPE.ROLE, roleRole, roleId);
+            for (String userName : filteredUserNames) {
+                Long               userId      = userNameIdMap.get(userName);
+                RoleUserAssociator associator = new RoleUserAssociator(userName, userId, roleId, roleExists);
 
-				if (!associator.doAssociate(false)) {
-					if (isCreateNonExistentUGRs) {
-						rangerTransactionSynchronizationAdapter.executeOnTransactionCommit(associator);
-					} else {
-						throw restErrorUtil.createRESTException("Role with name: " + roleRole + " does not exist ", MessageEnums.INVALID_INPUT_DATA);
-					}
-				}
-			}
-		}
+                if (userId != null) {
+                    XXRoleRefUser userRef = associator.getRoleRef();
 
-	}
+                    if (userRef != null) {
+                        xxRoleRefUsers.add(userRef);
+                    }
+                } else if (isCreateNonExistentUGRs) {
+                    rangerTransactionSynchronizationAdapter.executeOnTransactionCommit(associator);
+                } else {
+                    throw restErrorUtil.createRESTException("user with name: " + userName + " does not exist ", MessageEnums.INVALID_INPUT_DATA);
+                }
+            }
 
-	public Boolean cleanupRefTables(RangerRole rangerRole) {
-		final Long roleId = rangerRole.getId();
+            batchInsert(xxRoleRefUsers, daoMgr.getXXRoleRefUser(), oldBulkMode);
+        }
 
-		if (roleId == null) {
-			return false;
-		}
+        if (CollectionUtils.isNotEmpty(roleGroups)) {
+            LOG.debug("New group entries to be inserted into x_role_ref_group for role ID {}: {}", roleId, roleGroups);
 
-		XXRoleRefUserDao xRoleUserDao = daoMgr.getXXRoleRefUser();
-		XXRoleRefGroupDao xRoleGroupDao = daoMgr.getXXRoleRefGroup();
-		XXRoleRefRoleDao xRoleRoleDao = daoMgr.getXXRoleRefRole();
+            Set<String> filteredGroupNames = roleGroups.stream()
+                    .filter(StringUtils::isNotBlank)
+                    .collect(Collectors.toSet());
 
-		List<Long> xxRoleRefUserIds = xRoleUserDao.findIdsByRoleId(roleId);
-		xRoleUserDao.deleteRoleRefUserByIds(xxRoleRefUserIds);
+            List<XXRoleRefGroup> xxRoleRefGroups = new ArrayList<>();
+            Map<String, Long>    groupNameIdMap = daoMgr.getXXGroup().getIdsByGroupNames(filteredGroupNames);
 
-		List<Long> xxRoleRefGroupByIds = xRoleGroupDao.findIdsByRoleId(roleId);
-		xRoleGroupDao.deleteRoleRefGroupByIds(xxRoleRefGroupByIds);
+            for (String groupName : filteredGroupNames) {
+                Long                groupId     = groupNameIdMap.get(groupName);
+                RoleGroupAssociator associator = new RoleGroupAssociator(groupName, groupId, roleId, roleExists);
 
-		List<Long> xxRoleRefRoleIds = xRoleRoleDao.findIdsByRoleId(roleId);
-		xRoleRoleDao.deleteRoleRefRoleByIds(xxRoleRefRoleIds);
+                if (groupId != null) {
+                    XXRoleRefGroup groupRef = associator.getRoleRef();
 
-		return true;
-	}
+                    if (groupRef != null) {
+                        xxRoleRefGroups.add(groupRef);
+                    }
+                } else if (isCreateNonExistentUGRs) {
+                    rangerTransactionSynchronizationAdapter.executeOnTransactionCommit(associator);
+                } else {
+                    throw restErrorUtil.createRESTException("Group with name: " + groupName + " does not exist ", MessageEnums.INVALID_INPUT_DATA);
+                }
+            }
 
-	private class RolePrincipalAssociator implements Runnable {
-		final PolicyRefUpdater.PRINCIPAL_TYPE type;
-		final String                     name;
-		final Long                       roleId;
+            batchInsert(xxRoleRefGroups, daoMgr.getXXRoleRefGroup(), oldBulkMode);
+        }
 
-		public RolePrincipalAssociator(PolicyRefUpdater.PRINCIPAL_TYPE type, String name, Long roleId) {
-			this.type    = type;
-			this.name    = name;
-			this.roleId  = roleId;
-		}
+        if (CollectionUtils.isNotEmpty(roleRoles)) {
+            LOG.debug("New sub role entries to be inserted into x_role_ref_role for role ID {}: {}", roleId, roleRoles);
 
-		@Override
-		public void run() {
-			if (doAssociate(true)) {
-				if (LOG.isDebugEnabled()) {
-					LOG.debug("Associated " + type.name() + ":" + name + " with role id:[" + roleId + "]");
-				}
-			} else {
-				throw new RuntimeException("Failed to associate " + type.name() + ":" + name + " with role id:[" + roleId + "]");
-			}
-		}
+            Set<String> filteredSubRoleNames = roleRoles.stream()
+                    .filter(StringUtils::isNotBlank)
+                    .collect(Collectors.toSet());
 
-		boolean doAssociate(boolean isAdmin) {
-			if (LOG.isDebugEnabled()) {
-				LOG.debug("===> RolePrincipalAssociator.doAssociate(" + isAdmin + ")");
-			}
-			final boolean ret;
+            List<XXRoleRefRole> xxRoleRefRoles = new ArrayList<>();
+            Map<String, Long>   subRoleNameIdMap = daoMgr.getXXRole().getIdsByRoleNames(filteredSubRoleNames);
 
-			Long id = createOrGetPrincipal(isAdmin);
-			if (id != null) {
-				// associate with role
-				createRoleAssociation(id, name);
-				ret = true;
-			} else {
-				ret = false;
-			}
+            for (String subRoleName : filteredSubRoleNames) {
+                Long               subRoleId  = subRoleNameIdMap.get(subRoleName);
+                RoleRoleAssociator associator = new RoleRoleAssociator(subRoleName, subRoleId, roleId, roleExists);
 
-			if (LOG.isDebugEnabled()) {
-				LOG.debug("<=== RolePrincipalAssociator.doAssociate(" + isAdmin + ") : " + ret);
-			}
-			return ret;
-		}
+                if (subRoleId != null) {
+                    XXRoleRefRole roleRef = associator.getRoleRef();
 
-		private Long createOrGetPrincipal(final boolean createIfAbsent) {
-			if (LOG.isDebugEnabled()) {
-				LOG.debug("===> RolePrincipalAssociator.createOrGetPrincipal(" + createIfAbsent + ")");
-			}
+                    if (roleRef != null) {
+                        xxRoleRefRoles.add(roleRef);
+                    }
+                } else if (isCreateNonExistentUGRs) {
+                    rangerTransactionSynchronizationAdapter.executeOnTransactionCommit(associator);
+                } else {
+                    throw restErrorUtil.createRESTException("Role with name: " + subRoleName + " does not exist ", MessageEnums.INVALID_INPUT_DATA);
+                }
+            }
 
-			Long ret = null;
+            batchInsert(xxRoleRefRoles, daoMgr.getXXRoleRefRole(), oldBulkMode);
+        }
+    }
 
-			switch (type) {
-				case USER: {
-					XXUser xUser = daoMgr.getXXUser().findByUserName(name);
-					if (xUser != null) {
-						ret = xUser.getId();
-					} else {
-						if (createIfAbsent) {
-							ret = createPrincipal(name);
-						}
-					}
-				}
-				break;
-				case GROUP: {
-					XXGroup xGroup = daoMgr.getXXGroup().findByGroupName(name);
+    public Boolean cleanupRefTables(RangerRole rangerRole) {
+        final Long roleId = rangerRole.getId();
 
-					if (xGroup != null) {
-						ret = xGroup.getId();
-					} else {
-						if (createIfAbsent) {
-							ret = createPrincipal(name);
-						}
-					}
-				}
-				break;
-				case ROLE: {
-					XXRole xRole = daoMgr.getXXRole().findByRoleName(name);
-					if (xRole != null) {
-						ret = xRole.getId();
-					} else {
-						if (createIfAbsent) {
-							RangerBizUtil.setBulkMode(false);
-							ret = createPrincipal(name);
-						}
-					}
-				}
-				break;
-				default:
-					break;
-			}
-			if (LOG.isDebugEnabled()) {
-				LOG.debug("<=== RolePrincipalAssociator.createOrGetPrincipal(" + createIfAbsent + ") : " + ret);
-			}
-			return ret;
-		}
+        if (roleId == null) {
+            return false;
+        }
 
-		private Long createPrincipal(String user) {
-			LOG.warn(type.name()+" specified in role does not exist in ranger admin, creating new "+type.name()+", Type: " + type.name() + ", name = " + user);
+        XXRoleRefUserDao  xRoleUserDao  = daoMgr.getXXRoleRefUser();
+        XXRoleRefGroupDao xRoleGroupDao = daoMgr.getXXRoleRefGroup();
+        XXRoleRefRoleDao  xRoleRoleDao  = daoMgr.getXXRoleRefRole();
 
-			if (LOG.isDebugEnabled()) {
-				LOG.debug("===> RolePrincipalAssociator.createPrincipal(type=" + type.name() +", name=" + name + ")");
-			}
+        List<Long> xxRoleRefUserIds = xRoleUserDao.findIdsByRoleId(roleId);
 
-			Long ret = null;
+        xRoleUserDao.deleteRoleRefUserByIds(xxRoleRefUserIds);
 
-			switch (type) {
-				case USER: {
-					// Create External user
-					VXUser vXUser = xUserMgr.createServiceConfigUser(name);
-					if (vXUser != null) {
-						XXUser xUser = daoMgr.getXXUser().findByUserName(name);
+        List<Long> xxRoleRefGroupByIds = xRoleGroupDao.findIdsByRoleId(roleId);
 
-						if (xUser == null) {
-							LOG.error("No User created!! Irrecoverable error! [" + name + "]");
-						} else {
-							ret = xUser.getId();
-						}
-					} else {
-						LOG.warn("serviceConfigUser:[" + name + "] creation failed. This may be a transient/spurious condition that may correct itself when transaction is committed");
-					}
-				}
-				break;
-				case GROUP: {
-					// Create group
-					VXGroup vxGroup = new VXGroup();
-					vxGroup.setName(name);
-					vxGroup.setDescription(name);
-					vxGroup.setGroupSource(RangerCommonEnums.GROUP_EXTERNAL);
-					VXGroup vXGroup = xGroupService.createXGroupWithOutLogin(vxGroup);
-					if (vXGroup != null) {
-						xGroupService.createTransactionLog(vXGroup, null, OPERATION_CREATE_CONTEXT);
+        xRoleGroupDao.deleteRoleRefGroupByIds(xxRoleRefGroupByIds);
 
-						ret = vXGroup.getId();
-					}
-				}
-				break;
-				case ROLE: {
-					// Create role
-					try {
-						RangerRole rRole = new RangerRole(name, null, null, null, null);
-						RangerRole createdRole = roleStore.createRole(rRole, false);
-						ret = createdRole.getId();
-					} catch (Exception e) {
-						LOG.error("Failed to create Role "+ type.name());
-					}
-				}
-				break;
-				default:
-					break;
-			}
-			if (LOG.isDebugEnabled()) {
-				LOG.debug("<=== RolePrincipalAssociator.createPrincipal(type=" + type.name() + ", name=" + name + ") : " + ret);
-			}
-			return ret;
-		}
+        List<Long> xxRoleRefRoleIds = xRoleRoleDao.findIdsByRoleId(roleId);
 
-		private void createRoleAssociation(Long id, String name) {
-			if(LOG.isDebugEnabled()) {
-				LOG.debug("===> RolePrincipalAssociator.createRoleAssociation(roleId=" + roleId + ", type=" + type.name() + ", name=" + name + ", id=" + id + ")");
-			}
-			switch (type) {
-				case USER: {
-					XXRoleRefUser xRoleRefUser = new XXRoleRefUser();
+        xRoleRoleDao.deleteRoleRefRoleByIds(xxRoleRefRoleIds);
 
-					xRoleRefUser.setRoleId(roleId);
-					xRoleRefUser.setUserId(id);
-					xRoleRefUser.setUserName(name);
-					xRoleRefUser.setUserType(0);
-					daoMgr.getXXRoleRefUser().create(xRoleRefUser);
-				}
-				break;
-				case GROUP: {
-					XXRoleRefGroup xRoleRefGroup = new XXRoleRefGroup();
+        return true;
+    }
 
-					xRoleRefGroup.setRoleId(roleId);
-					xRoleRefGroup.setGroupId(id);
-					xRoleRefGroup.setGroupName(name);
-					xRoleRefGroup.setGroupType(0);
-					daoMgr.getXXRoleRefGroup().create(xRoleRefGroup);
-				}
-				break;
-				case ROLE: {
-					XXRoleRefRole xRoleRefRole = new XXRoleRefRole();
+    public Boolean cleanupRefTablesForUpdate(RangerRole rangerRole, Set<String> roleUsers, Set<String> roleGroups, Set<String> roleRoles) {
+        final Long roleId = rangerRole.getId();
+        if (roleId == null) {
+            return false;
+        }
 
-					xRoleRefRole.setRoleId(roleId);
-					xRoleRefRole.setSubRoleId(id);
-					xRoleRefRole.setSubRoleName(name);
-					xRoleRefRole.setSubRoleType(0);
-					daoMgr.getXXRoleRefRole().create(xRoleRefRole);
-				}
-				break;
-				default:
-					break;
-			}
-			if(LOG.isDebugEnabled()) {
-				LOG.debug("<=== RolePrincipalAssociator.createRoleAssociation(roleId=" + roleId + ", type=" + type.name() + ", name=" + name + ", id=" + id + ")");
-			}
-		}
-	}
+        cleanupRoleUsers(roleUsers, roleId, daoMgr.getXXRoleRefUser());
+        cleanupRoleGroups(roleGroups, roleId, daoMgr.getXXRoleRefGroup());
+        cleanupRoleRoles(roleRoles, roleId, daoMgr.getXXRoleRefRole());
 
+        return true;
+    }
+
+    /**
+     * Synchronizes the role-user associations for a given role by identifying and removing
+     * users who are no longer associated with the role in the incoming data.
+     * <p>
+     * This method compares the current set of users assigned to the role (`roleUsers`)
+     * with the existing role-user mappings stored in the database (`userNameIdMap`).
+     * It determines which users should be deleted (present in the DB but not in `roleUsers`)
+     * and removes their associations using the DAO.
+     * <p>
+     * After execution:
+     * <ul>
+     *   <li>Users present in both the database and `roleUsers` (i.e., common users) are left unchanged.</li>
+     *   <li>Users present in the database but not in `roleUsers` are deleted.</li>
+     *   <li>The `roleUsers` set is modified to remove users that are already associated, leaving only new users to be inserted (if needed later).</li>
+     * </ul>
+     *
+     * @param roleUsers      Set of usernames that should be currently associated with the role.
+     *                       This is the source of truth, typically coming from an external request.
+     * @param roleId         ID of the role for which the cleanup is being performed.
+     * @param dao            DAO for role reference users.
+     */
+    private void cleanupRoleUsers(Set<String> roleUsers, Long roleId, XXRoleRefUserDao dao) {
+        Map<String, Long> userNameIdMap = dao.findUserNameIdMapByRoleId(roleId);
+        if (userNameIdMap != null && !userNameIdMap.isEmpty()) {
+            Set<String> existingUsers = userNameIdMap.keySet();
+            Set<String> toDeleteUsers = new HashSet<>(existingUsers);
+            Set<String> commonUsers = new HashSet<>(roleUsers);
+
+            // Identify users present in both new and existing sets
+            commonUsers.retainAll(toDeleteUsers);
+
+            // Identify users to delete (in DB but not in new set)
+            toDeleteUsers.removeAll(commonUsers);
+
+            // Remove already existing users from the new set (they don’t need to be inserted again)
+            roleUsers.removeAll(commonUsers);
+            if (CollectionUtils.isNotEmpty(toDeleteUsers)) {
+                List<Long> idsToDelete = toDeleteUsers.stream()
+                        .map(userNameIdMap::get)
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toList());
+
+                LOG.debug("Deleting user IDs from x_role_ref_user table: {} for role ID: {}", idsToDelete, roleId);
+                dao.deleteRoleRefUserByIds(idsToDelete);
+            }
+        }
+    }
+
+    /**
+     * Synchronizes role-group associations for a given role by identifying and removing
+     * groups that are no longer associated with the role in the incoming data.
+     * <p>
+     * This method compares the current set of groups that should be associated with a role
+     * (`roleGroups`) against the existing group-role mappings from the database (`groupNameIdMap`).
+     * It determines which group associations should be deleted (present in DB but not in input set),
+     * and deletes those associations using the DAO.
+     * <p>
+     * After execution:
+     * <ul>
+     *   <li>Groups present in both the input and DB (i.e., common groups) are preserved.</li>
+     *   <li>Groups present in the DB but not in the input set are deleted.</li>
+     *   <li>The `roleGroups` input set is modified to only include new groups to be inserted later (if any).</li>
+     * </ul>
+     *
+     * @param roleGroups       Set of group names that should be associated with the role.
+     *                         This is the latest source of truth (e.g., from an API or external input).
+     * @param roleId           The ID of the role for which associations are being synced.
+     * @param dao              DAO for role reference groups.
+     */
+    private void cleanupRoleGroups(Set<String> roleGroups, Long roleId, XXRoleRefGroupDao dao) {
+        Map<String, Long> groupNameIdMap = dao.findGroupNameIdByRoleId(roleId);
+        if (groupNameIdMap != null && !groupNameIdMap.isEmpty()) {
+            // All groups currently associated in the DB
+            Set<String> existingGroups = groupNameIdMap.keySet();
+
+            // Create a mutable set to track deletions
+            Set<String> toDeleteGroups = new HashSet<>(existingGroups);
+
+            // Identify common groups between input and existing
+            Set<String> commonGroups = new HashSet<>(roleGroups);
+            commonGroups.retainAll(toDeleteGroups);
+
+            // Remove common groups from both sets to isolate only new and obsolete entries
+            toDeleteGroups.removeAll(commonGroups); // only those to be deleted
+            roleGroups.removeAll(commonGroups);     // only those to be newly inserted
+
+            if (CollectionUtils.isNotEmpty(toDeleteGroups)) {
+                List<Long> idsToDelete = toDeleteGroups.stream()
+                        .map(groupNameIdMap::get)
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toList());
+
+                LOG.debug("Deleting group IDs from x_role_ref_group table: {} for role ID: {}", idsToDelete, roleId);
+                dao.deleteRoleRefGroupByIds(idsToDelete);
+            }
+        }
+    }
+
+    /**
+     * Synchronizes sub-role associations for a given parent role by identifying and removing
+     * sub-roles that are no longer associated with the parent role in the incoming data.
+     * <p>
+     * This method compares the current set of sub-roles that should be associated with a role
+     * (`roleRoles`) against the existing role-role mappings stored in the database (`subRoleNameIdMap`).
+     * It determines which sub-role associations should be removed (those present in the DB but not in the new set)
+     * and deletes them using the provided DAO.
+     * <p>
+     * After execution:
+     * <ul>
+     *   <li>Sub-roles that are present in both the input set and DB (common roles) are preserved.</li>
+     *   <li>Sub-roles that are present in the DB but missing from the input set are deleted.</li>
+     *   <li>The input set `roleRoles` is modified to retain only new sub-roles that may be inserted later.</li>
+     * </ul>
+     *
+     * @param roleRoles         A set of sub-role names that should currently be associated with the parent role.
+     *                          This represents the latest state (e.g., from an external request).
+     * @param roleId            The ID of the parent role for which sub-role associations are being updated.
+     * @param dao               DAO for role reference roles.
+     */
+    private void cleanupRoleRoles(Set<String> roleRoles, Long roleId, XXRoleRefRoleDao dao) {
+        Map<String, Long> subRoleNameIdMap = dao.findSubRoleNameIdByRoleId(roleId);
+        if (subRoleNameIdMap != null && !subRoleNameIdMap.isEmpty()) {
+            // Get the current set of associated sub-roles from DB
+            Set<String> existingRoles = subRoleNameIdMap.keySet();
+
+            // Prepare to identify obsolete sub-roles
+            Set<String> toDeleteRoles = new HashSet<>(existingRoles);
+
+            // Identify roles that are common in both new and existing sets
+            Set<String> commonRoles = new HashSet<>(roleRoles);
+            commonRoles.retainAll(toDeleteRoles);
+
+            // Remove common roles from the deletion list and the new input set
+            toDeleteRoles.removeAll(commonRoles);
+            roleRoles.removeAll(commonRoles);
+
+            // Delete obsolete sub-role associations
+            if (!toDeleteRoles.isEmpty()) {
+                List<Long> idsToDelete = toDeleteRoles.stream()
+                        .map(subRoleNameIdMap::get)
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toList());
+
+                LOG.debug("Deleting role IDs from x_role_ref_role table: {} for role ID: {}", idsToDelete, roleId);
+                dao.deleteRoleRefRoleByIds(idsToDelete);
+            }
+        }
+    }
+
+    private class RoleUserAssociator implements Runnable {
+        private final String  name;
+        private final Long    userId;
+        private final Long    roleId;
+        private final boolean roleExists;
+
+        RoleUserAssociator(String name, Long userId, Long roleId, boolean roleExists) {
+            this.name       = name;
+            this.userId     = userId;
+            this.roleId     = roleId;
+            this.roleExists = roleExists;
+        }
+
+        public XXRoleRefUser getRoleRef() {
+            Long id = resolveUserId(false);
+
+            if (id != null && roleExists) {
+                XXRoleRefUser xRoleRefUser = new XXRoleRefUser();
+
+                xRoleRefUser.setRoleId(roleId);
+                xRoleRefUser.setUserId(id);
+                xRoleRefUser.setUserName(name);
+                xRoleRefUser.setUserType(0);
+
+                return xRoleRefUser;
+            }
+
+            return null;
+        }
+
+        public void createRoleRef(Long id) {
+            if (roleExists) {
+                XXRoleRefUser xRoleRefUser = new XXRoleRefUser();
+
+                xRoleRefUser.setRoleId(roleId);
+                xRoleRefUser.setUserId(id);
+                xRoleRefUser.setUserName(name);
+                xRoleRefUser.setUserType(0);
+
+                daoMgr.getXXRoleRefUser().create(xRoleRefUser);
+            } else {
+                LOG.info("Role with id ={} does not exist, skipping role association!", roleId);
+            }
+        }
+
+        @Override
+        public void run() {
+            Long id = resolveUserId(true);
+
+            if (id != null) {
+                createRoleRef(id);
+
+                LOG.debug("Associated USER:{} with role id:[{}]", name, roleId);
+            } else {
+                throw new RuntimeException("Failed to associate USER:" + name + " with role id:[" + roleId + "]");
+            }
+        }
+
+        private Long resolveUserId(boolean createIfAbsent) {
+            Long ret = userId;
+
+            if (ret == null) {
+                XXUser xUser = daoMgr.getXXUser().findByUserName(name);
+
+                if (xUser != null) {
+                    ret = xUser.getId();
+                } else if (createIfAbsent) {
+                    ret = createUser();
+                }
+            }
+
+            return ret;
+        }
+
+        private Long createUser() {
+            LOG.warn("User specified in role does not exist in ranger admin, creating new user, name = {}", name);
+
+            VXUser vXUser = xUserMgr.createServiceConfigUser(name);
+
+            if (vXUser != null) {
+                XXUser xUser = daoMgr.getXXUser().findByUserName(name);
+
+                if (xUser == null) {
+                    LOG.error("No User created!! Irrecoverable error! [{}]", name);
+                } else {
+                    return xUser.getId();
+                }
+            } else {
+                LOG.warn("serviceConfigUser:[{}] creation failed. This may be a transient/spurious condition that may correct itself when transaction is committed", name);
+            }
+
+            return null;
+        }
+    }
+
+    private class RoleGroupAssociator implements Runnable {
+        private final String  name;
+        private final Long    groupId;
+        private final Long    roleId;
+        private final boolean roleExists;
+
+        RoleGroupAssociator(String name, Long groupId, Long roleId, boolean roleExists) {
+            this.name       = name;
+            this.groupId    = groupId;
+            this.roleId     = roleId;
+            this.roleExists = roleExists;
+        }
+
+        public XXRoleRefGroup getRoleRef() {
+            Long id = resolveGroupId(false);
+
+            if (id != null && roleExists) {
+                XXRoleRefGroup xRoleRefGroup = new XXRoleRefGroup();
+
+                xRoleRefGroup.setRoleId(roleId);
+                xRoleRefGroup.setGroupId(id);
+                xRoleRefGroup.setGroupName(name);
+                xRoleRefGroup.setGroupType(0);
+
+                return xRoleRefGroup;
+            }
+
+            return null;
+        }
+
+        public void createRoleRef(Long id) {
+            if (roleExists) {
+                XXRoleRefGroup xRoleRefGroup = new XXRoleRefGroup();
+
+                xRoleRefGroup.setRoleId(roleId);
+                xRoleRefGroup.setGroupId(id);
+                xRoleRefGroup.setGroupName(name);
+                xRoleRefGroup.setGroupType(0);
+
+                daoMgr.getXXRoleRefGroup().create(xRoleRefGroup);
+            } else {
+                LOG.info("Role with id ={} does not exist, skipping role association!", roleId);
+            }
+        }
+
+        @Override
+        public void run() {
+            Long id = resolveGroupId(true);
+
+            if (id != null) {
+                createRoleRef(id);
+
+                LOG.debug("Associated GROUP:{} with role id:[{}]", name, roleId);
+            } else {
+                throw new RuntimeException("Failed to associate GROUP:" + name + " with role id:[" + roleId + "]");
+            }
+        }
+
+        private Long resolveGroupId(boolean createIfAbsent) {
+            Long ret = groupId;
+
+            if (ret == null) {
+                XXGroup xGroup = daoMgr.getXXGroup().findByGroupName(name);
+
+                if (xGroup != null) {
+                    ret = xGroup.getId();
+                } else if (createIfAbsent) {
+                    ret = createGroup();
+                }
+            }
+
+            return ret;
+        }
+
+        private Long createGroup() {
+            LOG.warn("Group specified in role does not exist in ranger admin, creating new group, name = {}", name);
+
+            VXGroup vxGroup = new VXGroup();
+
+            vxGroup.setName(name);
+            vxGroup.setDescription(name);
+            vxGroup.setGroupSource(RangerCommonEnums.GROUP_EXTERNAL);
+
+            VXGroup vXGroup = xGroupService.createXGroupWithOutLogin(vxGroup);
+
+            if (vXGroup != null) {
+                xGroupService.createTransactionLog(vXGroup, null, OPERATION_CREATE_CONTEXT);
+
+                return vXGroup.getId();
+            }
+
+            return null;
+        }
+    }
+
+    private class RoleRoleAssociator implements Runnable {
+        private final String  name;
+        private final Long    subRoleId;
+        private final Long    roleId;
+        private final boolean roleExists;
+
+        RoleRoleAssociator(String name, Long subRoleId, Long roleId, boolean roleExists) {
+            this.name       = name;
+            this.subRoleId  = subRoleId;
+            this.roleId     = roleId;
+            this.roleExists = roleExists;
+        }
+
+        public XXRoleRefRole getRoleRef() {
+            Long id = resolveSubRoleId(false);
+
+            if (id != null && roleExists) {
+                XXRoleRefRole xRoleRefRole = new XXRoleRefRole();
+
+                xRoleRefRole.setRoleId(roleId);
+                xRoleRefRole.setSubRoleId(id);
+                xRoleRefRole.setSubRoleName(name);
+                xRoleRefRole.setSubRoleType(0);
+
+                return xRoleRefRole;
+            }
+
+            return null;
+        }
+
+        public void createRoleRef(Long id) {
+            if (roleExists) {
+                XXRoleRefRole xRoleRefRole = new XXRoleRefRole();
+
+                xRoleRefRole.setRoleId(roleId);
+                xRoleRefRole.setSubRoleId(id);
+                xRoleRefRole.setSubRoleName(name);
+                xRoleRefRole.setSubRoleType(0);
+
+                daoMgr.getXXRoleRefRole().create(xRoleRefRole);
+            } else {
+                LOG.info("Role with id ={} does not exist, skipping role association!", roleId);
+            }
+        }
+
+        @Override
+        public void run() {
+            Long id = resolveSubRoleId(true);
+
+            if (id != null) {
+                createRoleRef(id);
+
+                LOG.debug("Associated ROLE:{} with role id:[{}]", name, roleId);
+            } else {
+                throw new RuntimeException("Failed to associate ROLE:" + name + " with role id:[" + roleId + "]");
+            }
+        }
+
+        private Long resolveSubRoleId(boolean createIfAbsent) {
+            Long ret = subRoleId;
+
+            if (ret == null) {
+                XXRole xRole = daoMgr.getXXRole().findByRoleName(name);
+
+                if (xRole != null) {
+                    ret = xRole.getId();
+                } else if (createIfAbsent) {
+                    RangerBizUtil.setBulkMode(false);
+
+                    ret = createSubRole();
+                }
+            }
+
+            return ret;
+        }
+
+        private Long createSubRole() {
+            LOG.warn("Sub-role specified in role does not exist in ranger admin, creating new role, name = {}", name);
+
+            try {
+                RangerRole rRole       = new RangerRole(name, null, null, null, null);
+                RangerRole createdRole = roleStore.createRole(rRole, false, false);
+
+                return createdRole.getId();
+            } catch (Exception e) {
+                LOG.error("Failed to create sub-role {}", name, e);
+
+                return null;
+            }
+        }
+    }
+
+    private <T> void batchInsert(List<T> entities, BaseDao<T> dao, boolean oldBulkMode) {
+        if (CollectionUtils.isNotEmpty(entities)) {
+            long startTimeMs = System.currentTimeMillis();
+
+            LOG.debug("Batch insert started for create/update {} with {} records.", dao.getClass().getSimpleName(), entities.size());
+
+            RangerBizUtil.setBulkMode(false);
+            dao.batchCreate(entities);
+            RangerBizUtil.setBulkMode(oldBulkMode);
+
+            LOG.debug("Batch insert completed for create/update {} with {} records in {} ms.", dao.getClass().getSimpleName(), entities.size(), (System.currentTimeMillis() - startTimeMs));
+        }
+    }
 }

--- a/security-admin/src/main/java/org/apache/ranger/db/XXRoleRefGroupDao.java
+++ b/security-admin/src/main/java/org/apache/ranger/db/XXRoleRefGroupDao.java
@@ -19,51 +19,55 @@
 
 package org.apache.ranger.db;
 
-import java.util.Collections;
-import java.util.List;
-
-import javax.persistence.NoResultException;
-
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.ranger.common.db.BaseDao;
 import org.apache.ranger.entity.XXRoleRefGroup;
 import org.springframework.stereotype.Service;
 
-@Service
-public class XXRoleRefGroupDao extends BaseDao<XXRoleRefGroup>{
+import javax.persistence.NoResultException;
 
-    public XXRoleRefGroupDao(RangerDaoManagerBase daoManager)  {
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+public class XXRoleRefGroupDao extends BaseDao<XXRoleRefGroup> {
+    public XXRoleRefGroupDao(RangerDaoManagerBase daoManager) {
         super(daoManager);
     }
 
     public List<XXRoleRefGroup> findByRoleId(Long roleId) {
-        if(roleId == null) {
-            return Collections.EMPTY_LIST;
+        if (roleId == null) {
+            return Collections.emptyList();
         }
+
         try {
             return getEntityManager()
                     .createNamedQuery("XXRoleRefGroup.findByRoleId", tClass)
                     .setParameter("roleId", roleId).getResultList();
         } catch (NoResultException e) {
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         }
     }
 
     public List<XXRoleRefGroup> findByGroupId(Long groupId) {
-        if(groupId == null) {
-            return Collections.EMPTY_LIST;
+        if (groupId == null) {
+            return Collections.emptyList();
         }
+
         try {
             return getEntityManager()
                     .createNamedQuery("XXRoleRefGroup.findByGroupId", tClass)
                     .setParameter("groupId", groupId).getResultList();
         } catch (NoResultException e) {
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         }
     }
 
     public List<Long> findIdsByRoleId(Long roleId) {
-        List<Long> ret = Collections.EMPTY_LIST;
+        List<Long> ret = Collections.emptyList();
 
         if (roleId != null) {
             try {
@@ -71,7 +75,7 @@ public class XXRoleRefGroupDao extends BaseDao<XXRoleRefGroup>{
                         .createNamedQuery("XXRoleRefGroup.findIdsByRoleId", Long.class)
                         .setParameter("roleId", roleId).getResultList();
             } catch (NoResultException e) {
-                ret = Collections.EMPTY_LIST;
+                // ignore
             }
         }
 
@@ -80,14 +84,35 @@ public class XXRoleRefGroupDao extends BaseDao<XXRoleRefGroup>{
 
     public List<XXRoleRefGroup> findByGroupName(String groupName) {
         if (groupName == null) {
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         }
+
         try {
             return getEntityManager().createNamedQuery("XXRoleRefGroup.findByGroupName", tClass)
                     .setParameter("groupName", groupName).getResultList();
         } catch (NoResultException e) {
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         }
+    }
+
+    public Map<String, Long> findGroupNameIdByRoleId(Long roleId) {
+        Map<String, Long> ret = Collections.emptyMap();
+        if (roleId != null) {
+            try {
+                Collection<Object[]> results = getEntityManager()
+                        .createNamedQuery("XXRoleRefGroup.findGroupNameIdByRoleId", Object[].class)
+                        .setParameter("roleId", roleId)
+                        .getResultList();
+                ret = results.stream().collect(
+                        Collectors.toMap(
+                                object -> (String) object[0],
+                                object -> (Long) object[1],
+                                (existing, replacement) -> existing));
+            } catch (NoResultException e) {
+                // ignore
+            }
+        }
+        return ret;
     }
 
     public void deleteRoleRefGroupByIds(List<Long> ids) {
@@ -95,5 +120,4 @@ public class XXRoleRefGroupDao extends BaseDao<XXRoleRefGroup>{
             batchDeleteByIds("XXRoleRefGroup.deleteRoleRefGroupByIds", ids, "ids");
         }
     }
-
 }

--- a/security-admin/src/main/java/org/apache/ranger/db/XXRoleRefRoleDao.java
+++ b/security-admin/src/main/java/org/apache/ranger/db/XXRoleRefRoleDao.java
@@ -19,40 +19,43 @@
 
 package org.apache.ranger.db;
 
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
-import javax.persistence.NoResultException;
-
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.ranger.common.db.BaseDao;
 import org.apache.ranger.entity.XXRoleRefRole;
 import org.springframework.stereotype.Service;
 
-@Service
-public class XXRoleRefRoleDao extends BaseDao<XXRoleRefRole>{
+import javax.persistence.NoResultException;
 
-    public XXRoleRefRoleDao(RangerDaoManagerBase daoManager)  {
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+public class XXRoleRefRoleDao extends BaseDao<XXRoleRefRole> {
+    public XXRoleRefRoleDao(RangerDaoManagerBase daoManager) {
         super(daoManager);
     }
 
     public List<XXRoleRefRole> findByRoleId(Long roleId) {
-        if(roleId == null) {
-            return Collections.EMPTY_LIST;
+        if (roleId == null) {
+            return Collections.emptyList();
         }
+
         try {
             return getEntityManager()
                     .createNamedQuery("XXRoleRefRole.findByRoleId", tClass)
                     .setParameter("roleId", roleId).getResultList();
         } catch (NoResultException e) {
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         }
     }
 
     public List<Long> findIdsByRoleId(Long roleId) {
-        List<Long> ret = Collections.EMPTY_LIST;
+        List<Long> ret = Collections.emptyList();
 
         if (roleId != null) {
             try {
@@ -60,7 +63,7 @@ public class XXRoleRefRoleDao extends BaseDao<XXRoleRefRole>{
                         .createNamedQuery("XXRoleRefRole.findIdsByRoleId", Long.class)
                         .setParameter("roleId", roleId).getResultList();
             } catch (NoResultException e) {
-                ret = Collections.EMPTY_LIST;
+                ret = Collections.emptyList();
             }
         }
 
@@ -68,56 +71,79 @@ public class XXRoleRefRoleDao extends BaseDao<XXRoleRefRole>{
     }
 
     public List<XXRoleRefRole> findBySubRoleId(Long subRoleId) {
-        if(subRoleId == null) {
-            return Collections.EMPTY_LIST;
+        if (subRoleId == null) {
+            return Collections.emptyList();
         }
+
         try {
             return getEntityManager()
                     .createNamedQuery("XXRoleRefRole.findBySubRoleId", tClass)
                     .setParameter("subRoleId", subRoleId).getResultList();
         } catch (NoResultException e) {
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         }
     }
 
     public List<XXRoleRefRole> findBySubRoleName(String subRoleName) {
         if (subRoleName == null) {
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         }
+
         try {
             return getEntityManager().createNamedQuery("XXRoleRefRole.findBySubRoleName", tClass)
                     .setParameter("subRoleName", subRoleName).getResultList();
         } catch (NoResultException e) {
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         }
     }
 
-	public Long findRoleRefRoleCount(String subRoleName) {
-		Long ret = -1L;
+    public Long findRoleRefRoleCount(String subRoleName) {
+        Long ret = -1L;
 
-		try {
-			ret = getEntityManager().createNamedQuery("XXRoleRefRole.findRoleRefRoleCount", Long.class)
-					.setParameter("subRoleName", subRoleName).getSingleResult();
-		} catch (Exception e) {
-		}
+        try {
+            ret = getEntityManager().createNamedQuery("XXRoleRefRole.findRoleRefRoleCount", Long.class)
+                    .setParameter("subRoleName", subRoleName).getSingleResult();
+        } catch (Exception e) {
+            // ignore
+        }
 
-		return ret;
-	}
+        return ret;
+    }
 
     public Set<Long> getContainingRoles(Long subRoleId) {
-        Set<Long> ret;
-
+        Set<Long>           ret;
         List<XXRoleRefRole> roles = findBySubRoleId(subRoleId);
 
         if (CollectionUtils.isNotEmpty(roles)) {
             ret = new HashSet<>();
+
             for (XXRoleRefRole role : roles) {
                 ret.add(role.getRoleId());
             }
         } else {
-            ret = Collections.EMPTY_SET;
+            ret = Collections.emptySet();
         }
 
+        return ret;
+    }
+
+    public Map<String, Long> findSubRoleNameIdByRoleId(Long roleId) {
+        Map<String, Long> ret = Collections.emptyMap();
+        if (roleId != null) {
+            try {
+                Collection<Object[]> results = getEntityManager()
+                        .createNamedQuery("XXRoleRefRole.findSubRoleNameIdByRoleId", Object[].class)
+                        .setParameter("roleId", roleId)
+                        .getResultList();
+                ret = results.stream().collect(
+                        Collectors.toMap(
+                                object -> (String) object[0],
+                                object -> (Long) object[1],
+                                (existing, replacement) -> existing));
+            } catch (NoResultException e) {
+                // ignore
+            }
+        }
         return ret;
     }
 

--- a/security-admin/src/main/java/org/apache/ranger/db/XXRoleRefUserDao.java
+++ b/security-admin/src/main/java/org/apache/ranger/db/XXRoleRefUserDao.java
@@ -19,38 +19,41 @@
 
 package org.apache.ranger.db;
 
-import java.util.Collections;
-import java.util.List;
-
-import javax.persistence.NoResultException;
-
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.ranger.common.db.BaseDao;
 import org.apache.ranger.entity.XXRoleRefUser;
 import org.springframework.stereotype.Service;
 
-@Service
-public class XXRoleRefUserDao extends BaseDao<XXRoleRefUser>{
+import javax.persistence.NoResultException;
 
-    public XXRoleRefUserDao(RangerDaoManagerBase daoManager)  {
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+public class XXRoleRefUserDao extends BaseDao<XXRoleRefUser> {
+    public XXRoleRefUserDao(RangerDaoManagerBase daoManager) {
         super(daoManager);
     }
 
     public List<XXRoleRefUser> findByRoleId(Long roleId) {
-        if(roleId == null) {
-            return Collections.EMPTY_LIST;
+        if (roleId == null) {
+            return Collections.emptyList();
         }
+
         try {
             return getEntityManager()
                     .createNamedQuery("XXRoleRefUser.findByRoleId", tClass)
                     .setParameter("roleId", roleId).getResultList();
         } catch (NoResultException e) {
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         }
     }
 
     public List<Long> findIdsByRoleId(Long roleId) {
-        List<Long> ret = Collections.EMPTY_LIST;
+        List<Long> ret = Collections.emptyList();
 
         if (roleId != null) {
             try {
@@ -58,35 +61,57 @@ public class XXRoleRefUserDao extends BaseDao<XXRoleRefUser>{
                         .createNamedQuery("XXRoleRefUser.findIdsByRoleId", Long.class)
                         .setParameter("roleId", roleId).getResultList();
             } catch (NoResultException e) {
-                ret = Collections.EMPTY_LIST;
+                // ignore
             }
         }
 
         return ret;
     }
 
-    public List<XXRoleRefUser> findByUserId(Long userId) {
-        if(userId == null) {
-            return Collections.EMPTY_LIST;
+    public Map<String, Long> findUserNameIdMapByRoleId(Long roleId) {
+        Map<String, Long> ret = Collections.emptyMap();
+        if (roleId != null) {
+            try {
+                Collection<Object[]> results = getEntityManager()
+                        .createNamedQuery("XXRoleRefUser.findUserNameIdByRoleId", Object[].class)
+                        .setParameter("roleId", roleId)
+                        .getResultList();
+                ret = results.stream().collect(
+                        Collectors.toMap(
+                                object -> (String) object[0],
+                                object -> (Long) object[1],
+                                (existing, replacement) -> existing));
+            } catch (NoResultException e) {
+                // ignore
+            }
         }
+        return ret;
+    }
+
+    public List<XXRoleRefUser> findByUserId(Long userId) {
+        if (userId == null) {
+            return Collections.emptyList();
+        }
+
         try {
             return getEntityManager()
                     .createNamedQuery("XXRoleRefUser.findByUserId", tClass)
                     .setParameter("userId", userId).getResultList();
         } catch (NoResultException e) {
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         }
     }
 
     public List<XXRoleRefUser> findByUserName(String userName) {
         if (userName == null) {
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         }
+
         try {
             return getEntityManager().createNamedQuery("XXRoleRefUser.findByUserName", tClass)
                     .setParameter("userName", userName).getResultList();
         } catch (NoResultException e) {
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         }
     }
 

--- a/security-admin/src/main/java/org/apache/ranger/rest/RoleREST.java
+++ b/security-admin/src/main/java/org/apache/ranger/rest/RoleREST.java
@@ -171,7 +171,7 @@ public class RoleREST {
             if (containsInvalidMember(role.getUsers())) {
                 throw new Exception("Invalid role user(s)");
             }
-            ret = roleStore.createRole(role, createNonExistUserGroup);
+            ret = roleStore.createRole(role, createNonExistUserGroup, false);
         } catch(WebApplicationException excp) {
             throw excp;
         } catch(Throwable excp) {
@@ -224,7 +224,7 @@ public class RoleREST {
             if (containsInvalidMember(role.getUsers())) {
                 throw new Exception("Invalid role user(s)");
             }
-            ret = roleStore.updateRole(role, createNonExistUserGroup);
+            ret = roleStore.updateRole(role, createNonExistUserGroup, true);
         } catch(WebApplicationException excp) {
             throw excp;
         } catch(Throwable excp) {
@@ -527,7 +527,7 @@ public class RoleREST {
 												}
 											}
 											else {
-												roleStore.updateRole(roleInJson, createNonExistUserGroupRole);
+												roleStore.updateRole(roleInJson, createNonExistUserGroupRole, true);
 												totalRoleUpdate++;
 											}
 										} catch (WebApplicationException excp) {
@@ -546,7 +546,7 @@ public class RoleREST {
 									ret.setStatusCode(RESTResponse.STATUS_SUCCESS);
 								} else if (!roleNameList.contains(roleNameInJson) && (!roleNameInJson.isEmpty())) {
 									try {
-										roleStore.createRole(roleInJson, createNonExistUserGroupRole);
+										roleStore.createRole(roleInJson, createNonExistUserGroupRole, false);
 									} catch (WebApplicationException excp) {
 										throw excp;
 									} catch (Throwable excp) {
@@ -708,7 +708,7 @@ public class RoleREST {
             role.setUsers(new ArrayList<>(roleUsers));
             role.setGroups(new ArrayList<>(roleGroups));
 
-            role = roleStore.updateRole(role,false);
+            role = roleStore.updateRole(role, false, true);
 
         } catch(WebApplicationException excp) {
             throw excp;
@@ -764,7 +764,7 @@ public class RoleREST {
                 }
             }
 
-            role = roleStore.updateRole(role, false);
+            role = roleStore.updateRole(role, false, true);
 
         } catch(WebApplicationException excp) {
             throw excp;
@@ -812,7 +812,7 @@ public class RoleREST {
                 }
             }
 
-            role = roleStore.updateRole(role, false);
+            role = roleStore.updateRole(role, false, true);
 
         } catch(WebApplicationException excp) {
             throw excp;
@@ -1383,7 +1383,7 @@ public class RoleREST {
             role.setGroups(new ArrayList<>(roleGroups));
             role.setRoles(new ArrayList<>(roleRoles));
 
-            role = roleStore.updateRole(role, false);
+            role = roleStore.updateRole(role, false, true);
 
         } catch(WebApplicationException excp) {
             throw excp;
@@ -1440,7 +1440,7 @@ public class RoleREST {
                 }
             }
 
-            role = roleStore.updateRole(role, false);
+            role = roleStore.updateRole(role, false, true);
 
         } catch(WebApplicationException excp) {
             throw excp;
@@ -1485,7 +1485,7 @@ public class RoleREST {
                 }
             }
 
-            role = roleStore.updateRole(role, false);
+            role = roleStore.updateRole(role, false, true);
 
         } catch(WebApplicationException excp) {
             throw excp;

--- a/security-admin/src/main/resources/META-INF/jpa_named_queries.xml
+++ b/security-admin/src/main/resources/META-INF/jpa_named_queries.xml
@@ -1988,6 +1988,10 @@
 				<query>select obj.id from XXRoleRefUser obj  where obj.roleId = :roleId</query>
 		</named-query>
 
+		<named-query name="XXRoleRefUser.findUserNameIdByRoleId">
+					<query>SELECT obj.userName, obj.id FROM XXRoleRefUser obj WHERE obj.roleId = :roleId</query>
+		</named-query>
+
     <named-query name="XXRoleRefUser.findByUserId">
         <query>select obj from XXRoleRefUser obj where obj.userId = :userId</query>
     </named-query>
@@ -2012,6 +2016,10 @@
         <query>select obj from XXRoleRefGroup obj where obj.groupName = :groupName </query>
     </named-query>
 
+	<named-query name="XXRoleRefGroup.findGroupNameIdByRoleId">
+				<query>SELECT obj.groupName, obj.id FROM XXRoleRefGroup obj WHERE obj.roleId = :roleId</query>
+	</named-query>
+
     <named-query name="XXRoleRefRole.findByRoleId">
         <query>select obj from XXRoleRefRole obj  where obj.roleId = :roleId</query>
     </named-query>
@@ -2031,6 +2039,10 @@
 	<named-query name="XXRoleRefRole.findRoleRefRoleCount">
         <query>select count(obj.roleId) from XXRoleRefRole obj where obj.subRoleName = :subRoleName </query>
     </named-query>
+
+	<named-query name="XXRoleRefRole.findSubRoleNameIdByRoleId">
+		<query>SELECT obj.subRoleName, obj.id FROM XXRoleRefRole obj WHERE obj.roleId = :roleId</query>
+	</named-query>
 
 	<named-query name="XXRoleRefGroup.deleteRoleRefGroupByIds">
 				<query>DELETE FROM XXRoleRefGroup obj WHERE obj.id IN :ids </query>

--- a/security-admin/src/test/java/org/apache/ranger/biz/TestPolicyRefUpdater.java
+++ b/security-admin/src/test/java/org/apache/ranger/biz/TestPolicyRefUpdater.java
@@ -196,7 +196,7 @@ public class TestPolicyRefUpdater {
 
         org.apache.ranger.db.XXPolicyDao policyDao = mock(org.apache.ranger.db.XXPolicyDao.class);
         when(daoMgr.getXXPolicy()).thenReturn(policyDao);
-        when(policyDao.getById(xPolicy.getId())).thenReturn(xPolicy);
+        when(policyDao.getCountById(xPolicy.getId())).thenReturn(1L);
 
         XXUserDao userDao = mock(XXUserDao.class);
         when(daoMgr.getXXUser()).thenReturn(userDao);
@@ -322,11 +322,6 @@ public class TestPolicyRefUpdater {
         xPolicy.setId(10L);
         xPolicy.setService(100L);
 
-        // FIX: Mock policy DAO hierarchy to satisfy doesPolicyExist(xPolicy) checks
-        org.apache.ranger.db.XXPolicyDao policyDao = mock(org.apache.ranger.db.XXPolicyDao.class);
-        when(daoMgr.getXXPolicy()).thenReturn(policyDao);
-        when(policyDao.getById(xPolicy.getId())).thenReturn(xPolicy);
-
         // Mock audit population to be identity
         Mockito.lenient().when(rangerAuditFields.populateAuditFields(Mockito.any(), Mockito.any()))
             .thenAnswer(inv -> inv.getArgument(0));
@@ -354,9 +349,9 @@ public class TestPolicyRefUpdater {
         }
         Assert.assertNotNull(userAssociatorClass);
         Constructor<?> userCtor = userAssociatorClass.getDeclaredConstructor(
-                PolicyRefUpdater.class, String.class, Long.class, XXPolicy.class);
+                PolicyRefUpdater.class, String.class, Long.class, XXPolicy.class, boolean.class);
         userCtor.setAccessible(true);
-        Object associatorUser = userCtor.newInstance(updater, "uNew", null, xPolicy);
+        Object associatorUser = userCtor.newInstance(updater, "uNew", null, xPolicy, true);
         Method runUser = userAssociatorClass.getDeclaredMethod("run");
         runUser.setAccessible(true);
         runUser.invoke(associatorUser);
@@ -383,9 +378,9 @@ public class TestPolicyRefUpdater {
         }
         Assert.assertNotNull(groupAssociatorClass);
         Constructor<?> groupCtor = groupAssociatorClass.getDeclaredConstructor(
-                PolicyRefUpdater.class, String.class, Long.class, XXPolicy.class);
+                PolicyRefUpdater.class, String.class, Long.class, XXPolicy.class, boolean.class);
         groupCtor.setAccessible(true);
-        Object associatorGroup = groupCtor.newInstance(updater, "gNew", null, xPolicy);
+        Object associatorGroup = groupCtor.newInstance(updater, "gNew", null, xPolicy, true);
         Method runGroup = groupAssociatorClass.getDeclaredMethod("run");
         runGroup.setAccessible(true);
         runGroup.invoke(associatorGroup);
@@ -399,7 +394,7 @@ public class TestPolicyRefUpdater {
         when(roleDao.findByRoleName("rNew")).thenReturn(null);
         RangerRole createdRole = new RangerRole("rNew", null, null, null, null);
         createdRole.setId(33L);
-        when(roleStore.createRole(Mockito.any(RangerRole.class), Mockito.eq(false))).thenReturn(createdRole);
+        when(roleStore.createRole(Mockito.any(RangerRole.class), Mockito.eq(false), Mockito.eq(false))).thenReturn(createdRole);
         XXPolicyRefRoleDao polRoleDao = mock(XXPolicyRefRoleDao.class);
         when(daoMgr.getXXPolicyRefRole()).thenReturn(polRoleDao);
 
@@ -412,9 +407,9 @@ public class TestPolicyRefUpdater {
         }
         Assert.assertNotNull(roleAssociatorClass);
         Constructor<?> roleCtor = roleAssociatorClass.getDeclaredConstructor(
-                PolicyRefUpdater.class, String.class, Long.class, XXPolicy.class);
+                PolicyRefUpdater.class, String.class, Long.class, XXPolicy.class, boolean.class);
         roleCtor.setAccessible(true);
-        Object associatorRole = roleCtor.newInstance(updater, "rNew", null, xPolicy);
+        Object associatorRole = roleCtor.newInstance(updater, "rNew", null, xPolicy, true);
         Method runRole = roleAssociatorClass.getDeclaredMethod("run");
         runRole.setAccessible(true);
         runRole.invoke(associatorRole);

--- a/security-admin/src/test/java/org/apache/ranger/biz/TestRoleDBStore.java
+++ b/security-admin/src/test/java/org/apache/ranger/biz/TestRoleDBStore.java
@@ -396,7 +396,7 @@ public class TestRoleDBStore {
         Mockito.when(restErrorUtil.createRESTException(Mockito.anyString(), Mockito.any())).thenThrow(new WebApplicationException());
         thrown.expect(WebApplicationException.class);
 
-        roleDBStore.createRole(rangerRole, true);
+        roleDBStore.createRole(rangerRole, true, false);
     }
 
     @Test
@@ -410,10 +410,10 @@ public class TestRoleDBStore {
         Mockito.when(roleService.create(rangerRole)).thenReturn(rangerRole);
         Mockito.when(roleService.read(xxRole.getId())).thenReturn(rangerRole);
         Mockito.doNothing().when(transactionSynchronizationAdapter).executeOnTransactionCommit(Mockito.any());
-        Mockito.doNothing().when(roleRefUpdater).createNewRoleMappingForRefTable(Mockito.any(), Mockito.anyBoolean());
+        Mockito.doNothing().when(roleRefUpdater).createNewRoleMappingForRefTable(Mockito.any(), Mockito.anyBoolean(), Mockito.anyBoolean());
         Mockito.doNothing().when(roleService).createTransactionLog( Mockito.any(), Mockito.any(), Mockito.anyInt());
 
-        roleDBStore.createRole(rangerRole, true);
+        roleDBStore.createRole(rangerRole, true, false);
     }
 
     @Test
@@ -426,7 +426,7 @@ public class TestRoleDBStore {
         Mockito.when(restErrorUtil.createRESTException(Mockito.anyString())).thenThrow(new WebApplicationException());
         thrown.expect(WebApplicationException.class);
 
-        roleDBStore.updateRole(rangerRole, true);
+        roleDBStore.updateRole(rangerRole, true, true);
     }
 
     @Test
@@ -439,11 +439,11 @@ public class TestRoleDBStore {
         Mockito.when(xxRoleDao.findByRoleId(rangerRole.getId())).thenReturn(xxRole);
         Mockito.doNothing().when(transactionSynchronizationAdapter).executeOnTransactionCommit(Mockito.any());
         Mockito.when(roleService.update(rangerRole)).thenReturn(rangerRole);
-        Mockito.doNothing().when(roleRefUpdater).createNewRoleMappingForRefTable(Mockito.any(), Mockito.anyBoolean());
+        Mockito.doNothing().when(roleRefUpdater).createNewRoleMappingForRefTable(Mockito.any(), Mockito.anyBoolean(), Mockito.anyBoolean());
         Mockito.doNothing().when(roleService).updatePolicyVersions(rangerRole.getId());
         Mockito.doNothing().when(roleService).createTransactionLog( Mockito.any(),  Mockito.any(), Mockito.anyInt());
 
-        roleDBStore.updateRole(rangerRole, true);
+        roleDBStore.updateRole(rangerRole, true, true);
     }
 
     @Test

--- a/security-admin/src/test/java/org/apache/ranger/biz/TestRoleRefUpdater.java
+++ b/security-admin/src/test/java/org/apache/ranger/biz/TestRoleRefUpdater.java
@@ -29,9 +29,6 @@ import org.apache.ranger.db.XXRoleRefUserDao;
 import org.apache.ranger.db.XXUserDao;
 import org.apache.ranger.entity.XXGroup;
 import org.apache.ranger.entity.XXRole;
-import org.apache.ranger.entity.XXRoleRefGroup;
-import org.apache.ranger.entity.XXRoleRefRole;
-import org.apache.ranger.entity.XXRoleRefUser;
 import org.apache.ranger.entity.XXUser;
 import org.apache.ranger.plugin.model.RangerRole;
 import org.junit.jupiter.api.Assertions;
@@ -44,9 +41,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -137,16 +137,25 @@ public class TestRoleRefUpdater {
         xg.setId(22L);
         XXRole xr = new XXRole();
         xr.setId(33L);
-        when(xUserDao.findByUserName("u1")).thenReturn(xu);
-        when(xGroupDao.findByGroupName("g1")).thenReturn(xg);
-        when(xRoleDao.findByRoleName("r1")).thenReturn(xr);
+        when(urd.findUserNameIdMapByRoleId(5L)).thenReturn(Collections.emptyMap());
+        when(grd.findGroupNameIdByRoleId(5L)).thenReturn(Collections.emptyMap());
+        when(rrd.findSubRoleNameIdByRoleId(5L)).thenReturn(Collections.emptyMap());
+        Map<String, Long> userIds = new HashMap<>();
+        userIds.put("u1", 11L);
+        Map<String, Long> groupIds = new HashMap<>();
+        groupIds.put("g1", 22L);
+        Map<String, Long> roleIds = new HashMap<>();
+        roleIds.put("r1", 33L);
+        when(xUserDao.getIdsByUserNames(anySet())).thenReturn(userIds);
+        when(xGroupDao.getIdsByGroupNames(anySet())).thenReturn(groupIds);
+        when(xRoleDao.getIdsByRoleNames(anySet())).thenReturn(roleIds);
 
         RangerRole role = buildRole(5L, Collections.singletonList("u1"), Collections.singletonList("g1"),
                 Collections.singletonList("r1"));
-        updater.createNewRoleMappingForRefTable(role, true);
-        verify(urd, times(1)).create(any(XXRoleRefUser.class));
-        verify(grd, times(1)).create(any(XXRoleRefGroup.class));
-        verify(rrd, times(1)).create(any(XXRoleRefRole.class));
+        updater.createNewRoleMappingForRefTable(role, true, true);
+        verify(urd, times(1)).batchCreate(any());
+        verify(grd, times(1)).batchCreate(any());
+        verify(rrd, times(1)).batchCreate(any());
     }
 
     @Test
@@ -168,20 +177,69 @@ public class TestRoleRefUpdater {
         when(dao.getXXRoleRefUser()).thenReturn(urd);
         when(dao.getXXRoleRefGroup()).thenReturn(grd);
         when(dao.getXXRoleRefRole()).thenReturn(rrd);
-        when(urd.findIdsByRoleId(7L)).thenReturn(Collections.emptyList());
-        when(grd.findIdsByRoleId(7L)).thenReturn(Collections.emptyList());
-        when(rrd.findIdsByRoleId(7L)).thenReturn(Collections.emptyList());
+        when(urd.findUserNameIdMapByRoleId(7L)).thenReturn(Collections.emptyMap());
+        when(grd.findGroupNameIdByRoleId(7L)).thenReturn(Collections.emptyMap());
+        when(rrd.findSubRoleNameIdByRoleId(7L)).thenReturn(Collections.emptyMap());
+        when(xUserDao.getIdsByUserNames(anySet())).thenReturn(Collections.emptyMap());
         when(biz.checkAdminAccess()).thenReturn(false);
 
         RangerRole role = buildRole(7L, Collections.singletonList("missingUser"), Collections.emptyList(),
                 Collections.emptyList());
         RuntimeException expected = new RuntimeException("missing");
         when(rest.createRESTException(anyString(), any())).thenThrow(expected);
-        Assertions.assertThrows(RuntimeException.class, () -> updater.createNewRoleMappingForRefTable(role, false));
+        Assertions.assertThrows(RuntimeException.class, () -> updater.createNewRoleMappingForRefTable(role, false, false));
 
-        // allow creation: should schedule associator
+        // allow creation: should schedule associator (principal creation runs on transaction commit)
         when(biz.checkAdminAccess()).thenReturn(true);
-        updater.createNewRoleMappingForRefTable(role, true);
+        updater.createNewRoleMappingForRefTable(role, true, true);
         verify(adapter, times(1)).executeOnTransactionCommit(any(Runnable.class));
+    }
+
+    @Test
+    public void test04_cleanupRefTablesForUpdate_selectivePrincipalCleanup() throws Exception {
+        RoleRefUpdater updater = new RoleRefUpdater();
+        RangerDaoManager dao = mock(RangerDaoManager.class);
+        XXRoleRefUserDao urd = mock(XXRoleRefUserDao.class);
+        XXRoleRefGroupDao grd = mock(XXRoleRefGroupDao.class);
+        XXRoleRefRoleDao rrd = mock(XXRoleRefRoleDao.class);
+        when(dao.getXXRoleRefUser()).thenReturn(urd);
+        when(dao.getXXRoleRefGroup()).thenReturn(grd);
+        when(dao.getXXRoleRefRole()).thenReturn(rrd);
+        setField(updater, RoleRefUpdater.class, "daoMgr", dao);
+
+        final Long roleId = 100L;
+        java.util.Set<String> roleUsers = new java.util.HashSet<>(Arrays.asList("alice", "bob", "carol"));
+        java.util.Set<String> roleRoles = new java.util.HashSet<>(Arrays.asList("roleA", "roleB", "roleNew"));
+        java.util.Set<String> roleGroups = new java.util.HashSet<>(Arrays.asList("grp1", "grp2", "grpNew"));
+
+        Map<String, Long> existingUsers = new HashMap<>();
+        existingUsers.put("alice", 1L);
+        existingUsers.put("bob", 2L);
+        existingUsers.put("dave", 4L);
+
+        Map<String, Long> existingRoles = new HashMap<>();
+        existingRoles.put("roleA", 10L);
+        existingRoles.put("roleOld", 12L);
+
+        Map<String, Long> existingGroups = new HashMap<>();
+        existingGroups.put("grp1", 20L);
+        existingGroups.put("grpOld", 22L);
+
+        when(urd.findUserNameIdMapByRoleId(roleId)).thenReturn(existingUsers);
+        when(rrd.findSubRoleNameIdByRoleId(roleId)).thenReturn(existingRoles);
+        when(grd.findGroupNameIdByRoleId(roleId)).thenReturn(existingGroups);
+
+        RangerRole role = new RangerRole("role", null, null, null, null);
+        role.setId(roleId);
+        Assertions.assertTrue(updater.cleanupRefTablesForUpdate(role, roleUsers, roleGroups, roleRoles));
+
+        verify(urd).deleteRoleRefUserByIds(Collections.singletonList(4L));
+        Assertions.assertEquals(Collections.singleton("carol"), roleUsers);
+
+        verify(rrd).deleteRoleRefRoleByIds(Collections.singletonList(12L));
+        Assertions.assertEquals(new java.util.HashSet<>(Arrays.asList("roleB", "roleNew")), roleRoles);
+
+        verify(grd).deleteRoleRefGroupByIds(Collections.singletonList(22L));
+        Assertions.assertEquals(new java.util.HashSet<>(Arrays.asList("grp2", "grpNew")), roleGroups);
     }
 }

--- a/security-admin/src/test/java/org/apache/ranger/rest/TestRoleREST.java
+++ b/security-admin/src/test/java/org/apache/ranger/rest/TestRoleREST.java
@@ -142,7 +142,7 @@ public class TestRoleREST {
         Mockito.when(bizUtil.isUserRangerAdmin(Mockito.anyString())).thenReturn(true);
         RangerRole rangerRole = createRole();
         try {
-            Mockito.when(roleStore.createRole(Mockito.any(RangerRole.class), eq(createNonExistUserGroup))).
+            Mockito.when(roleStore.createRole(Mockito.any(RangerRole.class), eq(createNonExistUserGroup), eq(false))).
                     thenReturn(rangerRole);
         } catch (Exception e) {
             throw new RuntimeException(e);
@@ -169,7 +169,7 @@ public class TestRoleREST {
             throw new RuntimeException(e);
         }
         try {
-            Mockito.when(roleStore.updateRole(Mockito.any(RangerRole.class),Mockito.anyBoolean())).thenReturn(rangerRole);
+            Mockito.when(roleStore.updateRole(Mockito.any(RangerRole.class), Mockito.anyBoolean(), eq(true))).thenReturn(rangerRole);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -282,7 +282,7 @@ public class TestRoleREST {
             throw new RuntimeException(e);
         }
         try {
-            Mockito.when(roleStore.updateRole(Mockito.any(RangerRole.class),Mockito.anyBoolean())).
+            Mockito.when(roleStore.updateRole(Mockito.any(RangerRole.class), Mockito.anyBoolean(), eq(true))).
                     then(AdditionalAnswers.returnsFirstArg());
         } catch (Exception e) {
             throw new RuntimeException(e);
@@ -312,7 +312,7 @@ public class TestRoleREST {
             throw new RuntimeException(e);
         }
         try {
-            Mockito.when(roleStore.updateRole(Mockito.any(RangerRole.class),Mockito.anyBoolean())).
+            Mockito.when(roleStore.updateRole(Mockito.any(RangerRole.class), Mockito.anyBoolean(), eq(true))).
                     then(AdditionalAnswers.returnsFirstArg());
         } catch (Exception e) {
             throw new RuntimeException(e);
@@ -351,7 +351,7 @@ public class TestRoleREST {
             throw new RuntimeException(e);
         }
         try {
-            Mockito.when(roleStore.updateRole(Mockito.any(RangerRole.class),Mockito.anyBoolean())).
+            Mockito.when(roleStore.updateRole(Mockito.any(RangerRole.class), Mockito.anyBoolean(), eq(true))).
                     then(AdditionalAnswers.returnsFirstArg());
         } catch (Exception e) {
             throw new RuntimeException(e);
@@ -374,7 +374,7 @@ public class TestRoleREST {
         GrantRevokeRoleRequest grantRevokeRoleRequest = createGrantRevokeRoleRequest();
         Mockito.when(bizUtil.isUserRangerAdmin(Mockito.anyString())).thenReturn(true,true,true);
         try {
-            Mockito.when(roleStore.updateRole(Mockito.any(RangerRole.class),Mockito.anyBoolean())).
+            Mockito.when(roleStore.updateRole(Mockito.any(RangerRole.class), Mockito.anyBoolean(), eq(true))).
                     then(AdditionalAnswers.returnsFirstArg());
         } catch (Exception e) {
             throw new RuntimeException(e);
@@ -402,7 +402,7 @@ public class TestRoleREST {
             throw new RuntimeException(e);
         }
         try {
-            Mockito.when(roleStore.updateRole(Mockito.any(RangerRole.class),Mockito.anyBoolean())).
+            Mockito.when(roleStore.updateRole(Mockito.any(RangerRole.class), Mockito.anyBoolean(), eq(true))).
                     then(AdditionalAnswers.returnsFirstArg());
         } catch (Exception e) {
             throw new RuntimeException(e);
@@ -604,7 +604,7 @@ public class TestRoleREST {
             throw new RuntimeException(e);
         }
         try {
-            Mockito.when(roleStore.updateRole(Mockito.any(RangerRole.class),Mockito.anyBoolean())).
+            Mockito.when(roleStore.updateRole(Mockito.any(RangerRole.class), Mockito.anyBoolean(), eq(true))).
                     then(AdditionalAnswers.returnsFirstArg());
         } catch (Exception e) {
             throw new RuntimeException(e);
@@ -672,7 +672,7 @@ public class TestRoleREST {
             throw new RuntimeException(e);
         }
         try {
-            Mockito.when(roleStore.updateRole(Mockito.any(RangerRole.class),Mockito.anyBoolean())).
+            Mockito.when(roleStore.updateRole(Mockito.any(RangerRole.class), Mockito.anyBoolean(), eq(true))).
                     then(AdditionalAnswers.returnsFirstArg());
         } catch (Exception e) {
             throw new RuntimeException(e);
@@ -1105,7 +1105,7 @@ public class TestRoleREST {
 
 		Mockito.when(searchUtil.getSearchFilter(request, roleService.sortFields)).thenReturn(filter);
 		Mockito.when(roleStore.getRoleNames(Mockito.any(SearchFilter.class))).thenReturn(roleList);
-		Mockito.when(roleStore.createRole(Mockito.any(RangerRole.class), eq(createNonExistUserGroupRole)))
+		Mockito.when(roleStore.createRole(Mockito.any(RangerRole.class), eq(createNonExistUserGroupRole), eq(false)))
 				.thenReturn(rangerRole);
 
 		RESTResponse resp = roleRest.importRolesFromFile(request, uploadedInputStream, fileDetail, updateIfExists,
@@ -1135,7 +1135,7 @@ public class TestRoleREST {
 
 		Mockito.when(searchUtil.getSearchFilter(request, roleService.sortFields)).thenReturn(filter);
 		Mockito.when(roleStore.getRoleNames(Mockito.any(SearchFilter.class))).thenReturn(roleList);
-		Mockito.when(roleStore.createRole(Mockito.any(RangerRole.class), eq(createNonExistUserGroupRole)))
+		Mockito.when(roleStore.createRole(Mockito.any(RangerRole.class), eq(createNonExistUserGroupRole), eq(false)))
 				.thenReturn(rangerRole);
 
 		RESTResponse resp = roleRest.importRolesFromFile(request, uploadedInputStream, fileDetail, updateIfExists,
@@ -1166,7 +1166,9 @@ public class TestRoleREST {
 		Mockito.when(searchUtil.getSearchFilter(request, roleService.sortFields)).thenReturn(filter);
 		Mockito.when(roleStore.getRoleNames(Mockito.any(SearchFilter.class))).thenReturn(roleList);
 		Mockito.when(roleStore.getRole(Mockito.anyString())).thenReturn(rangerRole);
-		Mockito.when(roleStore.createRole(Mockito.any(RangerRole.class), eq(createNonExistUserGroupRole)))
+		Mockito.when(roleStore.createRole(Mockito.any(RangerRole.class), eq(createNonExistUserGroupRole), eq(false)))
+				.thenReturn(rangerRole);
+		Mockito.when(roleStore.updateRole(Mockito.any(RangerRole.class), eq(createNonExistUserGroupRole), eq(true)))
 				.thenReturn(rangerRole);
 
 		RESTResponse resp = roleRest.importRolesFromFile(request, uploadedInputStream, fileDetail, updateIfExists,


### PR DESCRIPTION
## What changes were proposed in this pull request?

Optimized `RoleRefUpdater` and related role-ref DAOs so role create/update performs fewer database round-trips when a role references many users, groups, and sub-roles. The design mirrors [RANGER-3899](https://issues.apache.org/jira/browse/RANGER-3899) / PR [#962](https://github.com/apache/ranger/pull/962) (`PolicyRefUpdater`).
When creating or updating a role with a large number of principals, Ranger Admin was slow because:

1. **N+1 lookups** — Users, groups, and sub-roles were resolved with repeated per-name database calls during ref-table maintenance.
2. **Full ref-table rebuild on every update** — `createNewRoleMappingForRefTable()` always called `cleanupRefTables()`, deleting all rows from `x_role_ref_user`, `x_role_ref_group`, and `x_role_ref_role`, then re-inserting every principal even when nothing changed.
3. **Monolithic associator** — A single `RolePrincipalAssociator` took three collection parameters and populated one of them inside `doAssociate()`, which was harder to read and inconsistent with the refactored policy path.

## How was this patch tested?

Refer:https://github.com/apache/ranger/pull/980
