### PR TITLE
RANGER-5619: Keyadmin user unable to perform test connection for cm_k…

### DIFF
--- a/security-admin/src/main/java/org/apache/ranger/rest/ServiceREST.java
+++ b/security-admin/src/main/java/org/apache/ranger/rest/ServiceREST.java
@@ -196,7 +196,7 @@ public class ServiceREST {
     public static final String PURGE_RECORD_TYPE_LOGIN_LOGS         = "login_records";
     public static final String PURGE_RECORD_TYPE_TRX_LOGS           = "trx_records";
     public static final String PURGE_RECORD_TYPE_POLICY_EXPORT_LOGS = "policy_export_logs";
-    public static final String ERR_VALIDATE_CONFIG_ADMIN_ONLY       = "Only system administrators can validate service configs";
+    public static final String ERR_VALIDATE_CONFIG_ADMIN_ONLY       = "Only system administrators or key administrators can validate service configs";
 
     private final RangerAdminConfig config                              = RangerAdminConfig.getInstance();
     private final int               maxPolicyNameLength                 = config.getInt("ranger.policyname.maxlength", 255);
@@ -1080,8 +1080,14 @@ public class ServiceREST {
         RangerPerfTracer perf = null;
 
         if (!bizUtil.isAdmin()) {
-            LOG.warn("Unauthorized validateConfig attempt by user: {}", bizUtil.getCurrentUserLoginId());
-            throw restErrorUtil.createRESTException(HttpServletResponse.SC_FORBIDDEN, ERR_VALIDATE_CONFIG_ADMIN_ONLY, true);
+            if (!bizUtil.isKeyAdmin()) {
+                LOG.warn("Unauthorized validateConfig attempt by user: {}", bizUtil.getCurrentUserLoginId());
+                throw restErrorUtil.createRESTException(HttpServletResponse.SC_FORBIDDEN, ERR_VALIDATE_CONFIG_ADMIN_ONLY, true);
+            }
+            XXServiceDef serviceDef = daoManager.getXXServiceDef().findByName(service.getType());
+            if (serviceDef == null || !EmbeddedServiceDefsUtil.KMS_IMPL_CLASS_NAME.equals(serviceDef.getImplclassname())) {
+                throw restErrorUtil.createRESTException(HttpServletResponse.SC_FORBIDDEN, ERR_VALIDATE_CONFIG_ADMIN_ONLY, true);
+            }
         }
         try {
             if (RangerPerfTracer.isPerfTraceEnabled(PERF_LOG)) {

--- a/security-admin/src/test/java/org/apache/ranger/rest/TestServiceREST.java
+++ b/security-admin/src/test/java/org/apache/ranger/rest/TestServiceREST.java
@@ -1134,6 +1134,44 @@ public class TestServiceREST {
     }
 
     @Test
+    public void test35eValidateConfig_KeyAdminUser_KmsService_Succeeds() throws Exception {
+        RangerService rangerService = rangerService();
+        rangerService.setType("cm_kms");
+        Mockito.when(bizUtil.isAdmin()).thenReturn(false);
+        Mockito.when(bizUtil.isKeyAdmin()).thenReturn(true);
+        XXServiceDef xServiceDef = serviceDef();
+        XXServiceDefDao xServiceDefDao = Mockito.mock(XXServiceDefDao.class);
+        xServiceDef.setImplclassname(EmbeddedServiceDefsUtil.KMS_IMPL_CLASS_NAME);
+        Mockito.when(daoManager.getXXServiceDef()).thenReturn(xServiceDefDao);
+        Mockito.when(xServiceDefDao.findByName("cm_kms")).thenReturn(xServiceDef);
+        Mockito.when(serviceMgr.validateConfig(rangerService, svcStore)).thenReturn(vXResponse);
+        VXResponse result = serviceREST.validateConfig(rangerService);
+        Assertions.assertNotNull(result);
+        Mockito.verify(bizUtil).isAdmin();
+        Mockito.verify(bizUtil).isKeyAdmin();
+        Mockito.verify(serviceMgr).validateConfig(rangerService, svcStore);
+    }
+
+    @Test
+    public void test35fValidateConfig_KeyAdminUser_NonKmsService_ThrowsForbidden() throws Exception {
+        RangerService rangerService = rangerService();
+        rangerService.setType("hdfs");
+        Mockito.when(bizUtil.isAdmin()).thenReturn(false);
+        Mockito.when(bizUtil.isKeyAdmin()).thenReturn(true);
+        XXServiceDef xServiceDef = serviceDef();
+        XXServiceDefDao xServiceDefDao = Mockito.mock(XXServiceDefDao.class);
+        xServiceDef.setImplclassname("org.apache.ranger.services.hdfs.RangerServiceHdfs");
+        Mockito.when(daoManager.getXXServiceDef()).thenReturn(xServiceDefDao);
+        Mockito.when(xServiceDefDao.findByName("hdfs")).thenReturn(xServiceDef);
+        Mockito.when(restErrorUtil.createRESTException(Mockito.eq(HttpServletResponse.SC_FORBIDDEN), Mockito.anyString(), Mockito.eq(true)))
+                .thenReturn(new WebApplicationException(HttpServletResponse.SC_FORBIDDEN));
+        Assertions.assertThrows(WebApplicationException.class, () -> serviceREST.validateConfig(rangerService));
+        Mockito.verify(bizUtil).isAdmin();
+        Mockito.verify(bizUtil).isKeyAdmin();
+        Mockito.verify(serviceMgr, Mockito.never()).validateConfig(Mockito.any(), Mockito.any());
+    }
+
+    @Test
     public void test40applyPolicy() {
         RangerPolicy existingPolicy = rangerPolicy();
         RangerPolicy appliedPolicy  = rangerPolicy();


### PR DESCRIPTION
…ms service

## What changes were proposed in this pull request?

Added explicit role check in ServiceREST.validateConfig():

ROLE_SYS_ADMIN --> allowed for all services
ROLE_KEY_ADMIN --> allowed for KMS services only
All other roles --> FORBIDDEN

Initial fix caused a regression where KeyAdmin users were unable to test connection for cm_kms service. Fixed by allowing ROLE_KEY_ADMIN access for KMS service types only, verified via service definition implementation class name.


## How was this patch tested?

added a new test
