### PR TITLE
RANGER-5634: CTAS and temporary-table queries must authorize UDF SELECT

### DIFF
--- a/hive-agent/src/main/java/org/apache/ranger/authorization/hive/authorizer/RangerHiveAuthorizer.java
+++ b/hive-agent/src/main/java/org/apache/ranger/authorization/hive/authorizer/RangerHiveAuthorizer.java
@@ -1795,6 +1795,8 @@ public class RangerHiveAuthorizer extends RangerHiveAuthorizerBase {
 				case CREATE_MATERIALIZED_VIEW:
 					if(hiveObj.getType() == HivePrivilegeObjectType.TABLE_OR_VIEW) {
 						accessType = isInput ? HiveAccessType.SELECT : HiveAccessType.CREATE;
+					} else if (hiveObj.getType() == HivePrivilegeObjectType.FUNCTION) {
+						accessType = HiveAccessType.SELECT;
 					}
 				break;
 				case ALTERVIEW_AS:


### PR DESCRIPTION
## Summary

Backport of [409e8a72](https://github.com/apache/ranger/commit/409e8a72cacbdf7d160d6ca508d7fb4770188a5f) / [#1012](https://github.com/apache/ranger/pull/1012) to `ranger-2.9`.

For `CREATETABLE_AS_SELECT` and `CREATE_MATERIALIZED_VIEW`, treat input `FUNCTION` privilege objects as `SELECT` so CTAS/temp-table queries cannot bypass UDF select authorization.

Fixes [RANGER-5634](https://issues.apache.org/jira/browse/RANGER-5634).

## Changes

| File | Change |
|------|--------|
| `hive-agent/.../RangerHiveAuthorizer.java` | Map input `FUNCTION` objects to `HiveAccessType.SELECT` for CTAS / create materialized view |

**Note:** Unit tests from #1012 (`TestRangerHiveAuthorizer`) are not included — that test class does not exist on `ranger-2.9`. Production fix only.

## Test plan

- [ ] Manual: user without UDF SELECT should get `HiveAccessControlException` on `CREATE TABLE ... AS SELECT ...` using that UDF
- [ ] Manual: plain `SELECT` with UDF still denied as before
- [ ] CI `build-8` green on `ranger-2.9`


Made with [Cursor](https://cursor.com)