### PR TITLE
RANGER-5642: Exclude duplicate Jersey JARs from Kafka plugin packaging

### DIFF
--- a/agents-common/src/test/resources/policyengine/test_policyengine_tag_hive.json
+++ b/agents-common/src/test/resources/policyengine/test_policyengine_tag_hive.json
@@ -250,7 +250,7 @@
         "resource":{"elements":{"database":"employee", "table":"personal", "column":"ssn"}},
         "accessType":"select","user":"testuser","userGroups":[],"requestData":"select ssn from employee.personal;' for testuser",
 
-        "context": {"TAGS":"[{\"type\":\"EXPIRES_ON\", \"attributes\":{\"expiry_date\":\"2099-12-31T15:05:15.000Z\"}, \"matchType\":\"DESCENDANT\"}]"}
+        "context": {"TAGS":"[{\"type\":\"EXPIRES_ON\", \"attributes\":{\"expiry_date\":\"2026-06-15T15:05:15.000Z\"}, \"matchType\":\"DESCENDANT\"}]"}
       },
       "result":{"isAudited":true,"isAllowed":false,"policyId":-1}
     },
@@ -259,7 +259,7 @@
         "resource":{"elements":{"database":"employee", "table":"personal", "column":"ssn"}},
         "accessType":"select","user":"user1","userGroups":[],"requestData":"select ssn from employee.personal;' for user1",
 
-        "context": {"TAGS":"[{\"type\":\"EXPIRES_ON\", \"attributes\":{\"expiry_date\":\"2099-12-31T15:05:15.000Z\"}, \"matchType\":\"SELF\"}]"}
+        "context": {"TAGS":"[{\"type\":\"EXPIRES_ON\", \"attributes\":{\"expiry_date\":\"2026-06-15T15:05:15.000Z\"}, \"matchType\":\"SELF\"}]"}
       },
       "result":{"isAudited":true,"isAllowed":true,"policyId":101}
     },

--- a/agents-common/src/test/resources/policyengine/test_policyengine_tag_hive.json
+++ b/agents-common/src/test/resources/policyengine/test_policyengine_tag_hive.json
@@ -250,7 +250,7 @@
         "resource":{"elements":{"database":"employee", "table":"personal", "column":"ssn"}},
         "accessType":"select","user":"testuser","userGroups":[],"requestData":"select ssn from employee.personal;' for testuser",
 
-        "context": {"TAGS":"[{\"type\":\"EXPIRES_ON\", \"attributes\":{\"expiry_date\":\"2026-06-15T15:05:15.000Z\"}, \"matchType\":\"DESCENDANT\"}]"}
+        "context": {"TAGS":"[{\"type\":\"EXPIRES_ON\", \"attributes\":{\"expiry_date\":\"2099-12-31T15:05:15.000Z\"}, \"matchType\":\"DESCENDANT\"}]"}
       },
       "result":{"isAudited":true,"isAllowed":false,"policyId":-1}
     },
@@ -259,7 +259,7 @@
         "resource":{"elements":{"database":"employee", "table":"personal", "column":"ssn"}},
         "accessType":"select","user":"user1","userGroups":[],"requestData":"select ssn from employee.personal;' for user1",
 
-        "context": {"TAGS":"[{\"type\":\"EXPIRES_ON\", \"attributes\":{\"expiry_date\":\"2026-06-15T15:05:15.000Z\"}, \"matchType\":\"SELF\"}]"}
+        "context": {"TAGS":"[{\"type\":\"EXPIRES_ON\", \"attributes\":{\"expiry_date\":\"2099-12-31T15:05:15.000Z\"}, \"matchType\":\"SELF\"}]"}
       },
       "result":{"isAudited":true,"isAllowed":true,"policyId":101}
     },

--- a/distro/src/main/assembly/plugin-kafka.xml
+++ b/distro/src/main/assembly/plugin-kafka.xml
@@ -82,11 +82,6 @@
 					<include>org.apache.solr:solr-solrj:jar:${solr.version}</include>
 					<include>org.codehaus.woodstox:stax2-api</include>
 					<include>org.eclipse.jetty:jetty-client:jar:${jetty-client.version}</include>
-					<include>org.glassfish.jersey.core:jersey-client</include>
-					<include>org.glassfish.jersey.core:jersey-common</include>
-					<include>org.glassfish.jersey.inject:jersey-hk2</include>
-					<include>org.glassfish.hk2.external:javax.inject</include>
-					<include>jakarta.ws.rs:jakarta.ws.rs-api</include>
 					<include>org.glassfish.jersey.ext:jersey-entity-filtering:jar:${jersey-client.version}</include>
 					<include>org.glassfish.jersey.media:jersey-media-json-jackson:jar:${jersey-client.version}</include>
 				</includes>

