### PR TITLE
RANGER-5530: Fix for KMS API not working in docker kerberos env (#1004)

### DIFF
--- a/dev-support/ranger-docker/docker-compose.ranger-kms.yml
+++ b/dev-support/ranger-docker/docker-compose.ranger-kms.yml
@@ -15,7 +15,8 @@ services:
     volumes:
       - ./dist/keytabs/ranger-kms:/etc/keytabs
       - ./scripts/kdc/krb5.conf:/etc/krb5.conf
-      - ./scripts/hadoop/core-site.xml:/home/ranger/scripts/core-site.xml:ro
+      - ./scripts/kms/core-site.xml:/home/ranger/scripts/core-site.xml:ro
+      - ./scripts/kms/kms-site.xml:/home/ranger/scripts/kms-site.xml:ro
       - ./dist/version:/home/ranger/dist/version:ro
       - ./scripts/kms/ranger-kms-install-${RANGER_DB_TYPE}.properties:/opt/ranger/kms/install.properties
     stdin_open: true

--- a/dev-support/ranger-docker/scripts/admin/create-ranger-services.py
+++ b/dev-support/ranger-docker/scripts/admin/create-ranger-services.py
@@ -81,7 +81,7 @@ hbase = RangerService({'name': 'dev_hbase', 'type': 'hbase',
 
 kms = RangerService({'name': 'dev_kms', 'type': 'kms',
                      'configs': {'username': 'keyadmin', 'password': 'rangerR0cks!',
-                                 'provider': 'http://ranger-kms.rangernw:9292',
+                                 'provider': 'kms://http@ranger-kms.rangernw:9292/kms',
                                  'policy.download.auth.users': 'rangerkms',
                                  'tag.download.auth.users': 'rangerkms',
                                  'userstore.download.auth.users': 'rangerkms',

--- a/dev-support/ranger-docker/scripts/kdc/entrypoint.sh
+++ b/dev-support/ranger-docker/scripts/kdc/entrypoint.sh
@@ -79,6 +79,7 @@ function create_keytabs() {
   create_principal_and_keytab rangerusersync ranger-usersync
 
   create_principal_and_keytab rangerkms ranger-kms
+  create_principal_and_keytab HTTP      ranger-kms
 
   create_principal_and_keytab HTTP      ranger-pdp
   create_principal_and_keytab rangerpdp ranger-pdp

--- a/dev-support/ranger-docker/scripts/kms/core-site.xml
+++ b/dev-support/ranger-docker/scripts/kms/core-site.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <property>
+        <name>hadoop.security.authentication</name>
+        <value>kerberos</value>
+    </property>
+    <property>
+        <name>hadoop.security.auth_to_local</name>
+        <value>RULE:[2:$1/$2@$0](rangeradmin/ranger\.rangernw@EXAMPLE\.COM)s/.*/ranger/
+RULE:[2:$1/$2@$0](rangertagsync/ranger-tagsync\.rangernw@EXAMPLE\.COM)s/.*/rangertagsync/
+RULE:[2:$1/$2$0](rangerusersync/ranger-usersync\.rangernw@EXAMPLE\.COM)s/.*/rangerusersync/
+RULE:[2:$1/$2$0](rangerkms/ranger-kms\.rangernw@EXAMPLE\.COM)s/.*/keyadmin/
+DEFAULT</value>
+        <description>
+            Rules used to resolve Kerberos principal names.
+        </description>
+    </property>
+</configuration>

--- a/dev-support/ranger-docker/scripts/kms/kms-site.xml
+++ b/dev-support/ranger-docker/scripts/kms/kms-site.xml
@@ -1,0 +1,196 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<configuration>
+
+  <!-- KMS Backend KeyProvider -->
+
+  <property>
+    <name>hadoop.kms.key.provider.uri</name>
+    <value>dbks://http@localhost:9292/kms</value>
+    <description>
+      URI of the backing KeyProvider for the KMS.
+    </description>
+  </property>
+
+  <property>
+    <name>hadoop.security.keystore.JavaKeyStoreProvider.password</name>
+    <value>none</value>
+    <description>
+      If using the JavaKeyStoreProvider, the password for the keystore file.
+    </description>
+  </property>
+  
+  <!-- KMS Cache -->
+
+  <property>
+    <name>hadoop.kms.cache.enable</name>
+    <value>true</value>
+    <description>
+      Whether the KMS will act as a cache for the backing KeyProvider.
+      When the cache is enabled, operations like getKeyVersion, getMetadata,
+      and getCurrentKey will sometimes return cached data without consulting
+      the backing KeyProvider. Cached values are flushed when keys are deleted
+      or modified.
+    </description>
+  </property>
+
+  <property>
+    <name>hadoop.kms.cache.timeout.ms</name>
+    <value>600000</value>
+    <description>
+      Expiry time for the KMS key version and key metadata cache, in
+      milliseconds. This affects getKeyVersion and getMetadata.
+    </description>
+  </property>
+
+  <property>
+    <name>hadoop.kms.current.key.cache.timeout.ms</name>
+    <value>30000</value>
+    <description>
+      Expiry time for the KMS current key cache, in milliseconds. This
+      affects getCurrentKey operations.
+    </description>
+  </property>
+
+  <!-- KMS Audit -->
+
+  <property>
+    <name>hadoop.kms.audit.aggregation.window.ms</name>
+    <value>10000</value>
+    <description>
+      Duplicate audit log events within the aggregation window (specified in
+      ms) are quashed to reduce log traffic. A single message for aggregated
+      events is printed at the end of the window, along with a count of the
+      number of aggregated events.
+    </description>
+  </property>
+
+  <!-- KMS Security -->
+
+  <property>
+    <name>hadoop.kms.authentication.type</name>
+    <value>kerberos</value>
+    <description>
+      Authentication type for the KMS. Can be either &quot;simple&quot;
+      or &quot;kerberos&quot;.
+    </description>
+  </property>
+
+  <property>
+    <name>hadoop.kms.authentication.kerberos.keytab</name>
+    <value>/etc/keytabs/HTTP.keytab</value>
+    <description>
+      Path to the keytab with credentials for the configured Kerberos principal.
+    </description>
+  </property>
+
+  <property>
+    <name>hadoop.kms.authentication.kerberos.principal</name>
+    <value>HTTP/ranger-kms.rangernw@EXAMPLE.COM</value>
+    <description>
+      The Kerberos principal to use for the HTTP endpoint.
+      The principal must start with 'HTTP/' as per the Kerberos HTTP SPNEGO specification.
+    </description>
+  </property>
+
+  <property>
+    <name>hadoop.kms.authentication.kerberos.name.rules</name>
+    <value>RULE:[2:$1/$2@$0](rangeradmin/ranger\.rangernw@EXAMPLE\.COM)s/.*/ranger/
+RULE:[2:$1/$2@$0](rangertagsync/ranger-tagsync\.rangernw@EXAMPLE\.COM)s/.*/rangertagsync/
+RULE:[2:$1/$2$0](rangerusersync/ranger-usersync\.rangernw@EXAMPLE\.COM)s/.*/rangerusersync/
+RULE:[2:$1/$2$0](rangerkms/ranger-kms\.rangernw@EXAMPLE\.COM)s/.*/keyadmin/
+DEFAULT</value>
+    <description>
+      Rules used to resolve Kerberos principal names.
+    </description>
+  </property>
+
+  <!-- Authentication cookie signature source -->
+
+  <property>
+    <name>hadoop.kms.authentication.signer.secret.provider</name>
+    <value>random</value>
+    <description>
+      Indicates how the secret to sign the authentication cookies will be
+      stored. Options are 'random' (default), 'string' and 'zookeeper'.
+      If using a setup with multiple KMS instances, 'zookeeper' should be used.
+    </description>
+  </property>
+
+  <!-- Configuration for 'zookeeper' authentication cookie signature source -->
+
+  <property>
+    <name>hadoop.kms.authentication.signer.secret.provider.zookeeper.path</name>
+    <value>/hadoop-kms/hadoop-auth-signature-secret</value>
+    <description>
+      The Zookeeper ZNode path where the KMS instances will store and retrieve
+      the secret from.
+    </description>
+  </property>
+
+  <property>
+    <name>hadoop.kms.authentication.signer.secret.provider.zookeeper.connection.string</name>
+    <value>#HOSTNAME#:#PORT#,...</value>
+    <description>
+      The Zookeeper connection string, a list of hostnames and port comma
+      separated.
+    </description>
+  </property>
+
+  <property>
+    <name>hadoop.kms.authentication.signer.secret.provider.zookeeper.auth.type</name>
+    <value>kerberos</value>
+    <description>
+      The Zookeeper authentication type, 'none' or 'sasl' (Kerberos).
+    </description>
+  </property>
+
+  <property>
+    <name>hadoop.kms.authentication.signer.secret.provider.zookeeper.kerberos.keytab</name>
+    <value>/etc/hadoop/conf/kms.keytab</value>
+    <description>
+      The absolute path for the Kerberos keytab with the credentials to
+      connect to Zookeeper.
+    </description>
+  </property>
+
+  <property>
+    <name>hadoop.kms.authentication.signer.secret.provider.zookeeper.kerberos.principal</name>
+    <value>kms/#HOSTNAME#</value>
+    <description>
+      The Kerberos service principal used to connect to Zookeeper.
+    </description>
+  </property>
+  
+  <property>
+  	<name>hadoop.kms.security.authorization.manager</name>
+  	<value>org.apache.ranger.authorization.kms.authorizer.RangerKmsAuthorizer</value>
+  </property>
+  
+  <property>
+  	<name>hadoop.kms.proxyuser.ranger.groups</name>
+  	<value>*</value>
+  </property>
+  
+  <property>
+  	<name>hadoop.kms.proxyuser.ranger.hosts</name>
+  	<value>*</value>
+  </property>
+  
+  <property>
+  	<name>hadoop.kms.proxyuser.ranger.users</name>
+  	<value>*</value>
+  </property>
+</configuration>

--- a/dev-support/ranger-docker/scripts/kms/ranger-kms.sh
+++ b/dev-support/ranger-docker/scripts/kms/ranger-kms.sh
@@ -37,6 +37,7 @@ then
     if [ "${KERBEROS_ENABLED}" == "true" ]
     then
       cp ${RANGER_SCRIPTS}/core-site.xml ${RANGER_HOME}/kms/ews/webapp/WEB-INF/classes/conf/core-site.xml
+      cp ${RANGER_SCRIPTS}/kms-site.xml ${RANGER_HOME}/kms/ews/webapp/WEB-INF/classes/conf/kms-site.xml
     fi
 
     touch "${RANGER_HOME}"/.setupDone

--- a/distro/src/main/assembly/kms.xml
+++ b/distro/src/main/assembly/kms.xml
@@ -188,6 +188,7 @@
                     <include>com.squareup.okhttp:okhttp</include>
                     <!-- ranger common metrics module-->
                             <include>org.apache.ranger:ranger-metrics</include>
+                            <include>org.apache.ranger:ranger-common-utils</include>
                         </includes>
                     </dependencySet>
                 </dependencySets>
@@ -260,6 +261,7 @@
             <useAllReactorProjects>true</useAllReactorProjects>
             <includes>
                 <include>org.apache.ranger:ranger-util</include>
+                <include>org.apache.ranger:ranger-common-utils</include>
                 <include>org.apache.ranger:ranger-kms-plugin-shim</include>
                 <include>org.apache.ranger:ranger-plugin-classloader</include>
                 <include>org.apache.ranger:credentialbuilder</include>


### PR DESCRIPTION
Ranger-KMS APIs (including dev_kms TestConnection) were breaking due to authentication & authorisation error after kerberos implementation in Docker env.
This PR contains fix for following:

Enabled KMS to run in kerberos: KMS uses kms-site.xml in it's authentication flow, not core-site.xml. So included kms-site.xml with correct config.
Updated KDC entrypoint to generate HTTP.keytab for KMS , It is required for SPNEGO.
Corrected hadoop_auth_local rule as per kerberos principal
Updated dev_kms KMS URL connection
Fixed Class loading errors due to duplicate jars being added in ews/lib & WEB-INF/lib
After kerberos fix, it was throwing following error:

```
2026-06-09 07:19:48,155 ERROR [http-nio-9292-exec-9] o.a.c.c.C.[.[.[.[webservices-driver] (DirectJDKLog.java:170) - Servlet.service() for servlet [webservices-driver] in context with path [] threw exception [org.glassfish.jersey.server.ContainerException: java.lang.NoClassDefFoundError: Could not initialize class org.apache.ranger.plugin.util.JsonUtilsV2] with root cause
java.lang.ExceptionInInitializerError: Exception java.lang.LinkageError: loader constraint violation: loader 'app' wants to load class com.fasterxml.jackson.databind.ObjectMapper. A different class with the same name was previously loaded by org.apache.catalina.loader.ParallelWebappClassLoader @54336c81. (com.fasterxml.jackson.databind.ObjectMapper is in unnamed module of loader org.apache.catalina.loader.ParallelWebappClassLoader @54336c81, parent loader 'app') [in thread "http-nio-9292-exec-3"]
at java.base/java.lang.ClassLoader.defineClass1(Native Method)
at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1017)
………………………………………
………………………………………
at org.apache.ranger.plugin.util.JsonUtilsV2.<clinit>(JsonUtilsV2.java:34)
at org.apache.hadoop.crypto.key.kms.server.KMSJSONWriter.writeTo(KMSJSONWriter.java:61)
at org.glassfish.jersey.message.internal.WriterInterceptorExecutor$TerminalWriterInterceptor.invokeWriteTo(WriterInterceptorExecutor.java:242)
at ……………..
…………………………..
at org.glassfish.jersey.internal.Errors.process(Errors.java:244)
```
As per my analysis, it happened due to duplicate jackson-*:jar jars available inside distro/kms.xml . Once inside "ews/webapp/WEB-INF/lib/" and once inside "ews/lib".

RCA: "[ranger-common-utils](https://issues.apache.org/jira/browse/RANGER-common-utils)" was part of "ews/lib" and Jackson jars were part of both moduleSets. JsonUtilsV2.java tries to load com.fasterxml.jackson.databind.ObjectMapper . It's part of Jackson jars and it was already loaded by another class loader. That is, once it gets loaded by the app loader, then the webapp loader tries to load it again → loader constraint violation → JsonUtilsV2 cannot initialize.

Fix: : Removed [ranger-common-utils](https://issues.apache.org/jira/browse/RANGER-common-utils) dependency & Jackson-*.jar from ews/lib and added [ranger-common-utils](https://issues.apache.org/jira/browse/RANGER-common-utils) inside "ews/webapp/WEB-INF/lib/".

How was this patch tested?
-mvn build is working

setup docker env locally, KMS is UP & running.
dev_kms Test connection is working now
Zone key creation , rollover , delete etc. is working.