### PR TITLE
RANGER-5642, RANGER-5644: Package Jersey auditserver REST client JARs in Kafka and HBase plugins

### DIFF
--- a/distro/src/main/assembly/hbase-agent.xml
+++ b/distro/src/main/assembly/hbase-agent.xml
@@ -73,6 +73,10 @@
           <include>org.eclipse.jetty:jetty-client:jar:${jetty-client.version}</include>
           <include>org.glassfish.jersey.core:jersey-client</include>
           <include>org.glassfish.jersey.core:jersey-common</include>
+          <include>org.glassfish.jersey.ext:jersey-entity-filtering:jar:${jersey-client.version}</include>
+          <include>org.glassfish.jersey.inject:jersey-hk2</include>
+          <include>org.glassfish.jersey.media:jersey-media-json-jackson:jar:${jersey-client.version}</include>
+          <include>org.glassfish.hk2.external:javax.inject</include>
           <include>org.graalvm.js:js:jar:${graalvm.version}</include>
           <include>org.graalvm.js:js-scriptengine:jar:${graalvm.version}</include>
           <include>org.graalvm.regex:regex:jar:${graalvm.version}</include>

--- a/distro/src/main/assembly/hbase-agent.xml
+++ b/distro/src/main/assembly/hbase-agent.xml
@@ -74,9 +74,7 @@
           <include>org.glassfish.jersey.core:jersey-client</include>
           <include>org.glassfish.jersey.core:jersey-common</include>
           <include>org.glassfish.jersey.ext:jersey-entity-filtering:jar:${jersey-client.version}</include>
-          <include>org.glassfish.jersey.inject:jersey-hk2</include>
-          <include>org.glassfish.jersey.media:jersey-media-json-jackson:jar:${jersey-client.version}</include>
-          <include>org.glassfish.hk2.external:javax.inject</include>
+          <include>org.glassfish.jersey.media:jersey-media-json-jackson</include>
           <include>org.graalvm.js:js:jar:${graalvm.version}</include>
           <include>org.graalvm.js:js-scriptengine:jar:${graalvm.version}</include>
           <include>org.graalvm.regex:regex:jar:${graalvm.version}</include>

--- a/distro/src/main/assembly/plugin-kafka.xml
+++ b/distro/src/main/assembly/plugin-kafka.xml
@@ -82,6 +82,11 @@
 					<include>org.apache.solr:solr-solrj:jar:${solr.version}</include>
 					<include>org.codehaus.woodstox:stax2-api</include>
 					<include>org.eclipse.jetty:jetty-client:jar:${jetty-client.version}</include>
+					<include>org.glassfish.jersey.core:jersey-client</include>
+					<include>org.glassfish.jersey.core:jersey-common</include>
+					<include>org.glassfish.jersey.inject:jersey-hk2</include>
+					<include>org.glassfish.hk2.external:javax.inject</include>
+					<include>jakarta.ws.rs:jakarta.ws.rs-api</include>
 					<include>org.glassfish.jersey.ext:jersey-entity-filtering:jar:${jersey-client.version}</include>
 					<include>org.glassfish.jersey.media:jersey-media-json-jackson:jar:${jersey-client.version}</include>
 				</includes>


### PR DESCRIPTION
## Summary

Fixes audit delivery failures for **Kafka** and **HBase** plugins when the audit destination is **auditserver** (Tier 3 / central audit pipeline).

- **Kafka (RANGER-5642):** Whitelist the Glassfish Jersey REST/JSON client stack in `plugin-kafka.xml` so `RangerAuditServerDestination` can POST JSON audits without `MessageBodyWriter not found for media type=application/json`.
- **HBase (RANGER-5644):** Add missing JSON writer JARs in `hbase-agent.xml` (`jersey-entity-filtering`, `jersey-media-json-jackson`). **Do not** add `jersey-hk2` / `javax.inject` — they crash HMaster in `plugins-docker-build` (aligned with HDFS/Hive, which omit HK2).

Kafka and HBase had **different gaps on `master`**; see **Why the whitelists differ** below.

## Problem

When `XAAUDIT.AUDITSERVER.ENABLE=true`, plugins use `RangerRESTClient` (Jersey 2) to send audits to the central audit ingestor. Ranger plugin assemblies **whitelist** dependencies explicitly into `lib/*-plugin-impl/`; transitive deps are not copied unless listed.

