### PR TITLE
RANGER-5661: Fix Kafka plugin packaging for broker-delegate classloading on Kafka 3.9+

### DIFF
--- a/distro/src/main/assembly/plugin-kafka.xml
+++ b/distro/src/main/assembly/plugin-kafka.xml
@@ -78,9 +78,24 @@
 					<include>org.apache.solr:solr-solrj:jar:${solr.version}</include>
 					<include>org.codehaus.woodstox:stax2-api</include>
 					<include>org.eclipse.jetty:jetty-client:jar:${jetty-client.version}</include>
-					<include>org.glassfish.jersey.ext:jersey-entity-filtering:jar:${jersey-client.version}</include>
-					<include>org.glassfish.jersey.media:jersey-media-json-jackson:jar:${jersey-client.version}</include>
 				</includes>
+                <excludes>
+					<exclude>com.fasterxml.jackson.core:*</exclude>
+					<exclude>com.fasterxml.jackson.jaxrs:*</exclude>
+					<exclude>com.fasterxml.jackson.module:*</exclude>
+					<exclude>com.fasterxml.jackson.dataformat:*</exclude>
+					<exclude>org.apache.kafka:kafka-clients</exclude>
+					<exclude>org.glassfish.jersey.core:*</exclude>
+					<exclude>org.glassfish.jersey.ext:*</exclude>
+					<exclude>org.glassfish.jersey.inject:*</exclude>
+					<exclude>org.glassfish.jersey.media:*</exclude>
+					<exclude>org.glassfish.hk2:*</exclude>
+					<exclude>javax.ws.rs:javax.ws.rs-api</exclude>
+					<exclude>jakarta.ws.rs:jakarta.ws.rs-api</exclude>
+					<exclude>org.slf4j:*</exclude>
+					<exclude>org.apache.logging.log4j:*</exclude>
+					<exclude>ch.qos.reload4j:*</exclude>
+				</excludes>
 			</binaries>
 		</moduleSet>
 

--- a/plugin-kafka/template/configuration.xml
+++ b/plugin-kafka/template/configuration.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements. See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<configuration>
+</configuration>


### PR DESCRIPTION
## Summary

Fixes upstream Kafka plugin packaging so `RangerKafkaAuthorizer` can run on Kafka 3.9.x using a broker-delegate classloading model (shim + classloader on the broker classpath; implementation jars without duplicate broker libraries).

- **Add `plugin-kafka/template/configuration.xml`** — `plugin-kafka.xml` assembly references `plugin-kafka/template/` for `install/conf.templates/default`, but the directory was never committed. Without it, the assembled tarball can be incomplete and `enable-kafka-plugin.sh` may fail before writing Kafka security/audit configuration (same class of issue as YARN in RANGER-5660).
- **Exclude broker-supplied jars from `ranger-kafka-plugin-impl`** — stop shipping Jackson, Jersey/HK2, `kafka-clients`, SLF4J/log4j, and both JAX-RS API jars (`javax.ws.rs-api`, `jakarta.ws.rs-api`) that Kafka 3.9 already provides. Duplicate copies cause `LinkageError`, `ClassCastException`, or policy REST client failures at broker startup.

## Changes

| File | Change |
|------|--------|
| `plugin-kafka/template/configuration.xml` | New empty Hadoop-style template for assembly `conf.templates/default` |
| `distro/src/main/assembly/plugin-kafka.xml` | Exclude broker classpath artifacts from `ranger-kafka-plugin-impl`; remove explicit Jersey Jackson includes superseded by excludes |

## Manual testing

Tested on Kafka **3.9.1** with Kerberos (`SASL_PLAINTEXT`) and `authorizer.class.name=org.apache.ranger.authorization.kafka.authorizer.RangerKafkaAuthorizer`.

1. **Build** — `mvn package -Pranger-kafka-plugin` (distro assembly) completed successfully.
2. **Tarball packaging** — assembled `ranger-*-kafka-plugin.tar.gz` contains `install/conf.templates/enable/` XML/CFG files and `install/conf.templates/default/configuration.xml`.
3. **Impl contents** — `ranger-kafka-plugin-impl` contains no jackson, jersey, hk2, `kafka-clients`, slf4j, reload4j/log4j, or ws.rs API jars (broker-delegated).
4. **Broker startup** — Kafka broker started cleanly with `RangerKafkaAuthorizer` enabled (no `LinkageError` / `ClassCastException` on startup).
5. **Authorization** — `testuser2` console produce to a restricted topic was **denied**; `testuser1` with allow policy **succeeded**.

## Test plan

- [ ] `mvn package -Pranger-kafka-plugin` produces tarball with `install/conf.templates/enable/` and `install/conf.templates/default/configuration.xml`
- [ ] `ranger-kafka-plugin-impl` excludes broker-supplied Jackson, Jersey, HK2, `kafka-clients`, SLF4J, log4j/reload4j, and JAX-RS API jars
- [ ] Kafka 3.9.x broker starts with `RangerKafkaAuthorizer` configured
- [ ] Topic publish authorization enforced per Ranger policies