### PR TITLE
RANGER-5647: Backport tag policy test fixtures and path matcher fix to ranger-2.9

### DIFF
--- a/agents-common/src/main/java/org/apache/ranger/plugin/resourcematcher/RangerPathResourceMatcher.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/resourcematcher/RangerPathResourceMatcher.java
@@ -591,15 +591,17 @@ public class RangerPathResourceMatcher extends RangerDefaultResourceMatcher {
 			if (LOG.isDebugEnabled()) {
 				LOG.debug("==> RecursiveWildcardResourceMatcher.isMatch(resourceValue=" + resourceValue + ", evalContext=" + evalContext + ")");
 			}
-			String expandedValue;
+			String   expandedValue;
+			String[] pathElements;
 			if (getNeedsDynamicEval()) {
 				expandedValue = getExpandedValue(evalContext);
-				wildcardPathElements = StringUtils.split(expandedValue, pathSeparatorChar);
+				pathElements  = StringUtils.split(expandedValue, pathSeparatorChar);
 			} else {
 				expandedValue = value;
+				pathElements  = wildcardPathElements;
 			}
 
-			boolean ret = function.apply(resourceValue, expandedValue, pathSeparatorChar, ioCase, wildcardPathElements);
+			boolean ret = function.apply(resourceValue, expandedValue, pathSeparatorChar, ioCase, pathElements);
 
 			if (LOG.isDebugEnabled()) {
 				LOG.debug("<== RecursiveWildcardResourceMatcher.isMatch(resourceValue=" + resourceValue + ", expandedValue=" + expandedValue + ") : result:[" + ret + "]");

--- a/agents-common/src/test/resources/policyengine/ACLResourceTags.json
+++ b/agents-common/src/test/resources/policyengine/ACLResourceTags.json
@@ -43,7 +43,7 @@
     "tags": {
       "1": {
         "type": "EXPIRES_ON",
-        "attributes": { "expiry_date": "2026/06/15" },
+        "attributes": { "expiry_date": "2099/12/31" },
         "id": 1,
         "guid": "tag-expires-on-1-guid"
       },
@@ -61,19 +61,19 @@
       },
       "4": {
         "type": "RESTRICTED-FINAL",
-        "attributes": { "activation_date": "2026/06/15" },
+        "attributes": { "activation_date": "2099/12/31" },
         "id": 4,
         "guid": "tag-restricted-final-4-guid"
       },
       "5": {
         "type": "PII",
-        "attributes": { "expiry": "2026/06/15" },
+        "attributes": { "expiry": "2099/12/31" },
         "id": 5,
         "guid": "tag-pii-5-guid"
       },
       "6": {
         "type": "PII-FINAL",
-        "attributes": { "expiry": "2026/06/15" },
+        "attributes": { "expiry": "2099/12/31" },
         "id": 6,
         "guid": "tag-pii-final-6-guid"
       },

--- a/agents-common/src/test/resources/policyengine/descendant_tags.json
+++ b/agents-common/src/test/resources/policyengine/descendant_tags.json
@@ -26,7 +26,7 @@
     "tags": {
       "1": {
         "type": "PII",
-        "attributes": { "expiry": "2026/06/15" },
+        "attributes": { "expiry": "2099/12/31" },
         "id": 1,
         "guid": "tag-pii-1-guid"
       },

--- a/agents-common/src/test/resources/policyengine/plugin/resourceTags.json
+++ b/agents-common/src/test/resources/policyengine/plugin/resourceTags.json
@@ -37,7 +37,7 @@
     "tags": {
       "1": {
         "type": "EXPIRES_ON",
-        "attributes": { "expiry_date": "2026/06/15" },
+        "attributes": { "expiry_date": "2099/12/31" },
         "id": 1,
         "guid": "tag-expires-on-1-guid"
       },
@@ -55,19 +55,19 @@
       },
       "4": {
         "type": "RESTRICTED-FINAL",
-        "attributes": { "activation_date": "2026/06/15" },
+        "attributes": { "activation_date": "2099/12/31" },
         "id": 4,
         "guid": "tag-restricted-final-4-guid"
       },
       "5": {
         "type": "PII",
-        "attributes": { "expiry": "2026/06/15" },
+        "attributes": { "expiry": "2099/12/31" },
         "id": 5,
         "guid": "tag-pii-5-guid"
       },
       "6": {
         "type": "PII-FINAL",
-        "attributes": { "expiry": "2026/06/15" },
+        "attributes": { "expiry": "2099/12/31" },
         "id": 6,
         "guid": "tag-pii-final-6-guid"
       }

--- a/agents-common/src/test/resources/policyengine/resourceTags.json
+++ b/agents-common/src/test/resources/policyengine/resourceTags.json
@@ -37,7 +37,7 @@
     "tags": {
       "1": {
         "type": "EXPIRES_ON",
-        "attributes": { "expiry_date": "2026/06/15" },
+        "attributes": { "expiry_date": "2099/12/31" },
         "id": 1,
         "guid": "tag-expires-on-1-guid"
       },
@@ -55,19 +55,19 @@
       },
       "4": {
         "type": "RESTRICTED-FINAL",
-        "attributes": { "activation_date": "2026/06/15" },
+        "attributes": { "activation_date": "2099/12/31" },
         "id": 4,
         "guid": "tag-restricted-final-4-guid"
       },
       "5": {
         "type": "PII",
-        "attributes": { "expiry": "2026/06/15" },
+        "attributes": { "expiry": "2099/12/31" },
         "id": 5,
         "guid": "tag-pii-5-guid"
       },
       "6": {
         "type": "PII-FINAL",
-        "attributes": { "expiry": "2026/06/15" },
+        "attributes": { "expiry": "2099/12/31" },
         "id": 6,
         "guid": "tag-pii-final-6-guid"
       }

--- a/agents-common/src/test/resources/policyengine/test_policyengine_tag_hive.json
+++ b/agents-common/src/test/resources/policyengine/test_policyengine_tag_hive.json
@@ -241,7 +241,7 @@
       "request":{
         "resource":{"elements":{"database":"default", "table":"table2"}},
         "accessType":"","user":"denieduser","userGroups":[],"requestData":"desc default.table2;' for denieduser",
-        "context": {"TAGS":"[{\"type\":\"PII-FINAL\", \"attributes\":{\"expiry\":\"2026/06/15\"}}]"}
+        "context": {"TAGS":"[{\"type\":\"PII-FINAL\", \"attributes\":{\"expiry\":\"2099/12/31\"}}]"}
       },
       "result":{"isAudited":true,"isAllowed":false,"policyId":103}
     },
@@ -292,7 +292,7 @@
       "request":{
         "resource":{"elements":{"database":"employee", "table":"personal", "column":"ssn"}},
         "accessType":"select","user":"user1","userGroups":[],"requestData":"select ssn from employee.personal;' for user1",
-        "context": {"TAGS":"[{\"type\":\"RESTRICTED\", \"attributes\":{\"expiry\":\"2026/06/15\"}}]"}
+        "context": {"TAGS":"[{\"type\":\"RESTRICTED\", \"attributes\":{\"expiry\":\"2099/12/31\"}}]"}
       },
       "result":{"isAudited":true,"isAllowed":true,"policyId":1}
     },
@@ -300,7 +300,7 @@
       "request":{
         "resource":{"elements":{"database":"employee", "table":"personal", "column":"ssn"}},
         "accessType":"select","user":"user2","userGroups":[],"requestData":"select ssn from employee.personal;' for user2",
-        "context": {"TAGS":"[{\"type\":\"RESTRICTED-FINAL\", \"attributes\":{\"expiry\":\"2026/06/15\"}}]"}
+        "context": {"TAGS":"[{\"type\":\"RESTRICTED-FINAL\", \"attributes\":{\"expiry\":\"2099/12/31\"}}]"}
       },
       "result":{"isAudited":true,"isAllowed":false,"policyId":4}
     },
