### PR TITLE
RANGER-5646: Exclude duplicate Hive/Hadoop JARs from hive plugin packaging

### DIFF
--- a/distro/src/main/assembly/hive-agent.xml
+++ b/distro/src/main/assembly/hive-agent.xml
@@ -57,31 +57,16 @@
         <directoryMode>755</directoryMode>
         <fileMode>644</fileMode>
         <includes>
-          <include>com.carrotsearch:hppc</include>
-          <include>com.fasterxml.jackson.core:jackson-annotations:jar:${fasterxml.jackson.version}</include>
-          <include>com.fasterxml.jackson.core:jackson-core:jar:${fasterxml.jackson.version}</include>
-          <include>com.fasterxml.jackson.core:jackson-databind:jar:${fasterxml.jackson.databind.version}</include>
-          <include>com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:jar:${fasterxml.jackson.version}</include>
-          <include>com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:jar:${fasterxml.jackson.version}</include>
-          <include>com.fasterxml.jackson.module:jackson-module-jaxb-annotations:jar:${fasterxml.jackson.version}</include>
-          <include>commons-collections:commons-collections</include>
           <include>jakarta.ws.rs:jakarta.ws.rs-api</include>
-          <include>javax.annotation:javax.annotation-api</include>
-          <include>joda-time:joda-time</include>
           <include>org.apache.hadoop.thirdparty:hadoop-shaded-guava:jar:${hadoop-shaded-guava.version}</include>
-          <include>com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:jar:${fasterxml.jackson.version}</include>
-          <include>com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:jar:${fasterxml.jackson.version}</include>
-          <include>com.fasterxml.jackson.module:jackson-module-jaxb-annotations:jar:${fasterxml.jackson.version}</include>
           <include>org.apache.httpcomponents:httpasyncclient:jar:${httpcomponents.httpasyncclient.version}</include>
-          <include>org.apache.httpcomponents:httpclient:jar:${httpcomponents.httpclient.version}</include>
-          <include>org.apache.httpcomponents:httpcore-nio:jar:${httpcomponents.httpcore.version}</include>
-          <include>org.apache.httpcomponents:httpcore:jar:${httpcomponents.httpcore.version}</include>
           <include>org.apache.httpcomponents:httpmime:jar:${httpcomponents.httpmime.version}</include>
           <include>org.apache.solr:solr-solrj:jar:${solr.version}</include>
           <include>org.eclipse.jetty:jetty-client:jar:${jetty-client.version}</include>
           <include>org.glassfish.jersey.core:jersey-client</include>
           <include>org.glassfish.jersey.core:jersey-common</include>
           <include>org.glassfish.jersey.media:jersey-media-json-jackson</include>
