### PR TITLE
RANGER-5647: Backport ISO EXPIRES_ON tag test dates to ranger-2.9

### DIFF
--- a/agents-common/src/test/resources/policyengine/test_policyengine_tag_hive.json
+++ b/agents-common/src/test/resources/policyengine/test_policyengine_tag_hive.json
@@ -250,7 +250,7 @@
         "resource":{"elements":{"database":"employee", "table":"personal", "column":"ssn"}},
         "accessType":"select","user":"testuser","userGroups":[],"requestData":"select ssn from employee.personal;' for testuser",
 
-        "context": {"TAGS":"[{\"type\":\"EXPIRES_ON\", \"attributes\":{\"expiry_date\":\"2026-06-15T15:05:15.000Z\"}, \"matchType\":\"DESCENDANT\"}]"}
+        "context": {"TAGS":"[{\"type\":\"EXPIRES_ON\", \"attributes\":{\"expiry_date\":\"2099-12-31T15:05:15.000Z\"}, \"matchType\":\"DESCENDANT\"}]"}
       },
       "result":{"isAudited":true,"isAllowed":false,"policyId":-1}
     },
@@ -259,7 +259,7 @@
         "resource":{"elements":{"database":"employee", "table":"personal", "column":"ssn"}},
         "accessType":"select","user":"user1","userGroups":[],"requestData":"select ssn from employee.personal;' for user1",
 
-        "context": {"TAGS":"[{\"type\":\"EXPIRES_ON\", \"attributes\":{\"expiry_date\":\"2026-06-15T15:05:15.000Z\"}, \"matchType\":\"SELF\"}]"}
+        "context": {"TAGS":"[{\"type\":\"EXPIRES_ON\", \"attributes\":{\"expiry_date\":\"2099-12-31T15:05:15.000Z\"}, \"matchType\":\"SELF\"}]"}
       },
       "result":{"isAudited":true,"isAllowed":true,"policyId":101}
     },


### PR DESCRIPTION
## Summary

Backport of [#1021](https://github.com/apache/ranger/pull/1021) to `ranger-2.9`.

Completes the RANGER-5647 date fixture fix for ISO-format tag expiry dates in policy-engine tests.

| File | Change |
|------|--------|
| `agents-common/src/test/resources/policyengine/test_policyengine_tag_hive.json` | `2026-06-15T15:05:15.000Z` → `2099-12-31T15:05:15.000Z` for EXPIRES_ON **DESCENDANT** and **SELF** test cases |

No policy-engine logic changes — test fixture dates only.

Fixes [RANGER-5647](https://issues.apache.org/jira/browse/RANGER-5647).

## Related

- [#1041](https://github.com/apache/ranger/pull/1041) — backport of #1018 (slash-format dates + path matcher fix); merge first
- [#1018](https://github.com/apache/ranger/pull/1018) / [#1021](https://github.com/apache/ranger/pull/1021) on `master`

## Test plan

- [ ] `mvn test -pl agents-common -Dtest=TestPolicyEngine#testPolicyEngine_hiveForTag,TestPolicyEngine#testPolicyEngine_hiveForTag_filebased -Drat.skip=true -Dcheckstyle.skip=true -Dpmd.skip=true -Dspotbugs.skip=true`
- [ ] CI `build-8` green on `ranger-2.9`


Made with [Cursor](https://cursor.com)