### PR TITLE
RANGER-5643: Fix docker Kerberos for Solr audit dispatcher

### DIFF
--- a/dev-support/ranger-docker/scripts/audit-dispatcher/ranger-audit-dispatcher-solr-site.xml
+++ b/dev-support/ranger-docker/scripts/audit-dispatcher/ranger-audit-dispatcher-solr-site.xml
@@ -106,7 +106,7 @@
     <!-- SOLR DESTINATION CONFIGURATION -->
     <property>
         <name>xasecure.audit.destination.solr.urls</name>
-        <value>http://ranger-solr:8983/solr/ranger_audits</value>
+        <value>http://ranger-solr.rangernw:8983/solr/ranger_audits</value>
         <description>
             Solr URLs for audits when SolrCloud is not enabled.
             Docker supports only standalone mode for now,

--- a/dev-support/ranger-docker/scripts/solr/ranger-solr.sh
+++ b/dev-support/ranger-docker/scripts/solr/ranger-solr.sh
@@ -33,7 +33,7 @@ then
   KRB5_CONF="-Djava.security.krb5.conf=/etc/krb5.conf"
   KERBEROS_KEYTAB="-Dsolr.kerberos.keytab=/etc/keytabs/HTTP.keytab"
   KERBEROS_PRINCIPAL="-Dsolr.kerberos.principal=HTTP/ranger-solr.rangernw@EXAMPLE.COM"
-  COOKIE_DOMAIN="-Dsolr.kerberos.cookie.domain=ranger-solr"
+  COOKIE_DOMAIN="-Dsolr.kerberos.cookie.domain=ranger-solr.rangernw"
   KERBEROS_NAME_RULES="-Dsolr.kerberos.name.rules=RULE:[2:\$1/\$2@\$0]([ndj]n/.*@EXAMPLE\.COM)s/.*/hdfs/\
 RULE:[2:\$1/\$2@\$0]([rn]m/.*@EXAMPLE\.COM)s/.*/yarn/\
 RULE:[2:\$1/\$2@\$0](jhs/.*@EXAMPLE\.COM)s/.*/mapred/\

--- a/dev-support/ranger-docker/scripts/solr/solr-security.json
+++ b/dev-support/ranger-docker/scripts/solr/solr-security.json
@@ -4,8 +4,8 @@
     "kerberos.principal":     "HTTP/ranger-solr.rangernw@EXAMPLE.COM",
     "kerberos.keytab":        "/etc/keytabs/HTTP.keytab",
     "kerberos.name.rules":    "RULE:[2:$1@$0](.*@EXAMPLE.COM)s/@.*//\nRULE:[1:$1@$0](.*@EXAMPLE.COM)s/@.*//\nDEFAULT",
-    "kerberos.cookie.domain": "ranger-solr",
-    "cookie.domain":          "ranger-solr",
+    "kerberos.cookie.domain": "ranger-solr.rangernw",
+    "cookie.domain":          "ranger-solr.rangernw",
     "token.valid":            3600
   },
   "authorization": {


### PR DESCRIPTION
Fixes [RANGER-5643](https://issues.apache.org/jira/browse/RANGER-5643): In Kerberos-enabled Docker, the Solr audit dispatcher fails to index audits — SPNEGO errors (`LOOKING_UP_SERVER`, `NEGOTIATE`, 401 from Solr) when the dispatcher uses the short Solr hostname.

### Problem

The Solr dispatcher consumes from Kafka but cannot write to Solr. Logs show:

```
NEGOTIATE authentication error: ... Server not found in Kerberos database (7) - LOOKING_UP_SERVER
Error from server at http://ranger-solr:8983/solr/ranger_audits: ... 401 Unauthorized access
```

Solr’s HTTP service principal is `HTTP/ranger-solr.rangernw@REALM`, but the dispatcher was configured with `http://ranger-solr:8983/...`. SPNEGO requires the client target hostname to match the service principal host part.

### Changes

| File | Change |
|------|--------|
| `dev-support/ranger-docker/scripts/audit-dispatcher/ranger-audit-dispatcher-solr-site.xml` | `xasecure.audit.destination.solr.urls` → `http://ranger-solr.rangernw:8983/solr/ranger_audits` |
| `dev-support/ranger-docker/scripts/solr/ranger-solr.sh` | `COOKIE_DOMAIN` → `ranger-solr.rangernw` |
| `dev-support/ranger-docker/scripts/solr/solr-security.json` | `kerberos.cookie.domain` and `cookie.domain` → `ranger-solr.rangernw` |

### Why this is sufficient for Docker

- Solr SPNEGO: FQDN in `solr.urls` matches `HTTP/ranger-solr.rangernw@EXAMPLE.COM`
- Solr cookies: cookie domain aligned with the same FQDN
- Dispatcher JAAS `_HOST`: Docker compose already sets `hostname: ranger-audit-dispatcher-solr.rangernw`, which matches the keytab entry

### Test plan

- [ ] Rebuild and recreate Solr + Solr dispatcher containers:
  ```bash
  cd dev-support/ranger-docker
  docker compose -f docker-compose.ranger-audit-dispatcher-solr.yml build ranger-solr ranger-audit-dispatcher-solr
  docker compose -f docker-compose.ranger-audit-dispatcher-solr.yml up -d --force-recreate ranger-solr ranger-audit-dispatcher-solr
  ```
- [ ] Confirm dispatcher logs: no `LOOKING_UP_SERVER` / SPNEGO / 401 on Solr update
- [ ] Generate audit activity via ingestor; verify Solr doc count increases for the test repo/user