### PR TITLE
RANGER-5635: ranger.admin.allow.unauthenticated.download.access is ho…

### DIFF
--- a/security-admin/src/main/java/org/apache/ranger/biz/RangerBizUtil.java
+++ b/security-admin/src/main/java/org/apache/ranger/biz/RangerBizUtil.java
@@ -35,7 +35,6 @@ import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOCase;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.ranger.authorization.hadoop.config.RangerAdminConfig;
 import org.apache.ranger.common.AppConstants;
 import org.apache.ranger.common.ContextUtil;
@@ -467,21 +466,17 @@ public class RangerBizUtil {
 	}
 
 	public void failUnauthenticatedIfNotAllowed() throws Exception {
-		if (UserGroupInformation.isSecurityEnabled()) {
 			UserSessionBase currentUserSession = ContextUtil.getCurrentUserSession();
 			if (currentUserSession == null && !allowUnauthenticatedAccessInSecureEnvironment) {
 					throw new Exception("Unauthenticated access not allowed");
 			}
-		}
 	}
 
 	public void failUnauthenticatedDownloadIfNotAllowed() throws Exception {
-		if (UserGroupInformation.isSecurityEnabled()) {
 			UserSessionBase currentUserSession = ContextUtil.getCurrentUserSession();
 			if (currentUserSession == null && !allowUnauthenticatedDownloadAccessInSecureEnvironment) {
 					throw new Exception("Unauthenticated access not allowed");
 			}
-		}
 	}
 
 	/**

--- a/security-admin/src/test/java/org/apache/ranger/biz/TestRangerBizUtil.java
+++ b/security-admin/src/test/java/org/apache/ranger/biz/TestRangerBizUtil.java
@@ -16,6 +16,7 @@
  */
 package org.apache.ranger.biz;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -701,4 +702,61 @@ public class TestRangerBizUtil {
                 Assert.assertTrue(rangerBizUtil.checkUserAccessible(vXUser));
         }
 
+	@Test
+	public void testFailUnauthenticatedDownload_blocksWhenNoSessionAndFlagFalse() {
+		RangerContextHolder.setSecurityContext(null);
+		Assert.assertThrows(Exception.class, () -> rangerBizUtil.failUnauthenticatedDownloadIfNotAllowed());
+	}
+
+	@Test
+	public void testFailUnauthenticatedDownload_allowsWhenSessionPresent() {
+		try {
+			rangerBizUtil.failUnauthenticatedDownloadIfNotAllowed();
+		} catch (Exception e) {
+			Assert.fail("Expected no exception, but got: " + e.getMessage());
+		}
+	}
+
+	@Test
+	public void testFailUnauthenticatedDownload_allowsWhenFlagTrue() throws Exception {
+		RangerContextHolder.setSecurityContext(null);
+		setField("allowUnauthenticatedDownloadAccessInSecureEnvironment", true);
+		try {
+			rangerBizUtil.failUnauthenticatedDownloadIfNotAllowed();
+		} catch (Exception e) {
+			Assert.fail("Expected no exception, but got: " + e.getMessage());
+		}
+	}
+
+	@Test
+	public void testFailUnauthenticated_blocksWhenNoSessionAndFlagFalse() {
+		RangerContextHolder.setSecurityContext(null);
+		Assert.assertThrows(Exception.class, () -> rangerBizUtil.failUnauthenticatedIfNotAllowed());
+	}
+
+	@Test
+	public void testFailUnauthenticated_allowsWhenSessionPresent() {
+		try {
+			rangerBizUtil.failUnauthenticatedIfNotAllowed();
+		} catch (Exception e) {
+			Assert.fail("Expected no exception, but got: " + e.getMessage());
+		}
+	}
+
+	@Test
+	public void testFailUnauthenticated_allowsWhenFlagTrue() throws Exception {
+		RangerContextHolder.setSecurityContext(null);
+		setField("allowUnauthenticatedAccessInSecureEnvironment", true);
+		try {
+			rangerBizUtil.failUnauthenticatedIfNotAllowed();
+		} catch (Exception e) {
+			Assert.fail("Expected no exception, but got: " + e.getMessage());
+		}
+	}
+
+	private void setField(String name, Object value) throws Exception {
+		Field f = RangerBizUtil.class.getDeclaredField(name);
+		f.setAccessible(true);
+		f.set(rangerBizUtil, value);
+	}
 }

--- a/security-admin/src/test/java/org/apache/ranger/rest/TestServiceREST.java
+++ b/security-admin/src/test/java/org/apache/ranger/rest/TestServiceREST.java
@@ -2803,4 +2803,25 @@ public class TestServiceREST {
 		Assert.assertEquals(dbRangerPolicy.getId(), rangerPolicy.getId());
 		Assert.assertEquals(dbRangerPolicy.getName(), rangerPolicy.getName());
 	}
+	@Test
+	public void test155DownloadBlockedWhenUnauthenticatedAndFlagFalse() throws Exception {
+		HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+		RangerContextHolder.setSecurityContext(null);                       // no session; flag=false (mock default)
+		Mockito.doCallRealMethod().when(bizUtil).failUnauthenticatedDownloadIfNotAllowed();
+		Mockito.when(restErrorUtil.createRESTException(Mockito.anyInt(), Mockito.anyString(), Mockito.anyBoolean()))
+				.thenReturn(new WebApplicationException());
+		Assert.assertThrows(WebApplicationException.class, () -> serviceREST.getServicePoliciesIfUpdated("HDFS_1",
+				1L, 0L, "1", "", "", false, capabilityVector, request));
+	}
+
+	@Test
+	public void test156GrantBlockedWhenUnauthenticatedAndFlagFalse() throws Exception {
+		HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+		GrantRevokeRequest grantRequest = createValidGrantRevokeRequest();
+		Mockito.when(serviceUtil.isValidateHttpsAuthentication("HDFS_1", request)).thenReturn(true); // enter the guarded block
+		Mockito.doCallRealMethod().when(bizUtil).failUnauthenticatedIfNotAllowed();
+		RangerContextHolder.setSecurityContext(null);
+		Mockito.when(restErrorUtil.createRESTException(Mockito.anyString())).thenReturn(new WebApplicationException());
+		Assert.assertThrows(WebApplicationException.class, () -> serviceREST.grantAccess("HDFS_1", grantRequest, request));
+	}
 }


### PR DESCRIPTION
…nored only when Kerberos is enabled

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix. Create an issue in ASF JIRA before opening a pull request and
set the title of the pull request which starts with
the corresponding JIRA issue number. (e.g. RANGER-XXXX: Fix a typo in YYY))


## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)
