### PR TITLE
RANGER-5656: TagSync Atlas REST sync fails with AbstractMethodError after RANGER-4076 Jersey 2 migration

### DIFF
--- a/distro/src/main/assembly/tagsync.xml
+++ b/distro/src/main/assembly/tagsync.xml
@@ -69,9 +69,6 @@
 							<include>javax.inject:javax.inject</include>
 							<include>javax.xml.bind:jaxb-api</include>
 							<include>joda-time:joda-time</include>
-							<include>org.apache.atlas:atlas-client-common:jar:${atlas.version}</include>
-							<include>org.apache.atlas:atlas-client-v1:jar:${atlas.version}</include>
-							<include>org.apache.atlas:atlas-client-v2:jar:${atlas.version}</include>
 							<include>org.apache.atlas:atlas-common:jar:${atlas.version}</include>
 							<include>org.apache.atlas:atlas-intg:jar:${atlas.version}</include>
 							<include>org.apache.atlas:atlas-notification:jar:${atlas.version}</include>

--- a/tagsync/pom.xml
+++ b/tagsync/pom.xml
@@ -157,60 +157,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.atlas</groupId>
-            <artifactId>atlas-client-v1</artifactId>
-            <version>${atlas.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>jakarta.ws.rs</groupId>
-                    <artifactId>jakarta.ws.rs-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>javax.xml.bind</groupId>
-                    <artifactId>jaxb-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>javax.xml.bind</groupId>
-                    <artifactId>jaxb-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.springframework</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.atlas</groupId>
-            <artifactId>atlas-client-v2</artifactId>
-            <version>${atlas.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>jakarta.ws.rs</groupId>
-                    <artifactId>jakarta.ws.rs-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.springframework</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.atlas</groupId>
             <artifactId>atlas-common</artifactId>
             <version>${atlas.version}</version>
             <exclusions>

--- a/tagsync/src/main/java/org/apache/ranger/tagsync/source/atlasrest/AtlasRESTHttpClient.java
+++ b/tagsync/src/main/java/org/apache/ranger/tagsync/source/atlasrest/AtlasRESTHttpClient.java
@@ -43,19 +43,12 @@ import java.security.PrivilegedExceptionAction;
  * Jersey 2.x REST sink.
  */
 public final class AtlasRESTHttpClient {
-    /** Class logger. */
     private static final Logger LOG = LoggerFactory.getLogger(AtlasRESTHttpClient.class);
 
-    /** Atlas basic search API path (POST). */
-    private static final String SEARCH_PATH = "/api/atlas/v2/search/basic";
-
-    /** Atlas typedef export API path (GET). */
+    private static final String SEARCH_PATH   = "/api/atlas/v2/search/basic";
     private static final String TYPEDEFS_PATH = "/api/atlas/v2/types/typedefs/";
 
-    /** Ranger REST client with SSL and HA URL support. */
     private final RangerRESTClient restClient;
-
-    /** Whether TagSync runs with Kerberos credentials. */
     private final boolean          kerberized;
 
     /**
@@ -87,7 +80,7 @@ public final class AtlasRESTHttpClient {
      */
     public AtlasSearchResult facetedSearch(final SearchParameters searchParameters) throws Exception {
         Response response = execute(() -> restClient.post(SEARCH_PATH, null, searchParameters));
-        String json = readResponseBody(response, SEARCH_PATH);
+        String   json     = readResponseBody(response, SEARCH_PATH);
 
         return AtlasType.fromJson(json, AtlasSearchResult.class);
     }
@@ -100,7 +93,7 @@ public final class AtlasRESTHttpClient {
      */
     public AtlasTypesDef getAllTypeDefs() throws Exception {
         Response response = execute(() -> restClient.get(TYPEDEFS_PATH, null));
-        String json = readResponseBody(response, TYPEDEFS_PATH);
+        String   json     = readResponseBody(response, TYPEDEFS_PATH);
 
         return AtlasType.fromJson(json, AtlasTypesDef.class);
     }
@@ -117,6 +110,7 @@ public final class AtlasRESTHttpClient {
                 ret = ugi.doAs((PrivilegedExceptionAction<Response>) restCall::run);
             } catch (InterruptedException interruptedException) {
                 Thread.currentThread().interrupt();
+
                 throw new IOException("Atlas REST call interrupted", interruptedException);
             }
         } else {
@@ -131,8 +125,8 @@ public final class AtlasRESTHttpClient {
             throw new IOException("Atlas REST " + relativeUrl + " failed: no response from any configured URL");
         }
 
-        int status = response.getStatus();
-        String body = response.hasEntity() ? response.readEntity(String.class) : "";
+        int    status = response.getStatus();
+        String body   = response.hasEntity() ? response.readEntity(String.class) : "";
 
         if (status != Response.Status.OK.getStatusCode()) {
             throw new IOException("Atlas REST " + relativeUrl + " failed with HTTP " + status + ": " + body);

--- a/tagsync/src/main/java/org/apache/ranger/tagsync/source/atlasrest/AtlasRESTHttpClient.java
+++ b/tagsync/src/main/java/org/apache/ranger/tagsync/source/atlasrest/AtlasRESTHttpClient.java
@@ -24,23 +24,20 @@ import org.apache.atlas.model.discovery.SearchParameters;
 import org.apache.atlas.model.typedef.AtlasTypesDef;
 import org.apache.atlas.type.AtlasType;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.ranger.plugin.util.RangerRESTClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.ws.rs.core.Response;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
 import java.security.PrivilegedExceptionAction;
-import java.util.Base64;
 
 /**
  * Minimal Atlas REST client for TagSync.
  *
- * <p>Uses {@link HttpURLConnection} instead of {@code AtlasClientV2} so TagSync
+ * <p>Uses {@link RangerRESTClient} for SSL, HA URL failover, and auth so TagSync
  * does not load the Atlas Jersey 1.x client on the same classpath as Ranger's
  * Jersey 2.x REST sink.
  */
@@ -50,151 +47,100 @@ public final class AtlasRESTHttpClient {
             LoggerFactory.getLogger(AtlasRESTHttpClient.class);
 
     /** Atlas basic search API path (POST). */
-    private static final String SEARCH_PATH = "api/atlas/v2/search/basic";
+    private static final String SEARCH_PATH = "/api/atlas/v2/search/basic";
 
     /** Atlas typedef export API path (GET). */
-    private static final String TYPEDEFS_PATH = "api/atlas/v2/types/typedefs/";
+    private static final String TYPEDEFS_PATH = "/api/atlas/v2/types/typedefs/";
 
-    /** Minimum HTTP status treated as an error response. */
-    private static final int HTTP_STATUS_CLIENT_ERROR = 400;
+    private final RangerRESTClient restClient;
+    private final boolean          kerberized;
 
-    private AtlasRESTHttpClient() {
-        // utility class
+    /**
+     * Create an Atlas REST client backed by {@link RangerRESTClient}.
+     *
+     * @param restUrls          comma-separated Atlas REST base URLs
+     * @param sslConfigFile     SSL config file for HTTPS endpoints
+     * @param config            Hadoop configuration
+     * @param userNamePassword  basic-auth credentials; ignored when kerberized
+     * @param kerberized        {@code true} when TagSync uses a keytab
+     */
+    public AtlasRESTHttpClient(final String restUrls, final String sslConfigFile, final Configuration config, final String[] userNamePassword, final boolean kerberized) {
+        this.kerberized = kerberized;
+        this.restClient = new RangerRESTClient(restUrls, sslConfigFile, config, "ranger.tagsync");
+
+        if (userNamePassword != null && userNamePassword.length >= 2 && StringUtils.isNotEmpty(userNamePassword[0])) {
+            restClient.setBasicAuthInfo(userNamePassword[0], userNamePassword[1]);
+        }
+
+        restClient.getClient();
     }
 
     /**
      * Search Atlas for entities matching the given parameters.
      *
-     * @param restBaseUrl       Atlas REST base URL ending with {@code /}
-     * @param searchParameters  search filter (classification, limit, etc.)
-     * @param userNamePassword  basic-auth credentials; empty for Kerberos
-     * @param useKerberos       {@code true} when TagSync uses a keytab
+     * @param searchParameters search filter (classification, limit, etc.)
      * @return parsed search result
-     * @throws IOException when the REST call fails
+     * @throws Exception when the REST call fails on all configured URLs
      */
-    public static AtlasSearchResult facetedSearch(final String restBaseUrl,
-            final SearchParameters searchParameters,
-            final String[] userNamePassword, final boolean useKerberos)
-            throws IOException {
-        String body = AtlasType.toJson(searchParameters);
-        String json = postJson(restBaseUrl + SEARCH_PATH, body,
-                userNamePassword, useKerberos);
-
+    public AtlasSearchResult facetedSearch(final SearchParameters searchParameters)
+            throws Exception {
+        Response response = execute(() -> restClient.post(SEARCH_PATH, null, searchParameters));
+        String json = readResponseBody(response, SEARCH_PATH);
         return AtlasType.fromJson(json, AtlasSearchResult.class);
     }
 
     /**
      * Download all Atlas type definitions.
      *
-     * @param restBaseUrl       Atlas REST base URL ending with {@code /}
-     * @param userNamePassword  basic-auth credentials; empty for Kerberos
-     * @param useKerberos       {@code true} when TagSync uses a keytab
      * @return typedef bundle from Atlas
-     * @throws IOException when the REST call fails
+     * @throws Exception when the REST call fails on all configured URLs
      */
-    public static AtlasTypesDef getAllTypeDefs(final String restBaseUrl,
-            final String[] userNamePassword, final boolean useKerberos)
-            throws IOException {
-        String json = getJson(restBaseUrl + TYPEDEFS_PATH, userNamePassword,
-                useKerberos);
+    public AtlasTypesDef getAllTypeDefs() throws Exception {
+        Response response = execute(() -> restClient.get(TYPEDEFS_PATH, null));
+        String json = readResponseBody(response, TYPEDEFS_PATH);
 
         return AtlasType.fromJson(json, AtlasTypesDef.class);
     }
 
-    private static String postJson(final String url, final String body,
-            final String[] userNamePassword, final boolean useKerberos)
-            throws IOException {
-        return execute(url, "POST", body, userNamePassword, useKerberos);
-    }
-
-    private static String getJson(final String url,
-            final String[] userNamePassword, final boolean useKerberos)
-            throws IOException {
-        return execute(url, "GET", null, userNamePassword, useKerberos);
-    }
-
-    private static String execute(final String url, final String method,
-            final String body, final String[] userNamePassword,
-            final boolean useKerberos) throws IOException {
-        if (useKerberosAuth(userNamePassword, useKerberos)) {
+    private Response execute(final RestCall restCall) throws Exception {
+        if (kerberized) {
             UserGroupInformation ugi = UserGroupInformation.getLoginUser();
 
             ugi.checkTGTAndReloginFromKeytab();
 
             try {
-                return ugi.doAs((PrivilegedExceptionAction<String>) () -> openAndRead(url, method, body, null, true));
+                return ugi.doAs((PrivilegedExceptionAction<Response>) restCall::run);
             } catch (InterruptedException interruptedException) {
                 Thread.currentThread().interrupt();
-                throw new IOException("Atlas REST call interrupted",
-                        interruptedException);
+                throw new IOException("Atlas REST call interrupted", interruptedException);
             }
         }
 
-        return openAndRead(url, method, body, userNamePassword, false);
+        return restCall.run();
     }
 
-    private static boolean useKerberosAuth(final String[] userNamePassword,
-            final boolean useKerberos) {
-        return useKerberos && (userNamePassword == null || userNamePassword.length == 0 || StringUtils.isBlank(userNamePassword[0]));
-    }
-
-    private static String openAndRead(final String url, final String method,
-            final String body, final String[] userNamePassword,
-            final boolean kerberos) throws IOException {
-        HttpURLConnection connection =
-                (HttpURLConnection) new URL(url).openConnection();
-
-        connection.setRequestMethod(method);
-        connection.setRequestProperty("Accept", "application/json");
-        connection.setRequestProperty("Content-Type", "application/json");
-
-        if (!kerberos && userNamePassword != null && userNamePassword.length >= 2 && StringUtils.isNotEmpty(userNamePassword[0])) {
-            String credentials = userNamePassword[0] + ":"
-                    + userNamePassword[1];
-            String encoded = Base64.getEncoder().encodeToString(
-                    credentials.getBytes(StandardCharsets.UTF_8));
-
-            connection.setRequestProperty("Authorization", "Basic " + encoded);
+    private String readResponseBody(final Response response, final String relativeUrl)
+            throws IOException {
+        if (response == null) {
+            throw new IOException("Atlas REST " + relativeUrl + " failed: no response from any configured URL");
         }
 
-        if (body != null) {
-            connection.setDoOutput(true);
-            byte[] payload = body.getBytes(StandardCharsets.UTF_8);
+        int status = response.getStatus();
+        String body = response.hasEntity() ? response.readEntity(String.class) : "";
 
-            connection.setRequestProperty("Content-Length",
-                    String.valueOf(payload.length));
-
-            try (OutputStream outputStream = connection.getOutputStream()) {
-                outputStream.write(payload);
-            }
-        }
-
-        int status = connection.getResponseCode();
-        InputStream stream = status >= HTTP_STATUS_CLIENT_ERROR
-                ? connection.getErrorStream()
-                : connection.getInputStream();
-
-        if (stream == null) {
-            throw new IOException("Atlas REST " + method + " " + url + " returned HTTP " + status + " with empty body");
-        }
-
-        String response = readStream(stream);
-
-        if (status >= HTTP_STATUS_CLIENT_ERROR) {
-            throw new IOException("Atlas REST " + method + " " + url + " failed with HTTP " + status + ": " + response);
+        if (status != Response.Status.OK.getStatusCode()) {
+            throw new IOException("Atlas REST " + relativeUrl + " failed with HTTP " + status + ": " + body);
         }
 
         if (LOG.isDebugEnabled()) {
-            LOG.debug("Atlas REST {} {} -> HTTP {}", method, url, status);
+            LOG.debug("Atlas REST {} -> HTTP {}", relativeUrl, status);
         }
 
-        return response;
+        return body;
     }
 
-    private static String readStream(final InputStream stream)
-            throws IOException {
-        byte[] buffer = stream.readAllBytes();
-
-        return new String(buffer, StandardCharsets.UTF_8);
+    @FunctionalInterface
+    private interface RestCall {
+        Response run() throws Exception;
     }
 }

--- a/tagsync/src/main/java/org/apache/ranger/tagsync/source/atlasrest/AtlasRESTHttpClient.java
+++ b/tagsync/src/main/java/org/apache/ranger/tagsync/source/atlasrest/AtlasRESTHttpClient.java
@@ -31,6 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.core.Response;
+
 import java.io.IOException;
 import java.security.PrivilegedExceptionAction;
 
@@ -43,8 +44,7 @@ import java.security.PrivilegedExceptionAction;
  */
 public final class AtlasRESTHttpClient {
     /** Class logger. */
-    private static final Logger LOG =
-            LoggerFactory.getLogger(AtlasRESTHttpClient.class);
+    private static final Logger LOG = LoggerFactory.getLogger(AtlasRESTHttpClient.class);
 
     /** Atlas basic search API path (POST). */
     private static final String SEARCH_PATH = "/api/atlas/v2/search/basic";
@@ -52,7 +52,10 @@ public final class AtlasRESTHttpClient {
     /** Atlas typedef export API path (GET). */
     private static final String TYPEDEFS_PATH = "/api/atlas/v2/types/typedefs/";
 
+    /** Ranger REST client with SSL and HA URL support. */
     private final RangerRESTClient restClient;
+
+    /** Whether TagSync runs with Kerberos credentials. */
     private final boolean          kerberized;
 
     /**
@@ -61,11 +64,11 @@ public final class AtlasRESTHttpClient {
      * @param restUrls          comma-separated Atlas REST base URLs
      * @param sslConfigFile     SSL config file for HTTPS endpoints
      * @param config            Hadoop configuration
-     * @param userNamePassword  basic-auth credentials; ignored when kerberized
-     * @param kerberized        {@code true} when TagSync uses a keytab
+     * @param userNamePassword  basic-auth credentials when configured
+     * @param useKerberos       {@code true} when TagSync uses a keytab
      */
-    public AtlasRESTHttpClient(final String restUrls, final String sslConfigFile, final Configuration config, final String[] userNamePassword, final boolean kerberized) {
-        this.kerberized = kerberized;
+    public AtlasRESTHttpClient(final String restUrls, final String sslConfigFile, final Configuration config, final String[] userNamePassword, final boolean useKerberos) {
+        this.kerberized = useKerberos;
         this.restClient = new RangerRESTClient(restUrls, sslConfigFile, config, "ranger.tagsync");
 
         if (userNamePassword != null && userNamePassword.length >= 2 && StringUtils.isNotEmpty(userNamePassword[0])) {
@@ -82,10 +85,10 @@ public final class AtlasRESTHttpClient {
      * @return parsed search result
      * @throws Exception when the REST call fails on all configured URLs
      */
-    public AtlasSearchResult facetedSearch(final SearchParameters searchParameters)
-            throws Exception {
+    public AtlasSearchResult facetedSearch(final SearchParameters searchParameters) throws Exception {
         Response response = execute(() -> restClient.post(SEARCH_PATH, null, searchParameters));
         String json = readResponseBody(response, SEARCH_PATH);
+
         return AtlasType.fromJson(json, AtlasSearchResult.class);
     }
 
@@ -103,24 +106,27 @@ public final class AtlasRESTHttpClient {
     }
 
     private Response execute(final RestCall restCall) throws Exception {
+        Response ret;
+
         if (kerberized) {
             UserGroupInformation ugi = UserGroupInformation.getLoginUser();
 
             ugi.checkTGTAndReloginFromKeytab();
 
             try {
-                return ugi.doAs((PrivilegedExceptionAction<Response>) restCall::run);
+                ret = ugi.doAs((PrivilegedExceptionAction<Response>) restCall::run);
             } catch (InterruptedException interruptedException) {
                 Thread.currentThread().interrupt();
                 throw new IOException("Atlas REST call interrupted", interruptedException);
             }
+        } else {
+            ret = restCall.run();
         }
 
-        return restCall.run();
+        return ret;
     }
 
-    private String readResponseBody(final Response response, final String relativeUrl)
-            throws IOException {
+    private String readResponseBody(final Response response, final String relativeUrl) throws IOException {
         if (response == null) {
             throw new IOException("Atlas REST " + relativeUrl + " failed: no response from any configured URL");
         }

--- a/tagsync/src/main/java/org/apache/ranger/tagsync/source/atlasrest/AtlasRESTHttpClient.java
+++ b/tagsync/src/main/java/org/apache/ranger/tagsync/source/atlasrest/AtlasRESTHttpClient.java
@@ -1,0 +1,207 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.tagsync.source.atlasrest;
+
+import org.apache.atlas.model.discovery.AtlasSearchResult;
+import org.apache.atlas.model.discovery.SearchParameters;
+import org.apache.atlas.model.typedef.AtlasTypesDef;
+import org.apache.atlas.type.AtlasType;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.security.PrivilegedExceptionAction;
+import java.util.Base64;
+
+/**
+ * Minimal Atlas REST client for TagSync.
+ *
+ * <p>Uses {@link HttpURLConnection} instead of {@code AtlasClientV2} so TagSync
+ * does not load the Atlas Jersey 1.x client on the same classpath as Ranger's
+ * Jersey 2.x REST sink (see RANGER-4076).
+ */
+public final class AtlasRESTHttpClient {
+    /** Class logger. */
+    private static final Logger LOG =
+            LoggerFactory.getLogger(AtlasRESTHttpClient.class);
+
+    /** Atlas basic search API path (POST). */
+    private static final String SEARCH_PATH = "api/atlas/v2/search/basic";
+
+    /** Atlas typedef export API path (GET). */
+    private static final String TYPEDEFS_PATH = "api/atlas/v2/types/typedefs/";
+
+    /** Minimum HTTP status treated as an error response. */
+    private static final int HTTP_STATUS_CLIENT_ERROR = 400;
+
+    private AtlasRESTHttpClient() {
+        // utility class
+    }
+
+    /**
+     * Search Atlas for entities matching the given parameters.
+     *
+     * @param restBaseUrl       Atlas REST base URL ending with {@code /}
+     * @param searchParameters  search filter (classification, limit, etc.)
+     * @param userNamePassword  basic-auth credentials; empty for Kerberos
+     * @param useKerberos       {@code true} when TagSync uses a keytab
+     * @return parsed search result
+     * @throws IOException when the REST call fails
+     */
+    public static AtlasSearchResult facetedSearch(final String restBaseUrl,
+            final SearchParameters searchParameters,
+            final String[] userNamePassword, final boolean useKerberos)
+            throws IOException {
+        String body = AtlasType.toJson(searchParameters);
+        String json = postJson(restBaseUrl + SEARCH_PATH, body,
+                userNamePassword, useKerberos);
+
+        return AtlasType.fromJson(json, AtlasSearchResult.class);
+    }
+
+    /**
+     * Download all Atlas type definitions.
+     *
+     * @param restBaseUrl       Atlas REST base URL ending with {@code /}
+     * @param userNamePassword  basic-auth credentials; empty for Kerberos
+     * @param useKerberos       {@code true} when TagSync uses a keytab
+     * @return typedef bundle from Atlas
+     * @throws IOException when the REST call fails
+     */
+    public static AtlasTypesDef getAllTypeDefs(final String restBaseUrl,
+            final String[] userNamePassword, final boolean useKerberos)
+            throws IOException {
+        String json = getJson(restBaseUrl + TYPEDEFS_PATH, userNamePassword,
+                useKerberos);
+
+        return AtlasType.fromJson(json, AtlasTypesDef.class);
+    }
+
+    private static String postJson(final String url, final String body,
+            final String[] userNamePassword, final boolean useKerberos)
+            throws IOException {
+        return execute(url, "POST", body, userNamePassword, useKerberos);
+    }
+
+    private static String getJson(final String url,
+            final String[] userNamePassword, final boolean useKerberos)
+            throws IOException {
+        return execute(url, "GET", null, userNamePassword, useKerberos);
+    }
+
+    private static String execute(final String url, final String method,
+            final String body, final String[] userNamePassword,
+            final boolean useKerberos) throws IOException {
+        if (useKerberosAuth(userNamePassword, useKerberos)) {
+            UserGroupInformation ugi = UserGroupInformation.getLoginUser();
+
+            ugi.checkTGTAndReloginFromKeytab();
+
+            try {
+                return ugi.doAs((PrivilegedExceptionAction<String>) () ->
+                        openAndRead(url, method, body, null, true));
+            } catch (InterruptedException interruptedException) {
+                Thread.currentThread().interrupt();
+                throw new IOException("Atlas REST call interrupted",
+                        interruptedException);
+            }
+        }
+
+        return openAndRead(url, method, body, userNamePassword, false);
+    }
+
+    private static boolean useKerberosAuth(final String[] userNamePassword,
+            final boolean useKerberos) {
+        return useKerberos && (userNamePassword == null
+                || userNamePassword.length == 0
+                || StringUtils.isBlank(userNamePassword[0]));
+    }
+
+    private static String openAndRead(final String url, final String method,
+            final String body, final String[] userNamePassword,
+            final boolean kerberos) throws IOException {
+        HttpURLConnection connection =
+                (HttpURLConnection) new URL(url).openConnection();
+
+        connection.setRequestMethod(method);
+        connection.setRequestProperty("Accept", "application/json");
+        connection.setRequestProperty("Content-Type", "application/json");
+
+        if (!kerberos && userNamePassword != null
+                && userNamePassword.length >= 2
+                && StringUtils.isNotEmpty(userNamePassword[0])) {
+            String credentials = userNamePassword[0] + ":"
+                    + userNamePassword[1];
+            String encoded = Base64.getEncoder().encodeToString(
+                    credentials.getBytes(StandardCharsets.UTF_8));
+
+            connection.setRequestProperty("Authorization", "Basic " + encoded);
+        }
+
+        if (body != null) {
+            connection.setDoOutput(true);
+            byte[] payload = body.getBytes(StandardCharsets.UTF_8);
+
+            connection.setRequestProperty("Content-Length",
+                    String.valueOf(payload.length));
+
+            try (OutputStream outputStream = connection.getOutputStream()) {
+                outputStream.write(payload);
+            }
+        }
+
+        int status = connection.getResponseCode();
+        InputStream stream = status >= HTTP_STATUS_CLIENT_ERROR
+                ? connection.getErrorStream()
+                : connection.getInputStream();
+
+        if (stream == null) {
+            throw new IOException("Atlas REST " + method + " " + url
+                    + " returned HTTP " + status + " with empty body");
+        }
+
+        String response = readStream(stream);
+
+        if (status >= HTTP_STATUS_CLIENT_ERROR) {
+            throw new IOException("Atlas REST " + method + " " + url
+                    + " failed with HTTP " + status + ": " + response);
+        }
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Atlas REST {} {} -> HTTP {}", method, url, status);
+        }
+
+        return response;
+    }
+
+    private static String readStream(final InputStream stream)
+            throws IOException {
+        byte[] buffer = stream.readAllBytes();
+
+        return new String(buffer, StandardCharsets.UTF_8);
+    }
+}

--- a/tagsync/src/main/java/org/apache/ranger/tagsync/source/atlasrest/AtlasRESTHttpClient.java
+++ b/tagsync/src/main/java/org/apache/ranger/tagsync/source/atlasrest/AtlasRESTHttpClient.java
@@ -42,7 +42,7 @@ import java.util.Base64;
  *
  * <p>Uses {@link HttpURLConnection} instead of {@code AtlasClientV2} so TagSync
  * does not load the Atlas Jersey 1.x client on the same classpath as Ranger's
- * Jersey 2.x REST sink (see RANGER-4076).
+ * Jersey 2.x REST sink.
  */
 public final class AtlasRESTHttpClient {
     /** Class logger. */
@@ -122,8 +122,7 @@ public final class AtlasRESTHttpClient {
             ugi.checkTGTAndReloginFromKeytab();
 
             try {
-                return ugi.doAs((PrivilegedExceptionAction<String>) () ->
-                        openAndRead(url, method, body, null, true));
+                return ugi.doAs((PrivilegedExceptionAction<String>) () -> openAndRead(url, method, body, null, true));
             } catch (InterruptedException interruptedException) {
                 Thread.currentThread().interrupt();
                 throw new IOException("Atlas REST call interrupted",
@@ -136,9 +135,7 @@ public final class AtlasRESTHttpClient {
 
     private static boolean useKerberosAuth(final String[] userNamePassword,
             final boolean useKerberos) {
-        return useKerberos && (userNamePassword == null
-                || userNamePassword.length == 0
-                || StringUtils.isBlank(userNamePassword[0]));
+        return useKerberos && (userNamePassword == null || userNamePassword.length == 0 || StringUtils.isBlank(userNamePassword[0]));
     }
 
     private static String openAndRead(final String url, final String method,
@@ -151,9 +148,7 @@ public final class AtlasRESTHttpClient {
         connection.setRequestProperty("Accept", "application/json");
         connection.setRequestProperty("Content-Type", "application/json");
 
-        if (!kerberos && userNamePassword != null
-                && userNamePassword.length >= 2
-                && StringUtils.isNotEmpty(userNamePassword[0])) {
+        if (!kerberos && userNamePassword != null && userNamePassword.length >= 2 && StringUtils.isNotEmpty(userNamePassword[0])) {
             String credentials = userNamePassword[0] + ":"
                     + userNamePassword[1];
             String encoded = Base64.getEncoder().encodeToString(
@@ -180,15 +175,13 @@ public final class AtlasRESTHttpClient {
                 : connection.getInputStream();
 
         if (stream == null) {
-            throw new IOException("Atlas REST " + method + " " + url
-                    + " returned HTTP " + status + " with empty body");
+            throw new IOException("Atlas REST " + method + " " + url + " returned HTTP " + status + " with empty body");
         }
 
         String response = readStream(stream);
 
         if (status >= HTTP_STATUS_CLIENT_ERROR) {
-            throw new IOException("Atlas REST " + method + " " + url
-                    + " failed with HTTP " + status + ": " + response);
+            throw new IOException("Atlas REST " + method + " " + url + " failed with HTTP " + status + ": " + response);
         }
 
         if (LOG.isDebugEnabled()) {

--- a/tagsync/src/main/java/org/apache/ranger/tagsync/source/atlasrest/AtlasRESTTagSource.java
+++ b/tagsync/src/main/java/org/apache/ranger/tagsync/source/atlasrest/AtlasRESTTagSource.java
@@ -72,7 +72,7 @@ public class AtlasRESTTagSource extends AbstractTagSource implements Runnable {
     });
 
     private long     sleepTimeBetweenCycleInMillis;
-    private String[] restUrls;
+    private AtlasRESTHttpClient atlasRestClient;
     private boolean  isKerberized;
     private String[] userNamePassword;
     private int      entitiesBatchSize = TagSyncConfig.DEFAULT_TAGSYNC_ATLASREST_SOURCE_ENTITIES_BATCH_SIZE;
@@ -137,12 +137,12 @@ public class AtlasRESTTagSource extends AbstractTagSource implements Runnable {
         LOG.debug("kerberized={}", isKerberized);
 
         if (StringUtils.isNotEmpty(restEndpoint)) {
-            this.restUrls = restEndpoint.split(",");
-
-            for (int i = 0; i < restUrls.length; i++) {
-                if (!restUrls[i].endsWith("/")) {
-                    restUrls[i] += "/";
-                }
+            try {
+                atlasRestClient = new AtlasRESTHttpClient(restEndpoint, sslConfigFile,
+                        TagSyncConfig.getInstance(), userNamePassword, isKerberized);
+            } catch (RuntimeException exception) {
+                LOG.error("Failed to initialize Atlas REST client", exception);
+                ret = false;
             }
         } else {
             LOG.info("AtlasEndpoint not specified, Initial download of Atlas-entities cannot be done.");
@@ -228,11 +228,9 @@ public class AtlasRESTTagSource extends AbstractTagSource implements Runnable {
 
         List<RangerAtlasEntityWithTags> ret = new ArrayList<>();
 
-        if (restUrls == null || restUrls.length == 0) {
+        if (atlasRestClient == null) {
             return ret;
         }
-
-        String restBaseUrl = restUrls[0];
 
         SearchParameters searchParams = new SearchParameters();
 
@@ -254,10 +252,8 @@ public class AtlasRESTTagSource extends AbstractTagSource implements Runnable {
             isMoreData = false;
 
             try {
-                searchResult = AtlasRESTHttpClient.facetedSearch(restBaseUrl,
-                        searchParams, userNamePassword, isKerberized);
-                AtlasTypesDef typesDef = AtlasRESTHttpClient.getAllTypeDefs(
-                        restBaseUrl, userNamePassword, isKerberized);
+                searchResult = atlasRestClient.facetedSearch(searchParams);
+                AtlasTypesDef typesDef = atlasRestClient.getAllTypeDefs();
 
                 tty = typeRegistry.lockTypeRegistryForUpdate();
                 tty.addTypes(typesDef);
@@ -265,9 +261,11 @@ public class AtlasRESTTagSource extends AbstractTagSource implements Runnable {
             } catch (IOException excp) {
                 LOG.error("failed to download tags from Atlas", excp);
                 ret = null;
+                break;
             } catch (Exception unexpectedException) {
                 LOG.error("Failed to download tags from Atlas due to unexpected exception", unexpectedException);
                 ret = null;
+                break;
             } finally {
                 if (tty != null) {
                     typeRegistry.releaseTypeRegistryForUpdate(tty, commitUpdates);
@@ -316,7 +314,7 @@ public class AtlasRESTTagSource extends AbstractTagSource implements Runnable {
         }
         while (isMoreData);
 
-        LOG.debug("<== getAtlasActiveEntities(), count={}", ret.size());
+        LOG.debug("<== getAtlasActiveEntities(), count={}", ret == null ? 0 : ret.size());
 
         return ret;
     }

--- a/tagsync/src/main/java/org/apache/ranger/tagsync/source/atlasrest/AtlasRESTTagSource.java
+++ b/tagsync/src/main/java/org/apache/ranger/tagsync/source/atlasrest/AtlasRESTTagSource.java
@@ -138,8 +138,7 @@ public class AtlasRESTTagSource extends AbstractTagSource implements Runnable {
 
         if (StringUtils.isNotEmpty(restEndpoint)) {
             try {
-                atlasRestClient = new AtlasRESTHttpClient(restEndpoint, sslConfigFile,
-                        TagSyncConfig.getInstance(), userNamePassword, isKerberized);
+                atlasRestClient = new AtlasRESTHttpClient(restEndpoint, sslConfigFile, TagSyncConfig.getInstance(), userNamePassword, isKerberized);
             } catch (RuntimeException exception) {
                 LOG.error("Failed to initialize Atlas REST client", exception);
                 ret = false;

--- a/tagsync/src/main/java/org/apache/ranger/tagsync/source/atlasrest/AtlasRESTTagSource.java
+++ b/tagsync/src/main/java/org/apache/ranger/tagsync/source/atlasrest/AtlasRESTTagSource.java
@@ -248,22 +248,30 @@ public class AtlasRESTTagSource extends AbstractTagSource implements Runnable {
             boolean                                      commitUpdates = false;
 
             searchParams.setOffset(nextStartIndex);
+
             isMoreData = false;
 
             try {
                 searchResult = atlasRestClient.facetedSearch(searchParams);
+
                 AtlasTypesDef typesDef = atlasRestClient.getAllTypeDefs();
 
                 tty = typeRegistry.lockTypeRegistryForUpdate();
+
                 tty.addTypes(typesDef);
+
                 commitUpdates = true;
             } catch (IOException excp) {
                 LOG.error("failed to download tags from Atlas", excp);
+
                 ret = null;
+
                 break;
             } catch (Exception unexpectedException) {
                 LOG.error("Failed to download tags from Atlas due to unexpected exception", unexpectedException);
+
                 ret = null;
+
                 break;
             } finally {
                 if (tty != null) {
@@ -272,23 +280,28 @@ public class AtlasRESTTagSource extends AbstractTagSource implements Runnable {
             }
 
             if (commitUpdates && searchResult != null) {
-                LOG.debug(AtlasType.toJson(searchResult));
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug(AtlasType.toJson(searchResult));
+                }
 
                 List<AtlasEntityHeader> entityHeaders = searchResult.getEntities();
 
                 if (CollectionUtils.isNotEmpty(entityHeaders)) {
                     nextStartIndex += entityHeaders.size();
-                    isMoreData = true;
+                    isMoreData     = true;
 
                     for (AtlasEntityHeader header : entityHeaders) {
                         if (!header.getStatus().equals(AtlasEntity.Status.ACTIVE)) {
                             LOG.debug("Skipping entity because it is not ACTIVE, header:[{}]", header);
+
                             continue;
                         }
 
                         String typeName = header.getTypeName();
+
                         if (!AtlasResourceMapperUtil.isEntityTypeHandled(typeName)) {
                             LOG.debug("Not fetching Atlas entities of type:[{}]", typeName);
+
                             continue;
                         }
 
@@ -296,6 +309,7 @@ public class AtlasRESTTagSource extends AbstractTagSource implements Runnable {
 
                         for (AtlasClassification classification : header.getClassifications()) {
                             List<EntityNotificationWrapper.RangerAtlasClassification> tags = resolveTag(typeRegistry, classification);
+
                             if (tags != null) {
                                 allTagsForEntity.addAll(tags);
                             }

--- a/tagsync/src/main/java/org/apache/ranger/tagsync/source/atlasrest/AtlasRESTTagSource.java
+++ b/tagsync/src/main/java/org/apache/ranger/tagsync/source/atlasrest/AtlasRESTTagSource.java
@@ -19,10 +19,6 @@
 
 package org.apache.ranger.tagsync.source.atlasrest;
 
-import org.apache.atlas.AtlasClientV2;
-import org.apache.atlas.AtlasServiceException;
-import org.apache.atlas.exception.AtlasBaseException;
-import org.apache.atlas.model.SearchFilter;
 import org.apache.atlas.model.TimeBoundary;
 import org.apache.atlas.model.discovery.AtlasSearchResult;
 import org.apache.atlas.model.discovery.SearchParameters;
@@ -39,7 +35,6 @@ import org.apache.atlas.type.AtlasTypeRegistry;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.ranger.authorization.utils.JsonUtils;
 import org.apache.ranger.plugin.model.RangerValiditySchedule;
 import org.apache.ranger.plugin.util.ServiceTags;
@@ -233,104 +228,99 @@ public class AtlasRESTTagSource extends AbstractTagSource implements Runnable {
 
         List<RangerAtlasEntityWithTags> ret = new ArrayList<>();
 
-        AtlasClientV2 atlasClient = null;
-        try {
-            atlasClient = getAtlasClient();
-        } catch (IOException exception) {
-            LOG.error("Failed to get Atlas client.", exception);
+        if (restUrls == null || restUrls.length == 0) {
+            return ret;
         }
 
-        if (atlasClient != null) {
-            SearchParameters searchParams = new SearchParameters();
+        String restBaseUrl = restUrls[0];
 
-            searchParams.setExcludeDeletedEntities(true);
-            searchParams.setClassification("*");
-            //searchParams.setIncludeSubClassifications(true);
-            //searchParams.setIncludeSubTypes(true);
-            searchParams.setIncludeClassificationAttributes(true);
-            searchParams.setLimit(entitiesBatchSize);
+        SearchParameters searchParams = new SearchParameters();
 
-            boolean isMoreData;
-            int     nextStartIndex = 0;
+        searchParams.setExcludeDeletedEntities(true);
+        searchParams.setClassification("*");
+        searchParams.setIncludeClassificationAttributes(true);
+        searchParams.setLimit(entitiesBatchSize);
 
-            do {
-                AtlasTypeRegistry                            typeRegistry  = new AtlasTypeRegistry();
-                AtlasTypeRegistry.AtlasTransientTypeRegistry tty           = null;
-                AtlasSearchResult                            searchResult  = null;
-                boolean                                      commitUpdates = false;
+        boolean isMoreData;
+        int     nextStartIndex = 0;
 
-                searchParams.setOffset(nextStartIndex);
-                isMoreData = false;
+        do {
+            AtlasTypeRegistry                            typeRegistry  = new AtlasTypeRegistry();
+            AtlasTypeRegistry.AtlasTransientTypeRegistry tty           = null;
+            AtlasSearchResult                            searchResult  = null;
+            boolean                                      commitUpdates = false;
 
-                try {
-                    searchResult = atlasClient.facetedSearch(searchParams);
-                    AtlasTypesDef typesDef = atlasClient.getAllTypeDefs(new SearchFilter());
-                    tty = typeRegistry.lockTypeRegistryForUpdate();
-                    tty.addTypes(typesDef);
-                    commitUpdates = true;
-                } catch (AtlasServiceException | AtlasBaseException excp) {
-                    LOG.error("failed to download tags from Atlas", excp);
-                    ret = null;
-                } catch (Exception unexpectedException) {
-                    LOG.error("Failed to download tags from Atlas due to unexpected exception", unexpectedException);
-                    ret = null;
-                } finally {
-                    if (tty != null) {
-                        typeRegistry.releaseTypeRegistryForUpdate(tty, commitUpdates);
-                    }
+            searchParams.setOffset(nextStartIndex);
+            isMoreData = false;
+
+            try {
+                searchResult = AtlasRESTHttpClient.facetedSearch(restBaseUrl,
+                        searchParams, userNamePassword, isKerberized);
+                AtlasTypesDef typesDef = AtlasRESTHttpClient.getAllTypeDefs(
+                        restBaseUrl, userNamePassword, isKerberized);
+
+                tty = typeRegistry.lockTypeRegistryForUpdate();
+                tty.addTypes(typesDef);
+                commitUpdates = true;
+            } catch (IOException excp) {
+                LOG.error("failed to download tags from Atlas", excp);
+                ret = null;
+            } catch (Exception unexpectedException) {
+                LOG.error("Failed to download tags from Atlas due to unexpected exception", unexpectedException);
+                ret = null;
+            } finally {
+                if (tty != null) {
+                    typeRegistry.releaseTypeRegistryForUpdate(tty, commitUpdates);
                 }
+            }
 
-                if (commitUpdates && searchResult != null) {
-                    LOG.debug(AtlasType.toJson(searchResult));
+            if (commitUpdates && searchResult != null) {
+                LOG.debug(AtlasType.toJson(searchResult));
 
-                    List<AtlasEntityHeader> entityHeaders = searchResult.getEntities();
+                List<AtlasEntityHeader> entityHeaders = searchResult.getEntities();
 
-                    if (CollectionUtils.isNotEmpty(entityHeaders)) {
-                        nextStartIndex += entityHeaders.size();
-                        isMoreData = true;
+                if (CollectionUtils.isNotEmpty(entityHeaders)) {
+                    nextStartIndex += entityHeaders.size();
+                    isMoreData = true;
 
-                        for (AtlasEntityHeader header : entityHeaders) {
-                            if (!header.getStatus().equals(AtlasEntity.Status.ACTIVE)) {
-                                LOG.debug("Skipping entity because it is not ACTIVE, header:[{}]", header);
-                                continue;
+                    for (AtlasEntityHeader header : entityHeaders) {
+                        if (!header.getStatus().equals(AtlasEntity.Status.ACTIVE)) {
+                            LOG.debug("Skipping entity because it is not ACTIVE, header:[{}]", header);
+                            continue;
+                        }
+
+                        String typeName = header.getTypeName();
+                        if (!AtlasResourceMapperUtil.isEntityTypeHandled(typeName)) {
+                            LOG.debug("Not fetching Atlas entities of type:[{}]", typeName);
+                            continue;
+                        }
+
+                        List<EntityNotificationWrapper.RangerAtlasClassification> allTagsForEntity = new ArrayList<>();
+
+                        for (AtlasClassification classification : header.getClassifications()) {
+                            List<EntityNotificationWrapper.RangerAtlasClassification> tags = resolveTag(typeRegistry, classification);
+                            if (tags != null) {
+                                allTagsForEntity.addAll(tags);
                             }
+                        }
 
-                            String typeName = header.getTypeName();
-                            if (!AtlasResourceMapperUtil.isEntityTypeHandled(typeName)) {
-                                LOG.debug("Not fetching Atlas entities of type:[{}]", typeName);
-                                continue;
-                            }
+                        if (CollectionUtils.isNotEmpty(allTagsForEntity)) {
+                            RangerAtlasEntity         entity         = new RangerAtlasEntity(typeName, header.getGuid(), header.getAttributes());
+                            RangerAtlasEntityWithTags entityWithTags = new RangerAtlasEntityWithTags(entity, allTagsForEntity, typeRegistry);
 
-                            List<EntityNotificationWrapper.RangerAtlasClassification> allTagsForEntity = new ArrayList<>();
-
-                            for (AtlasClassification classification : header.getClassifications()) {
-                                List<EntityNotificationWrapper.RangerAtlasClassification> tags = resolveTag(typeRegistry, classification);
-                                if (tags != null) {
-                                    allTagsForEntity.addAll(tags);
-                                }
-                            }
-
-                            if (CollectionUtils.isNotEmpty(allTagsForEntity)) {
-                                RangerAtlasEntity         entity         = new RangerAtlasEntity(typeName, header.getGuid(), header.getAttributes());
-                                RangerAtlasEntityWithTags entityWithTags = new RangerAtlasEntityWithTags(entity, allTagsForEntity, typeRegistry);
-
-                                ret.add(entityWithTags);
-                            }
+                            ret.add(entityWithTags);
                         }
                     }
                 }
             }
-            while (isMoreData);
         }
+        while (isMoreData);
 
-        LOG.debug("<== getAtlasActiveEntities()");
+        LOG.debug("<== getAtlasActiveEntities(), count={}", ret.size());
 
         return ret;
     }
 
-    /*
-     * Returns a list of <EntityNotificationWrapper.RangerAtlasClassification>
-     */
     private List<EntityNotificationWrapper.RangerAtlasClassification> resolveTag(AtlasTypeRegistry typeRegistry, AtlasClassification classification) {
         List<EntityNotificationWrapper.RangerAtlasClassification> ret        = new ArrayList<>();
         String                                                    typeName   = classification.getTypeName();
@@ -369,10 +359,8 @@ public class AtlasRESTTagSource extends AbstractTagSource implements Runnable {
                     validitySchedules = EntityNotificationWrapper.convertTimeSpecFromAtlasToRanger(validityPeriods);
                 }
 
-                // Add most derived classificationType with all attributes
                 ret.add(new EntityNotificationWrapper.RangerAtlasClassification(typeName, allAttributes, validitySchedules));
 
-                // Find base classification types
                 Set<String> superTypeNames = classificationType.getAllSuperTypes();
                 for (String superTypeName : superTypeNames) {
                     AtlasClassificationType superType = typeRegistry.getClassificationTypeByName(superTypeName);
@@ -402,22 +390,6 @@ public class AtlasRESTTagSource extends AbstractTagSource implements Runnable {
         } catch (Exception exception) {
             LOG.error("Error in resolving tags for type:[{}]", typeName, exception);
         }
-        return ret;
-    }
-
-    private AtlasClientV2 getAtlasClient() throws IOException {
-        final AtlasClientV2 ret;
-
-        if (isKerberized) {
-            UserGroupInformation ugi = UserGroupInformation.getLoginUser();
-
-            ugi.checkTGTAndReloginFromKeytab();
-
-            ret = new AtlasClientV2(ugi, ugi.getShortUserName(), restUrls);
-        } else {
-            ret = new AtlasClientV2(restUrls, userNamePassword);
-        }
-
         return ret;
     }
 }

--- a/tagsync/src/main/java/org/apache/ranger/tagsync/source/atlasrest/AtlasRESTTagSource.java
+++ b/tagsync/src/main/java/org/apache/ranger/tagsync/source/atlasrest/AtlasRESTTagSource.java
@@ -321,6 +321,9 @@ public class AtlasRESTTagSource extends AbstractTagSource implements Runnable {
         return ret;
     }
 
+    /*
+     * Returns a list of <EntityNotificationWrapper.RangerAtlasClassification>
+     */
     private List<EntityNotificationWrapper.RangerAtlasClassification> resolveTag(AtlasTypeRegistry typeRegistry, AtlasClassification classification) {
         List<EntityNotificationWrapper.RangerAtlasClassification> ret        = new ArrayList<>();
         String                                                    typeName   = classification.getTypeName();
@@ -359,8 +362,10 @@ public class AtlasRESTTagSource extends AbstractTagSource implements Runnable {
                     validitySchedules = EntityNotificationWrapper.convertTimeSpecFromAtlasToRanger(validityPeriods);
                 }
 
+                // Add most derived classificationType with all attributes
                 ret.add(new EntityNotificationWrapper.RangerAtlasClassification(typeName, allAttributes, validitySchedules));
 
+                // Find base classification types
                 Set<String> superTypeNames = classificationType.getAllSuperTypes();
                 for (String superTypeName : superTypeNames) {
                     AtlasClassificationType superType = typeRegistry.getClassificationTypeByName(superTypeName);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixes [RANGER-5656](https://issues.apache.org/jira/browse/RANGER-5656): TagSync **Atlas REST** tag source fails when `TAG_SOURCE_ATLASREST_ENABLED=true` after [RANGER-4076](https://issues.apache.org/jira/browse/RANGER-4076) migrated TagSync to **Jersey 2.x**, while `AtlasRESTTagSource` still used **`AtlasClientV2`** (Jersey 1.x from `atlas-client-v2`).

### Problem

TagSync reads classifications from Atlas via `AtlasClientV2` and pushes tags to Ranger Admin via `TagAdminRESTSink` (Jersey 2). Both JAX-RS stacks load on the same JVM:

```
AbstractMethodError: javax.ws.rs.core.UriBuilder.uri(...)
  at org.glassfish.jersey.internal.util.collection.Values$LazyValueImpl.get(...)
```

The Atlas REST sync thread exits on the first poll. TagSync may appear running, but **no automatic Atlas → Ranger tag push** occurs.

| Before RANGER-4076 | After RANGER-4076 (broken) | This PR |
|--------------------|----------------------------|---------|
| TagSync sink: Jersey 1 + `AtlasClientV2`: Jersey 1 | TagSync sink: Jersey 2 + `AtlasClientV2`: Jersey 1 | Atlas REST: `HttpURLConnection`; sink: Jersey 2 |

### Solution

1. **`AtlasRESTHttpClient`** (new) — minimal Atlas REST client using `HttpURLConnection` + Atlas `AtlasType` JSON helpers (no Jersey, no `AtlasClientV2`).
   - `POST api/atlas/v2/search/basic` — classified entity search
   - `GET api/atlas/v2/types/typedefs/` — typedef load
   - Supports Basic auth and Kerberos (`UserGroupInformation.doAs`)

2. **`AtlasRESTTagSource`** — call `AtlasRESTHttpClient` instead of `AtlasClientV2`; remove `getAtlasClient()`.

3. **Packaging** — remove `atlas-client-v1` / `atlas-client-v2` from `tagsync/pom.xml` and from `distro/src/main/assembly/tagsync.xml` so Jersey 1 client JARs are not shipped in the TagSync tarball.

**Not changed:** `TagSynchronizer`, `TagAdminRESTSink`, Atlas Kafka tag source, Hive plugin.

### Files changed

| File | Change |
|------|--------|
| `tagsync/.../AtlasRESTHttpClient.java` | **Added** |
| `tagsync/.../AtlasRESTTagSource.java` | **Modified** — use HTTP client |
| `tagsync/pom.xml` | **Modified** — drop `atlas-client-v1/v2` dependencies |
| `distro/src/main/assembly/tagsync.xml` | **Modified** — drop `atlas-client-*` from `lib/` |

---

## How was this patch tested?

### Build and static checks

```bash
mvn package -pl tagsync -am -DskipTests
mvn checkstyle:check -pl tagsync -DskipTests
```

| Check | Result |
|-------|--------|
| `tagsync` module compile/package | Pass |
| Checkstyle on new `AtlasRESTHttpClient.java` | Pass (0 violations) |

### Manual testing (Atlas + Ranger + Hive integration)

Manual validation used a docker environment with Ranger Admin, TagSync, Apache Atlas, and Hive (Kerberos-enabled), with `TAG_SOURCE_ATLASREST_ENABLED=true` and Atlas REST credentials configured in TagSync install properties.

#### 1. TagSync starts without Jersey conflict

- Rebuilt TagSync from this branch and deployed the new tarball.
- Started TagSync with Atlas REST source enabled.
- Confirmed `TagSynchronizer` process is running and **no `AbstractMethodError`** / `UriBuilderImpl` errors appear in TagSync logs on startup or first poll.

#### 2. Atlas classification → Ranger tag mapping (automatic sync)

- Created a Hive table with columns suitable for governance testing.
- Applied a **PII** classification to a Hive column entity in Atlas via Atlas REST API.
- Waited for TagSync poll interval (~60 seconds).
- Verified in Ranger Admin **Tag** menu: tag definition **PII** and resource mapping on the Hive service for the classified column (`createdBy: rangertagsync`, GUID matches Atlas).
- Verified via Ranger REST: `GET /service/tags/resources?serviceName=<hive-service>` and `GET /service/tags/tagresourcemaps?serviceName=<hive-service>`.

#### 3. End-to-end tag policy enforcement in Hive

With tag mappings present, configured Ranger policies on **`dev_hive`** (RBAC allow) and **`dev_tag`** (tag deny for one user; tag data mask `hive:MASK` for another on tag **PII**). Loaded sample row data into the Hive table.

| User | Query | Expected | Result |
|------|-------|----------|--------|
| User A | `SELECT` non-PII column | Allowed | Pass |
| User A | `SELECT` PII-tagged column | Denied (`HiveAccessControlException`) | Pass |
| User B | `SELECT` PII-tagged column | Masked values (e.g. `nnn-nn-nnnn`) | Pass |
| Hive admin | `SELECT` PII-tagged column | Raw values | Pass |

#### 4. Regression checks

- TagSync still pushes tags to Ranger Admin via `TagAdminRESTSink` (Jersey 2 unchanged).
- No change to file-based or Kafka-based tag sources in this PR.

---

## Related issues

- **RANGER-4076** — Jersey 1 → 2 migration (regression source)
- **RANGER-1897** — original `AtlasClientV2` adoption in `AtlasRESTTagSource`
