### PR TITLE
RANGER-5657: Limit getAllModuleNames() to sys-admin sessions in SessionMgr

### DIFF
--- a/security-admin/src/main/java/org/apache/ranger/biz/SessionMgr.java
+++ b/security-admin/src/main/java/org/apache/ranger/biz/SessionMgr.java
@@ -222,7 +222,7 @@ public class SessionMgr {
         if (xUser != null) {
             List<String> permissionList;
 
-            if (userSession.isUserAdmin() || userSession.isKeyAdmin()) {
+            if (userSession.isUserAdmin()) {
                 permissionList = daoManager.getXXModuleDef().getAllModuleNames();
             } else {
                 permissionList = daoManager.getXXModuleDef().findAccessibleModulesByUserId(userSession.getUserId(), xUser.getId());


### PR DESCRIPTION
## What changes were proposed in this pull request?

Follow-up fix for [RANGER-5627](https://issues.apache.org/jira/browse/RANGER-5627) / #1000.

RANGER-5627 added configuration-based super users (`ranger.admin.super.users` /
`ranger.admin.super.groups`) and changed `SessionMgr.resetUserModulePermission()`
to grant **all UI modules** when `isUserAdmin() || isKeyAdmin()`.

That `isKeyAdmin()` branch is unintended for DB `ROLE_KEY_ADMIN` users:

- **Before RANGER-5627:** every user, including key-admin, received DB-scoped
  modules via `findAccessibleModulesByUserId()`.
- **After RANGER-5627:** DB key-admin receives `getAllModuleNames()`, including
  **Security Zone**, even when not listed in super-user config and without an
  explicit DB module grant.

Security Zone read APIs authorize with `hasModuleAccess("Security Zone")`, which
checks the session module set populated by `resetUserModulePermission()`. DB
key-admin therefore incorrectly gets HTTP 200 on zone GET APIs instead of 400.

**This patch:** use `getAllModuleNames()` only when `userSession.isUserAdmin()`.

Config super-users are **not** affected — they already get full admin through
`superUser` → `isUserAdmin()` in `UserSessionBase`. DB key-admin retains
DB-scoped modules (Key Manager and any explicitly granted modules only).

JIRA: https://issues.apache.org/jira/browse/RANGER-5657

## How was this patch tested?

- [x] `TestSessionMgr` — existing super-user / session tests (19 tests passed)
- [x] `TestRangerSuperUserConfig` — config super-user behavior unchanged (20
      tests passed )

**Manual verification (recommended):**

1. Login as DB key-admin (not in `super.users` / `super.groups`)
   - `GET /service/xusers/users/profile` — should **not** list Security Zone
   - `GET /service/public/v2/api/zones` — expect **400** (not authorized)
2. Configure `ranger.admin.super.users` for a test user, re-login
   - Profile shows all modules including Security Zone
   - Zone GET returns **200**
3. Login as sys admin — unchanged (all modules, zone GET **200**)

