### PR TITLE
RANGER-5667: Follow-on updates for RANGER-5628

### DIFF
--- a/agents-common/src/main/java/org/apache/ranger/plugin/conditionevaluator/RangerActionMatcher.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/conditionevaluator/RangerActionMatcher.java
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
 public class RangerActionMatcher extends RangerAbstractConditionEvaluator {
     private static final Logger LOG = LoggerFactory.getLogger(RangerActionMatcher.class);
 
-    private RangerActionListMatcher actionMatcher = new RangerActionListMatcher(null);
+    private RangerActionListMatcher actionMatcher;
 
     @Override
     public void init() {
@@ -43,7 +43,9 @@ public class RangerActionMatcher extends RangerAbstractConditionEvaluator {
     public boolean isMatched(final RangerAccessRequest request) {
         LOG.debug("==> RangerActionMatcher.isMatched({})", request);
 
-        final boolean ret = actionMatcher.isMatch(request != null ? request.getAction() : null);
+        final RangerActionListMatcher matcher = actionMatcher;
+        final String                  action  = request != null ? request.getAction() : null;
+        final boolean                 ret     = matcher == null || matcher.isMatch(action);
 
         LOG.debug("<== RangerActionMatcher.isMatched({}): {}", request, ret);
 

--- a/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerActionListMatcher.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerActionListMatcher.java
@@ -68,6 +68,10 @@ public class RangerActionListMatcher {
                     exactActions.add(action.toLowerCase(Locale.ROOT));
                 }
             }
+
+            if (!allowAny && exactActions.isEmpty() && tempPrefixList.isEmpty()) {
+                allowAny = true;
+            }
         }
 
         this.allowAnyAction = allowAny;
@@ -95,28 +99,27 @@ public class RangerActionListMatcher {
     }
 
     public boolean isMatch(String requestAction) {
-        boolean ret = allowAnyAction;
+        if (allowAnyAction) {
+            return true;
+        }
 
-        if (!ret) {
-            // if action is not available, don't enforce action restrictions
-            if (StringUtils.isBlank(requestAction)) {
-                ret = true;
-            } else {
-                final String actionLower = requestAction.toLowerCase(Locale.ROOT);
+        // Action restrictions exist; missing request action is not a match.
+        if (StringUtils.isBlank(requestAction)) {
+            return false;
+        }
 
-                if (exactActions.contains(actionLower)) {
-                    ret = true;
-                } else {
-                    for (String prefix : prefixActions) {
-                        if (actionLower.startsWith(prefix)) {
-                            ret = true;
-                            break;
-                        }
-                    }
-                }
+        final String actionLower = requestAction.toLowerCase(Locale.ROOT);
+
+        if (exactActions.contains(actionLower)) {
+            return true;
+        }
+
+        for (String prefix : prefixActions) {
+            if (actionLower.startsWith(prefix)) {
+                return true;
             }
         }
 
-        return ret;
+        return false;
     }
 }

--- a/agents-common/src/test/java/org/apache/ranger/plugin/conditionevaluator/RangerActionMatcherTest.java
+++ b/agents-common/src/test/java/org/apache/ranger/plugin/conditionevaluator/RangerActionMatcherTest.java
@@ -55,12 +55,12 @@ class RangerActionMatcherTest {
     }
 
     @Test
-    void testNoRequestActionDoesNotEnforce() {
+    void testNoRequestActionDoesNotMatchWhenActionsSpecified() {
         final RangerActionMatcher matcher = createMatcher(new String[] {"PutObject"});
 
-        assertTrue(matcher.isMatched(createRequest(null)));
-        assertTrue(matcher.isMatched(createRequest("")));
-        assertTrue(matcher.isMatched(createRequest("   ")));
+        assertFalse(matcher.isMatched(createRequest(null)));
+        assertFalse(matcher.isMatched(createRequest("")));
+        assertFalse(matcher.isMatched(createRequest("   ")));
     }
 
     @Test

--- a/agents-common/src/test/java/org/apache/ranger/plugin/util/RangerActionListMatcherTest.java
+++ b/agents-common/src/test/java/org/apache/ranger/plugin/util/RangerActionListMatcherTest.java
@@ -166,14 +166,25 @@ class RangerActionListMatcherTest {
     }
 
     @Test
-    void testBlankRequestActionBypassesRestriction() {
+    void testBlankRequestActionDoesNotMatchWhenActionsSpecified() {
         final RangerActionListMatcher matcher = new RangerActionListMatcher(
                 Arrays.asList("PutObject"));
 
-        // When no action is provided, action restrictions are not enforced
-        assertTrue(matcher.isMatch(null));
-        assertTrue(matcher.isMatch(""));
-        assertTrue(matcher.isMatch("   "));
+        // When action restrictions exist, missing action is not a match
+        assertFalse(matcher.isMatch(null));
+        assertFalse(matcher.isMatch(""));
+        assertFalse(matcher.isMatch("   "));
+    }
+
+    @Test
+    void testBlankRequestActionStillMatchesWhenNoActionsSpecified() {
+        final RangerActionListMatcher matcherNull = new RangerActionListMatcher(null);
+        assertTrue(matcherNull.isMatch(null));
+        assertTrue(matcherNull.isMatch(""));
+
+        final RangerActionListMatcher matcherEmpty = new RangerActionListMatcher(Collections.emptyList());
+        assertTrue(matcherEmpty.isMatch(null));
+        assertTrue(matcherEmpty.isMatch("   "));
     }
 
     @Test
@@ -183,6 +194,17 @@ class RangerActionListMatcherTest {
 
         assertTrue(matcher.isMatch("PutObject"));
         assertFalse(matcher.isMatch("GetObject"));
+    }
+
+    @Test
+    void testAllBlankActionsMatchAll() {
+        final RangerActionListMatcher matcher = new RangerActionListMatcher(
+                Arrays.asList("", "  ", "   "));
+
+        assertTrue(matcher.isMatch("PutObject"));
+        assertTrue(matcher.isMatch("GetObject"));
+        assertTrue(matcher.isMatch(null));
+        assertTrue(matcher.isMatch("   "));
     }
 
     @Test

--- a/agents-common/src/test/resources/policyevaluator/test_inline_policies_ozone.json
+++ b/agents-common/src/test/resources/policyevaluator/test_inline_policies_ozone.json
@@ -295,7 +295,7 @@
       },
       "result": { "isAudited": true, "isAllowed": true, "policyId": -1 }
     },
-    { "name": "ALLOW 'write s3v/iceberg/key2;' for user=svc-etl; no action in request bypasses action restriction",
+    { "name": "DENY 'write s3v/iceberg/key2;' for user=svc-etl; no action in request does not satisfy action restriction",
       "request": {
         "resource": { "elements": { "volume": "s3v", "bucket": "iceberg", "key": "key2" } }, "user": "svc-etl", "accessType": "write",
         "inlinePolicy": { "grantor":  "r:data-all-access", "mode": "INLINE",
@@ -304,7 +304,7 @@
           ]
         }
       },
-      "result": { "isAudited": true, "isAllowed": true, "policyId": -1 }
+      "result": { "isAudited": true, "isAllowed": false, "policyId": -1 }
     },
     { "name": "ALLOW 'read s3v/iceberg/key2;' for user=svc-etl; action=GetObject matches second entry in multi-action grant",
       "request": {

--- a/plugin-ozone/src/test/java/org/apache/ranger/authorization/ozone/authorizer/TestRangerOzoneAuthorizer.java
+++ b/plugin-ozone/src/test/java/org/apache/ranger/authorization/ozone/authorizer/TestRangerOzoneAuthorizer.java
@@ -262,7 +262,7 @@ public class TestRangerOzoneAuthorizer {
         assertFalse(ozoneAuthorizer.checkAccess(key1, ctxWriteGetObject),
                 "session-policy should deny write on key1 when S3 action is GetObject (not in grant)");
 
-        // No S3 action specified should bypass action restriction (allow through)
+        // No S3 action specified should be denied when the grant has S3-action restrictions
         RequestContext ctxWriteNoAction = reqCtxBuilder
                 .setAclRights(IAccessAuthorizer.ACLType.WRITE)
                 .setRecursiveAccessCheck(false)
@@ -270,7 +270,7 @@ public class TestRangerOzoneAuthorizer {
                 .setS3Action(null)
                 .build();
 
-        assertTrue(ozoneAuthorizer.checkAccess(key1, ctxWriteNoAction),
-                "session-policy should allow write on key1 when no S3 action is specified (bypass)");
+        assertFalse(ozoneAuthorizer.checkAccess(key1, ctxWriteNoAction),
+                "session-policy should deny write on key1 when no S3 action is specified and grant has S3 actions");
     }
 }

--- a/security-admin/src/main/webapp/react-webapp/src/hooks/usePruneStaleConditions.js
+++ b/security-admin/src/main/webapp/react-webapp/src/hooks/usePruneStaleConditions.js
@@ -70,7 +70,7 @@ export const usePruneStaleConditions = ({
     const newItems = [...items];
 
     newItems.forEach((item, index) => {
-      if (!item.conditions) {
+      if (!item?.conditions) {
         return;
       }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

A couple PR review comments came in after the PR associated with [RANGER-5628](https://issues.apache.org/jira/browse/RANGER-5628) was already merged. Essentially, if a Policy Condition has an `"action-matches"` condition, but the request does not supply an `s3Action` in the `RequestContext`, the request must be denied, and this is not being done currently. This ticket will address this issue.

Furthermore, a second comment related to unnecessary object allocation and this ticket also addresses that one.

Separately, it was identified that a non-empty list of actions, if they are all just whitespace, needs to be treated as if there were no action restrictions. This ticket addresses that as well.

Finally, separately, I noticed that for the Ozone service definition, pressing the "+" button to add a new rule under "Allow Conditions” section was causing an error to throw, and I traced it to a change I made in RANGER-5628.  Basically, PolicyPermissionItem.jsx is pushing `undefined` on the `addPolicyItem()` call, and my `usePruneStaleConditions.js` hook wasn't properly checking for that undefined.  This ticket makes that fix as well.


## How was this patch tested?
unit tests and end-to-end smoke tests locally with Ozone and Ranger
