### PR TITLE
RANGER-5657: Limit getAllModuleNames() to sys-admin sessions in SessionMgr

### DIFF
--- a/security-admin/src/main/java/org/apache/ranger/biz/SessionMgr.java
+++ b/security-admin/src/main/java/org/apache/ranger/biz/SessionMgr.java
@@ -236,7 +236,7 @@ public class SessionMgr {
 		XXUser xUser = daoManager.getXXUser().findByUserName(userSession.getLoginId());
 		if (xUser != null) {
 			List<String> permissionList;
-			if (userSession.isUserAdmin() || userSession.isKeyAdmin()) {
+			if (userSession.isUserAdmin()) {
 				permissionList = daoManager.getXXModuleDef().getAllModuleNames();
 			} else {
 				permissionList = daoManager.getXXModuleDef().findAccessibleModulesByUserId(userSession.getUserId(), xUser.getId());


### PR DESCRIPTION
## Summary

Backport of [0274a6a0](https://github.com/apache/ranger/commit/0274a6a0bc9680a7640e97432f8cbd3217a1659c) / [#1036](https://github.com/apache/ranger/pull/1036) to `ranger-2.9`.

Follow-up fix for [RANGER-5627](https://issues.apache.org/jira/browse/RANGER-5627). RANGER-5627 changed `SessionMgr.resetUserModulePermission()` to grant all UI modules when `isUserAdmin() || isKeyAdmin()`. That incorrectly gives DB key-admin users the full module list (including Security Zone) via `getAllModuleNames()`.

**Fix:** use `getAllModuleNames()` only when `userSession.isUserAdmin()`. Config super-users are unaffected (they already get full admin through `superUser` → `isUserAdmin()`).

Fixes [RANGER-5657](https://issues.apache.org/jira/browse/RANGER-5657).

## Test plan

- [ ] `mvn test -pl security-admin -Dtest=TestSessionMgr,TestRangerSuperUserConfig -Drat.skip=true -Dcheckstyle.skip=true -Dpmd.skip=true -Dspotbugs.skip=true`
- [ ] Manual: DB key-admin should not see Security Zone in profile; zone GET returns 400
- [ ] Manual: sys admin and config super-users unchanged (all modules, zone GET 200)


Made with [Cursor](https://cursor.com)