### PR TITLE
RANGER-5624: Fix inconsistent updatedBy masking in groupName API

### DIFF
--- a/security-admin/src/main/java/org/apache/ranger/rest/XUserREST.java
+++ b/security-admin/src/main/java/org/apache/ranger/rest/XUserREST.java
@@ -61,7 +61,6 @@ import org.apache.ranger.common.UserSessionBase;
 import org.apache.ranger.common.annotation.RangerAnnotationClassName;
 import org.apache.ranger.common.annotation.RangerAnnotationJSMgrName;
 import org.apache.ranger.db.RangerDaoManager;
-import org.apache.ranger.entity.XXGroup;
 import org.apache.ranger.entity.XXService;
 import org.apache.ranger.entity.XXServiceDef;
 import org.apache.ranger.plugin.model.RangerPluginInfo;
@@ -835,24 +834,8 @@ public class XUserREST {
 	public VXGroup getXGroupByGroupName(@Context HttpServletRequest request,
 			@PathParam("groupName") String groupName) {
 		VXGroup vXGroup = xGroupService.getGroupByGroupName(groupName);
-		UserSessionBase userSession = ContextUtil.getCurrentUserSession();
-		if (userSession != null && userSession.getLoginId() != null && userSession.isSingleRoleUserSession()) {
-			VXUser loggedInVXUser = xUserService.getXUserByUserName(userSession.getLoginId());
-			boolean isMatch = false;
-			if (loggedInVXUser != null && vXGroup != null) {
-				List<XXGroup> userGroups = xGroupService.getGroupsByUserId(loggedInVXUser.getId());
-				for (XXGroup xXGroup: userGroups) {
-					if (xXGroup != null && StringUtils.equals(xXGroup.getName(), vXGroup.getName())) {
-						isMatch = true;
-						break;
-					}
-				}
-			}
-			if (!isMatch) {
-				vXGroup = null;
-			}
-		}
-		return vXGroup;
+		Long id = vXGroup.getId();
+		return xUserMgr.getXGroup(id);
 	}
 
 	@DELETE

--- a/security-admin/src/test/java/org/apache/ranger/rest/TestXUserREST.java
+++ b/security-admin/src/test/java/org/apache/ranger/rest/TestXUserREST.java
@@ -1027,18 +1027,15 @@ public class TestXUserREST {
 	}
 	@Test
 	public void test63getXGroupByGroupName() {
-		HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
-		
 		VXGroup compareTestVXGroup=createVXGroup();
-		
 		Mockito.when(xGroupService.getGroupByGroupName(compareTestVXGroup.getName())).thenReturn(compareTestVXGroup);
-		
-		VXGroup retVxGroup= xUserRest.getXGroupByGroupName(request,compareTestVXGroup.getName());
-		
+		Mockito.when(xUserMgr.getXGroup(compareTestVXGroup.getId())).thenReturn(compareTestVXGroup);
+		VXGroup retVxGroup = xUserRest.getXGroupByGroupName(request, compareTestVXGroup.getName());
 		assertNotNull(retVxGroup);
-		assertEquals(compareTestVXGroup.getClass(),compareTestVXGroup.getClass());
-		assertEquals(compareTestVXGroup.getId(),compareTestVXGroup.getId());
+		assertEquals(compareTestVXGroup.getId(), retVxGroup.getId());
+		assertEquals(compareTestVXGroup.getName(), retVxGroup.getName());
 		Mockito.verify(xGroupService).getGroupByGroupName(compareTestVXGroup.getName());
+		Mockito.verify(xUserMgr).getXGroup(compareTestVXGroup.getId());
 	}
 	@Test
 	public void test64deleteXUserByUserName() {


### PR DESCRIPTION
Currently, there is an inconsistency in the masking behavior of the updatedBy field in VXGroup responses across group retrieval APIs. When a group is fetched by its ID (GET /xusers/groups/{id}), the field is correctly masked to prevent metadata leakage. However, retrieving the exact same group by its name ( GET /xusers/groups/groupName/ group_name} ) bypasses this masking and exposes the actual user value (e.g., "Admin"). This inconsistency leads to an unreliable API contract and the unintended exposure of sensitive user-related metadata.

This was solved by:

Resolve the group ID using the requested group name directly within the xuserrest layer.

Route the subsequent retrieval call through the existing xUserMgr.getXGroup(id) method.

Update the following unit tests accordingly

Align the underlying logic so both endpoints share the exact same retrieval pipeline, ensuring the updatedBy field is consistently masked across all responses.