Kafka and HBase included `ranger-audit-dest-auditserver` but were missing key Jersey runtime JARs. At runtime the plugin fails during audit init or first REST POST:

```
MessageBodyWriter not found for media type=application/json, type=class org.apache.ranger.audit.model.AuthAuditEvent, genericType=class org.apache.ranger.audit.model.AuthAuditEvent
```

| Plugin | Symptom | Root cause |
|--------|---------|------------|
| Kafka | Audits never reach audit ingestor / Kafka topic when auditserver destination enabled | `plugin-kafka.xml` lacked `jersey-client`, `jersey-common`, `jersey-hk2`, `javax.inject`, `jakarta.ws.rs-api` (JSON writer deps were listed but core Jersey client stack was not) |
| HBase | Same `MessageBodyWriter` error in RegionServer/Master logs | `hbase-agent.xml` had `jersey-client` + `jersey-common` (+ `jackson-jaxrs-json-provider`) only; missing `jersey-entity-filtering`, `jersey-media-json-jackson` |
| HBase CI (`plugins-docker-build`) | `ranger-hbase` container exits after HMaster crash | Initial fix added `jersey-hk2` + `javax.inject`; removed in follow-up — HK2 on HMaster classpath is unsafe |


## Changes

| Area | File | Change |
|------|------|--------|
| Kafka packaging | `distro/src/main/assembly/plugin-kafka.xml` | Add to `lib/ranger-kafka-plugin-impl` whitelist: `jersey-client`, `jersey-common`, `jersey-hk2`, `javax.inject`, `jakarta.ws.rs-api` (alongside existing `jersey-entity-filtering`, `jersey-media-json-jackson`, `ranger-audit-dest-auditserver`) |
| HBase packaging | `distro/src/main/assembly/hbase-agent.xml` | Add: `jersey-entity-filtering`, `jersey-media-json-jackson`. Keep existing: `jersey-client`, `jersey-common`, `jakarta.ws.rs-api`, `jackson-jaxrs-*`, `ranger-audit-dest-auditserver`. **Omit:** `jersey-hk2`, `javax.inject` |

### Why the whitelists differ

On **`master`**, each plugin was missing a **different half** of the auditserver Jersey stack:

| Plugin | Already in `*-plugin-impl` | Missing for auditserver REST |
|--------|------------------------------|------------------------------|
| **Kafka** | `jersey-entity-filtering`, `jersey-media-json-jackson` | Core client: `jersey-client`, `jersey-common`, `jersey-hk2`, `javax.inject`, `jakarta.ws.rs-api` |
| **HBase** | `jersey-client`, `jersey-common`, `jakarta.ws.rs-api`, `jackson-jaxrs-json-provider` | JSON writers: `jersey-entity-filtering`, `jersey-media-json-jackson` |

**Why Kafka keeps `jersey-hk2`:** the broker JVM had no Jersey client stack at all; `ClientBuilder.newClient()` needs HK2, and the broker tolerates those JARs (CI passes `ranger-kafka`).

**Why HBase omits `jersey-hk2`:** HBase already had the client + Jackson JAX-RS pieces (`RangerJersey2ClientBuilder` registers `JacksonJaxbJsonProvider` explicitly). Adding HK2 to `lib/ranger-hbase-plugin-impl` killed **HMaster** in Docker CI. HDFS/Hive assemblies also omit HK2 and pass `plugins-docker-build` with auditserver enabled.

The lists are **not** meant to be identical — they complement what each plugin already shipped.

### Dependency detail

**Kafka — newly whitelisted artifacts**

| Maven coordinate | Role |
|------------------|------|
| `org.glassfish.jersey.core:jersey-client` | Jersey HTTP client used by `RangerRESTClient` |
| `org.glassfish.jersey.core:jersey-common` | Jersey core runtime |
| `org.glassfish.jersey.inject:jersey-hk2` | HK2 injection for Jersey |
| `org.glassfish.hk2.external:javax.inject` | JSR-330 inject API (Jersey 2.x) |
| `jakarta.ws.rs:jakarta.ws.rs-api` | JAX-RS API |