@@ -325,7 +325,7 @@
       "request":{
         "resource":{"elements":{"database":"default", "table":"table1", "column":"name"}},
         "accessType":"select","user":"hive","userGroups":[],"requestData":"select name from default.table1;' for hive",
-        "context": {"TAGS":"[{\"type\":\"PII\", \"attributes\":{\"expiry\":\"2026/06/15\"}}]"}
+        "context": {"TAGS":"[{\"type\":\"PII\", \"attributes\":{\"expiry\":\"2099/12/31\"}}]"}
       },
       "result":{"isAudited":true,"isAllowed":true,"policyId":2}
     },
@@ -333,7 +333,7 @@
       "request":{
         "resource":{"elements":{"database":"default", "table":"table1"}},
         "accessType":"","user":"hive","userGroups":[],"requestData":"desc default.table1;' for hive",
-        "context": {"TAGS":"[{\"type\":\"PII\", \"attributes\":{\"expiry\":\"2026/06/15\"}}]"}
+        "context": {"TAGS":"[{\"type\":\"PII\", \"attributes\":{\"expiry\":\"2099/12/31\"}}]"}
       },
       "result":{"isAudited":true,"isAllowed":true,"policyId":2}
     },
@@ -341,7 +341,7 @@
       "request":{
         "resource":{"elements":{"database":"default", "table":"table1"}},
         "accessType":"","user":"user1","userGroups":[],"requestData":"desc default.table1;' for user1",
-        "context": {"TAGS":"[{\"type\":\"PII-FINAL\", \"attributes\":{\"expiry\":\"2026/06/15\"}}]"}
+        "context": {"TAGS":"[{\"type\":\"PII-FINAL\", \"attributes\":{\"expiry\":\"2099/12/31\"}}]"}
       },
       "result":{"isAudited":true,"isAllowed":false,"policyId":3}
     },