+          <include>com.fasterxml.jackson.module:jackson-module-jaxb-annotations:jar:2.16.1</include>
           <include>org.graalvm.js:js:jar:${graalvm.version}</include>
           <include>org.graalvm.js:js-scriptengine:jar:${graalvm.version}</include>
           <include>org.graalvm.regex:regex:jar:${graalvm.version}</include>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixes [RANGER-5646](https://issues.apache.org/jira/browse/RANGER-5646): Hive plugin audit delivery to the central audit ingestor fails with **HTTP 401** when duplicate libraries in `lib/ranger-hive-plugin-impl/` conflict with HiveServer2’s classpath.

### Problem

When `xasecure.audit.destination.auditserver=true`, the Hive plugin uses `RangerAuditServerDestination` (Jersey 2 REST client) to POST audits to the audit ingestor. Ranger plugin assemblies **whitelist** dependencies into `lib/ranger-hive-plugin-impl/`; anything listed is loaded on the isolated plugin classloader.

The Hive assembly currently whitelists JARs that HiveServer2 **already provides at different versions** on its application classpath (Jackson 2.17 from Ranger build vs 2.16 on Hive 4.x, httpclient/httpcore, hppc, commons-collections, etc.). Version skew across classloaders breaks the Jersey audit client’s auth/serialization path:

```
Failed to send audit batch … HTTP 401
Authentication failure
```

### Solution

Tighten the `lib/ranger-hive-plugin-impl` whitelist in `distro/src/main/assembly/hive-agent.xml`:

- **Remove** libraries Hive/Hadoop already ship (or that must not be duplicated on the plugin classloader): `hppc`, Ranger-pinned Jackson 2.17 (`jackson-core`, `jackson-databind`, `jackson-annotations`, `jackson-jaxrs-*`), `httpclient`, `httpcore`, `httpcore-nio`, `commons-collections`, `javax.annotation-api`, `joda-time`, duplicate `jackson-module-jaxb-annotations` entries.
- **Keep** Jersey audit-server client stack, audit-core/dest-auditserver module JARs, Graal/ICU (policy engine), Solr/Jetty/httpasyncclient/httpmime where not duplicated by Hive lib.
- **Pin** `jackson-module-jaxb-annotations:2.16.1` (Hive 4.x–aligned JAXB support for Jersey JSON) instead of `${fasterxml.jackson.version}` (2.17).

No Java source, POM, or Docker changes — **packaging only**.

### Changes

| Area | File | Change |
|------|------|--------|
| Hive packaging | `distro/src/main/assembly/hive-agent.xml` | Filter `lib/ranger-hive-plugin-impl` whitelist: drop Hive/Hadoop duplicate deps; pin `jackson-module-jaxb-annotations:2.16.1` |

#### Removed from plugin-impl whitelist

| Maven coordinate | Why removed |
|------------------|-------------|
| `com.carrotsearch:hppc` | Hive lib provides; version skew → 401 |
| `com.fasterxml.jackson.core:jackson-*` (2.17) | HS2 uses 2.16.x; plugin must not ship 2.17 copies |
| `com.fasterxml.jackson.jaxrs:jackson-jaxrs-*` (2.17) | Same |
| `com.fasterxml.jackson.module:jackson-module-jaxb-annotations` (2.17) | Replaced by pinned 2.16.1 |
| `commons-collections:commons-collections` | Duplicate of Hive classpath |
| `javax.annotation:javax.annotation-api` | Duplicate |
| `joda-time:joda-time` | Duplicate |
| `org.apache.httpcomponents:httpclient` | Hive/Hadoop lib provides aligned version |
| `org.apache.httpcomponents:httpcore` / `httpcore-nio` | Same |

#### Retained (audit + plugin runtime)

| Category | Examples |
|----------|----------|
| Audit REST client | `jersey-client`, `jersey-common`, `jersey-media-json-jackson`, `jakarta.ws.rs-api` |
| JAXB (Hive-aligned) | `jackson-module-jaxb-annotations:2.16.1` |
| Other whitelisted | `httpasyncclient`, `httpmime`, `solr-solrj`, `jetty-client`, Graal/ICU, `hadoop-shaded-guava` |

## How was this patch tested?

## Test plan

- [ ] Rebuild hive plugin tarball from fixed assembly (full reactor or `distro` with `-P-all,ranger-hive-plugin`).
- [ ] Verify `lib/ranger-hive-plugin-impl/` in tarball **does not** contain: `hppc`, `httpclient`, `httpcore`, `jackson-core-2.17*`, `commons-collections-3.2.2`, `hive-*`.
- [ ] Verify tarball **does** contain: `jersey-client`, `ranger-audit-dest-auditserver`, `jackson-module-jaxb-annotations-2.16.1`.
- [ ] Install/enable plugin on HiveServer2 (Kerberos + auditserver destination enabled).
- [ ] Run a Hive query; confirm HS2 logs show no HTTP **401** on audit batch send to ingestor.
- [ ] Confirm audits appear for the Hive service repository in the audit pipeline (ingestor / Solr / Admin Access as applicable).

**Build example:**

```bash
cd distro
mvn install -P-all,ranger-hive-plugin -DskipTests -Drat.skip=true
# Tarball: ../target/ranger-*-hive-plugin.tar.gz
```