**HBase — newly whitelisted artifacts**

| Maven coordinate | Role |
|------------------|------|
| `org.glassfish.jersey.ext:jersey-entity-filtering` | Entity providers |
| `org.glassfish.jersey.media:jersey-media-json-jackson` | **JSON `MessageBodyWriter`** (fixes reported error) |

**HBase — intentionally omitted** (crash HMaster in CI; same as HDFS/Hive):

| Maven coordinate | Reason omitted |
|------------------|----------------|
| `org.glassfish.jersey.inject:jersey-hk2` | HMaster exits when HK2 is on plugin-impl classpath |
| `org.glassfish.hk2.external:javax.inject` | Pulled in with HK2; not needed for HBase packaging fix |

No Java source, POM, or plugin logic changes — packaging only.

## Related

- Jira: [RANGER-5642](https://issues.apache.org/jira/browse/RANGER-5642) (Kafka)
- Jira: [RANGER-5644](https://issues.apache.org/jira/browse/RANGER-5644) (HBase)
- Prior auditserver packaging fixes: RANGER-5632 (#999), Ozone/Knox Jersey whitelist (#1006 / RANGER-5637)

## Test plan

### Assembly static check

- [x] Confirm assembly descriptors list required Jersey artifacts:
  ```bash
  cd dev-support/ranger-docker
  ./scripts/audit/verify-plugin-auditserver-jars.sh --check-assembly
  ```
  Expected: `PASS: assembly XML includes required Jersey artifacts`

### Rebuild plugin tarballs

- [ ] Build fat Kafka and HBase plugin tarballs (must be multi-MB, not ~12–20 KB config-only stubs):
  ```bash
  mvn package -Pranger-kafka-plugin -pl :ranger-kafka-plugin -am -DskipTests
  mvn package -Pranger-hbase-plugin -pl :ranger-hbase-plugin -am -DskipTests
  ```

### Tarball classpath verify

- [ ] After rebuild, confirm JARs present under `lib/*-plugin-impl/`:
  ```bash
  tar tzf target/ranger-*-kafka-plugin.tar.gz | grep -E 'plugin-impl/(jersey|ranger-audit-dest-auditserver|javax\.inject)'
  tar tzf target/ranger-*-hbase-plugin.tar.gz | grep -E 'plugin-impl/(jersey|jackson-jaxrs|ranger-audit-dest-auditserver)'
  tar tzf target/ranger-*-hbase-plugin.tar.gz | grep -E 'plugin-impl/jersey-hk2' && echo "UNEXPECTED: hk2 should not be in HBase tarball"
  ```
  Expected prefixes:
  - Kafka: `jersey-client-`, `jersey-common-`, `jersey-hk2-`, `jersey-entity-filtering-`, `jersey-media-json-jackson-`, `javax.inject-`, `jakarta.ws.rs-api-`, `ranger-audit-dest-auditserver-`
  - HBase: `jersey-client-`, `jersey-common-`, `jersey-entity-filtering-`, `jersey-media-json-jackson-`, `jackson-jaxrs-json-provider-`, `jakarta.ws.rs-api-`, `ranger-audit-dest-auditserver-` — **no** `jersey-hk2-`, **no** `javax.inject-`

### CI

- [ ] `plugins-docker-build` — all containers running after 60s, especially `ranger-hbase`
- [ ] Confirm no `MessageBodyWriter` in `ranger-kafka` / `ranger-hbase` logs

### Runtime audit E2E (optional)

- [ ] Enable auditserver destination; generate access events; confirm audits reach audit ingestor without REST client errors

## Notes for reviewers

- This is the same class of fix as Ozone/Knox Jersey whitelist changes — auditserver REST client deps must be explicitly listed in assembly XML.
- **Kafka and HBase whitelists are intentionally asymmetric** — each plugin had different missing JARs on `master`; do not copy the Kafka HK2 list onto HBase.
- HBase follows **HDFS/Hive** (entity-filtering + media-json-jackson, no HK2), not Knox/Ozone (which include HK2 but run in different JVMs).
- Customers must **rebuild and redeploy** Kafka/HBase plugin tarballs after merge.
- `plugins-docker-build` must show `ranger-hbase` **running** after the 60s health check (not just plugin enable succeeding).