--- a/distro/src/main/assembly/plugin-kafka.xml
+++ b/distro/src/main/assembly/plugin-kafka.xml
@@ -54,10 +54,6 @@
 				<fileMode>644</fileMode>
 				<includes>
 					<include>com.carrotsearch:hppc</include>
-					<include>com.fasterxml.jackson.core:jackson-annotations:jar:${fasterxml.jackson.version}</include>
-					<include>com.fasterxml.jackson.core:jackson-core:jar:${fasterxml.jackson.version}</include>
-					<include>com.fasterxml.jackson.core:jackson-databind:jar:${fasterxml.jackson.version}</include>
-					<include>com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:jar:${fasterxml.jackson.version}</include>
 					<include>com.fasterxml.woodstox:woodstox-core</include>
 					<include>com.google.code.gson:gson</include>
 					<include>com.google.protobuf:protobuf-java:jar:${protobuf-java.version}</include>


### PR DESCRIPTION
## Summary

Fixes **Kafka** plugin audit delivery to the **auditserver** ingestor when `XAAUDIT.AUDITSERVER.ENABLE=true` ([RANGER-5642](https://issues.apache.org/jira/browse/RANGER-5642)).

**Revert the Kafka portion of [#1015](https://github.com/apache/ranger/pull/1015):** remove duplicate Glassfish Jersey **and Jackson** JARs from `plugin-kafka.xml`. The Kafka broker already ships Jersey and Jackson (e.g. 2.16.x) on the application classpath; packaging different versions (Ranger 2.17.x) into `lib/ranger-kafka-plugin-impl/` causes class-loader skew and audit POST failures.

**Keep** in plugin-impl only what the broker lacks: `jersey-entity-filtering`, `jersey-media-json-jackson`, and `ranger-audit-dest-auditserver`.

Same principle as Hive [RANGER-5646 / #1019](https://github.com/apache/ranger/commit/9272baf0832007a21982e62be6510c7a1c3e0071) — tighten the assembly whitelist; do not duplicate host-provided libraries.

**Scope:** one file — `distro/src/main/assembly/plugin-kafka.xml`. No Java, POM, or Docker changes.

## Problem

After #1015, `plugin-kafka.xml` whitelisted broker-provided Jersey **and** Jackson JARs into `lib/ranger-kafka-plugin-impl/`. At runtime the plugin class loader and broker application classpath both supply these libraries (often at **different versions**), causing:

- `WadlAutoDiscoverable` / `AutoDiscoverable` ClassCastException (duplicate Jersey)
- `MessageBodyWriter` / Jackson `LinkageError` (duplicate Jackson 2.17.x in plugin vs 2.16.x on broker)
- Audits never reach audit ingestor

## Changes

| File | Change |
|------|--------|
| `distro/src/main/assembly/plugin-kafka.xml` | **Remove** from `lib/ranger-kafka-plugin-impl` whitelist: `jersey-client`, `jersey-common`, `jersey-hk2`, `javax.inject`, `jakarta.ws.rs-api`, and `jackson-annotations`, `jackson-core`, `jackson-databind`, `jackson-jaxrs-json-provider` |

**Unchanged** in plugin-impl whitelist:

| Maven coordinate | Role |
|------------------|------|
| `org.glassfish.jersey.ext:jersey-entity-filtering` | Entity providers |
| `org.glassfish.jersey.media:jersey-media-json-jackson` | JSON `MessageBodyWriter` for audit POST |
| `ranger-audit-dest-auditserver` | Audit ingestor destination |

Broker Jersey/Jackson are resolved from the Kafka broker classpath — single source for shared types.

## Test plan

### Assembly static check

```bash
grep -E 'jersey-(client|common|hk2)|javax\.inject|jakarta\.ws\.rs-api|jackson-(annotations|core|databind|jaxrs)'   distro/src/main/assembly/plugin-kafka.xml   && echo "UNEXPECTED" || echo "OK: no broker Jersey/Jackson whitelisted"
grep -E 'jersey-entity-filtering|jersey-media-json-jackson' distro/src/main/assembly/plugin-kafka.xml
```

### Rebuild Kafka plugin tarball

```bash
mvn package -Pranger-kafka-plugin -pl :ranger-kafka-plugin,:ranger-distro -am -DskipTests
# verify plugin-impl has JSON writers but no jackson-*.jar / jersey-client-*.jar:
tar tzf target/ranger-*-kafka-plugin.tar.gz | grep plugin-impl | grep -E 'jackson|jersey'
```
## Related

- Jira: [RANGER-5642](https://issues.apache.org/jira/browse/RANGER-5642)
- Regression: [#1015](https://github.com/apache/ranger/pull/1015)
- Analogue: [#1019](https://github.com/apache/ranger/commit/9272baf0832007a21982e62be6510c7a1c3e0071) / RANGER-5646 (Hive)