### PR TITLE
RANGER-5647: Fix remaining ISO EXPIRES_ON dates in hive tag tests

### DIFF
--- a/agents-common/src/test/resources/policyengine/test_policyengine_tag_hive.json
+++ b/agents-common/src/test/resources/policyengine/test_policyengine_tag_hive.json
@@ -250,7 +250,7 @@
         "resource":{"elements":{"database":"employee", "table":"personal", "column":"ssn"}},
         "accessType":"select","user":"testuser","userGroups":[],"requestData":"select ssn from employee.personal;' for testuser",
 
-        "context": {"TAGS":"[{\"type\":\"EXPIRES_ON\", \"attributes\":{\"expiry_date\":\"2026-06-15T15:05:15.000Z\"}, \"matchType\":\"DESCENDANT\"}]"}
+        "context": {"TAGS":"[{\"type\":\"EXPIRES_ON\", \"attributes\":{\"expiry_date\":\"2099-12-31T15:05:15.000Z\"}, \"matchType\":\"DESCENDANT\"}]"}
       },
       "result":{"isAudited":true,"isAllowed":false,"policyId":-1}
     },
@@ -259,7 +259,7 @@
         "resource":{"elements":{"database":"employee", "table":"personal", "column":"ssn"}},
         "accessType":"select","user":"user1","userGroups":[],"requestData":"select ssn from employee.personal;' for user1",
 
-        "context": {"TAGS":"[{\"type\":\"EXPIRES_ON\", \"attributes\":{\"expiry_date\":\"2026-06-15T15:05:15.000Z\"}, \"matchType\":\"SELF\"}]"}
+        "context": {"TAGS":"[{\"type\":\"EXPIRES_ON\", \"attributes\":{\"expiry_date\":\"2099-12-31T15:05:15.000Z\"}, \"matchType\":\"SELF\"}]"}
       },
       "result":{"isAudited":true,"isAllowed":true,"policyId":101}
     },


### PR DESCRIPTION
## Summary

Completes [RANGER-5647 / #1018](https://github.com/apache/ranger/pull/1018) for **ISO-format** tag expiry dates in policy-engine tests.

PR #1018 changed slash-format fixture dates (`2026/06/15` → `2099/12/31`) in shared tag JSON files and `RangerPathResourceMatcher` thread safety. Two **inline ISO** `EXPIRES_ON` values in `test_policyengine_tag_hive.json` were left unchanged.

After **2026-06-15**, CI `build-17` fails:

```
TestPolicyEngine.testPolicyEngine_hiveForTag
ALLOW 'select ssn from employee.personal;' for user1 using EXPIRES_ON tag
==> expected: <true> but was: <false>
```

Tag policy uses `ctx.isAccessedAfter('expiry_date')`; once the clock passes the fixture expiry, access is denied.

## Changes

| File | Change |
|------|--------|
| `agents-common/src/test/resources/policyengine/test_policyengine_tag_hive.json` | `2026-06-15T15:05:15.000Z` → `2099-12-31T15:05:15.000Z` for EXPIRES_ON **DESCENDANT** and **SELF** test cases |

No policy-engine logic changes — test fixture dates only.

## Related

- [#1018](https://github.com/apache/ranger/pull/1018) / [38d2153](https://github.com/apache/ranger/commit/38d21532259a9d19f9539ee358ec5b4c732f42ee) — slash-format dates + path matcher fix
- Unblocks CI failures seen on unrelated PRs (e.g. #1020) that inherit the expired ISO dates

## Test plan

- [ ] `mvn test -pl agents-common -Dtest=TestPolicyEngine#testPolicyEngine_hiveForTag,TestPolicyEngine#testPolicyEngine_hiveForTag_filebased -Drat.skip=true -Dcheckstyle.skip=true -Dpmd.skip=true -Dspotbugs.skip=true`