@@ -349,7 +349,7 @@
       "request":{
         "resource":{"elements":{"database":"default", "table":"table1"}},
         "accessType":"","user":"testuser","userGroups":[],"requestData":"desc default.table1;' for testuser",
-        "context": {"TAGS":"[{\"type\":\"PII-FINAL\", \"attributes\":{\"expiry\":\"2026/06/15\"}}]"}
+        "context": {"TAGS":"[{\"type\":\"PII-FINAL\", \"attributes\":{\"expiry\":\"2099/12/31\"}}]"}
       },
       "result":{"isAudited":true,"isAllowed":false,"policyId":-1}
     },
@@ -357,7 +357,7 @@
       "request":{
         "resource":{"elements":{"database":"default"}},
         "accessType":"","user":"hive","userGroups":[],"requestData":"use default",
-        "context": {"TAGS":"[{\"type\":\"PII-FINAL\", \"attributes\":{\"expiry\":\"2026/06/15\"}}]"}
+        "context": {"TAGS":"[{\"type\":\"PII-FINAL\", \"attributes\":{\"expiry\":\"2099/12/31\"}}]"}
       },
       "result":{"isAudited":true,"isAllowed":true,"policyId":101}
     },
@@ -365,7 +365,7 @@
       "request":{
         "resource":{"elements":{"database":"default"}},
         "accessType":"","user":"user1","userGroups":[],"requestData":"use default for user1",
-        "context": {"TAGS":"[{\"type\":\"PII-FINAL\", \"attributes\":{\"expiry\":\"2026/06/15\"}}]"}
+        "context": {"TAGS":"[{\"type\":\"PII-FINAL\", \"attributes\":{\"expiry\":\"2099/12/31\"}}]"}
       },
       "result":{"isAudited":true,"isAllowed":false,"policyId":3}
     },
@@ -373,7 +373,7 @@
       "request":{
         "resource":{"elements":{"database":"default", "table":"table1", "column":"name"}},
         "accessType":"select","user":"hive","userGroups":[],"requestData":"select * from default.table1",
-        "context": {"TAGS":"[{\"type\":\"PII\", \"attributes\":{\"expiry\":\"2026/06/15\"}}]"}
+        "context": {"TAGS":"[{\"type\":\"PII\", \"attributes\":{\"expiry\":\"2099/12/31\"}}]"}
       },
       "result":{"isAudited":true,"isAllowed":true,"policyId":2}
     },


### PR DESCRIPTION
## Summary

Backport of [#1018](https://github.com/apache/ranger/pull/1018) to `ranger-2.9`.

- Update slash-format tag fixture dates from `2026/06/15` to `2099/12/31` so date-bound tag policy engine tests stay stable after the cutoff date.
- Fix thread-unsafe dynamic path wildcard matching in `RecursiveWildcardResourceMatcher` by using local `pathElements` per `isMatch()` call instead of rewriting the shared `wildcardPathElements` field.

Fixes [RANGER-5647](https://issues.apache.org/jira/browse/RANGER-5647).

## Test plan

- [ ] `mvn test -pl agents-common -Dtest=TestPolicyEngine#testPolicyEngine_hiveForTag_filebased,TestPolicyEngine#testPolicyEngine_hdfs_resourcespec -Drat.skip=true -Dcheckstyle.skip=true -Dpmd.skip=true -Dspotbugs.skip=true`
- [ ] CI `build-8` green on `ranger-2.9`


Made with [Cursor](https://cursor.com)