### PR TITLE
RANGER-5623: Updated XUserMgr.java to solve UI consistency for put groupusers endpoint

### DIFF
--- a/security-admin/src/main/java/org/apache/ranger/biz/XUserMgr.java
+++ b/security-admin/src/main/java/org/apache/ranger/biz/XUserMgr.java
@@ -1016,7 +1016,32 @@ public class XUserMgr extends XUserMgrBase {
 
 	public VXGroupUser updateXGroupUser(VXGroupUser vXGroupUser) {
 		checkAdminAccess();
+
 		xaBizUtil.blockAuditorRoleUser();
+
+		if (vXGroupUser == null) {
+			throw restErrorUtil.createRESTException(HttpServletResponse.SC_BAD_REQUEST, "Groupuser not found", true);
+		}
+
+		if (vXGroupUser.getId() != null && daoManager.getXXGroupUser().getById(vXGroupUser.getId()) == null) {
+			throw restErrorUtil.createRESTException("Group-User mapping not found with ID: " + vXGroupUser.getId(),
+					MessageEnums.DATA_NOT_FOUND);
+		}
+
+		XXGroup xGroup = daoManager.getXXGroup().findByGroupName(vXGroupUser.getName());
+		if (xGroup == null) {
+			throw restErrorUtil.createRESTException("Group not found: " + vXGroupUser.getName(),
+					MessageEnums.DATA_NOT_FOUND);
+		}
+
+		XXUser xUser = daoManager.getXXUser().getById(vXGroupUser.getUserId());
+		if (xUser == null) {
+			throw restErrorUtil.createRESTException("User not found with ID: " + vXGroupUser.getUserId(),
+					MessageEnums.DATA_NOT_FOUND);
+		}
+
+		vXGroupUser.setParentGroupId(xGroup.getId());
+
 		return super.updateXGroupUser(vXGroupUser);
 	}
 

--- a/security-admin/src/test/java/org/apache/ranger/biz/TestXUserMgr.java
+++ b/security-admin/src/test/java/org/apache/ranger/biz/TestXUserMgr.java
@@ -132,6 +132,7 @@ import org.junit.Assert;
 import org.junit.FixMethodOrder;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.MethodSorters;
@@ -2345,15 +2346,48 @@ public class TestXUserMgr {
 	@Test
 	public void test55updateXGroupUser() {
 		setup();
-		VXUser vxUser = vxUser();
-		vxUser.setUserSource(RangerCommonEnums.USER_EXTERNAL);
+
 		VXGroupUser vxGroupUser = vxGroupUser();
-		Mockito.when(xGroupUserService.updateResource((VXGroupUser) Mockito.any())).thenReturn(vxGroupUser);
-		VXGroupUser dbvxUser = xUserMgr.updateXGroupUser(vxGroupUser);
-		Assert.assertNotNull(dbvxUser);
-		Assert.assertEquals(dbvxUser.getId(), vxGroupUser.getId());
-		Assert.assertEquals(dbvxUser.getName(), vxGroupUser.getName());
-		Mockito.verify(xGroupUserService).updateResource((VXGroupUser) Mockito.any());
+
+		// Mock GroupUser
+		XXGroupUserDao xxGroupUserDao = Mockito.mock(XXGroupUserDao.class);
+		XXGroupUser xxGroupUser = new XXGroupUser();
+
+		Mockito.when(daoManager.getXXGroupUser()).thenReturn(xxGroupUserDao);
+		Mockito.when(xxGroupUserDao.getById(vxGroupUser.getId())).thenReturn(xxGroupUser);
+
+		// Mock Group
+		XXGroupDao xxGroupDao = Mockito.mock(XXGroupDao.class);
+		XXGroup xxGroup = new XXGroup();
+		xxGroup.setId(1L);
+
+		Mockito.when(daoManager.getXXGroup()).thenReturn(xxGroupDao);
+		Mockito.when(xxGroupDao.findByGroupName(vxGroupUser.getName())).thenReturn(xxGroup);
+
+		// Mock User
+		XXUserDao xxUserDao = Mockito.mock(XXUserDao.class);
+		XXUser xxUser = new XXUser();
+
+		Mockito.when(daoManager.getXXUser()).thenReturn(xxUserDao);
+		Mockito.when(xxUserDao.getById(vxGroupUser.getUserId())).thenReturn(xxUser);
+
+		// Mock update
+		Mockito.when(xGroupUserService.updateResource(Mockito.any())).thenReturn(vxGroupUser);
+
+		VXGroupUser result = xUserMgr.updateXGroupUser(vxGroupUser);
+
+		Assert.assertNotNull(result);
+		Assert.assertEquals(vxGroupUser.getId(), result.getId());
+		Assert.assertEquals(vxGroupUser.getName(), result.getName());
+
+		// addition of parent group id
+		Assert.assertEquals(Long.valueOf(1L), result.getParentGroupId());
+
+		Mockito.verify(xxGroupUserDao).getById(vxGroupUser.getId());
+		Mockito.verify(xxGroupDao).findByGroupName(vxGroupUser.getName());
+		Mockito.verify(xxUserDao).getById(vxGroupUser.getUserId());
+
+		Mockito.verify(xGroupUserService).updateResource(Mockito.any());
 	}
 
 	@Test
@@ -2763,24 +2797,14 @@ public class TestXUserMgr {
 	}
 
 	@Test
-	public void test82updateXgroupUserForGroupUpdate() {
+	public void test82updateXGroupUser_nullVXGroupUser() {
 		setup();
-		XXGroupUserDao xxGroupUserDao = Mockito.mock(XXGroupUserDao.class);
-		VXGroup vXGroup = vxGroup();
-		List<XXGroupUser> xXGroupUserList = new ArrayList<XXGroupUser>();
-		VXGroupUser vxGroupUser = vxGroupUser();
-		XXGroupUser xXGroupUser =new XXGroupUser();
-		xXGroupUser.setId(vxGroupUser.getId());
-		xXGroupUser.setName(vxGroupUser.getName());
-		xXGroupUser.setParentGroupId(vxGroupUser.getParentGroupId());
-		xXGroupUser.setUserId(vxGroupUser.getUserId());
-		xXGroupUserList.add(xXGroupUser);
-		Mockito.when(daoManager.getXXGroupUser()).thenReturn(xxGroupUserDao);
-		Mockito.when(xxGroupUserDao.findByGroupId(vXGroup.getId())).thenReturn(xXGroupUserList);
-		Mockito.when(xGroupUserService.populateViewBean(xXGroupUser)).thenReturn(vxGroupUser);
-		xUserMgr.updateXgroupUserForGroupUpdate(vXGroup);
-		Mockito.verify(daoManager).getXXGroupUser();
-		Mockito.verify(xxGroupUserDao).findByGroupId(vXGroup.getId());
+
+		Mockito.when(restErrorUtil.createRESTException(HttpServletResponse.SC_BAD_REQUEST, "Groupuser not found", true)).thenThrow(new WebApplicationException());
+
+		Assert.assertThrows(WebApplicationException.class, () -> {
+			xUserMgr.updateXGroupUser(null);
+		});
 	}
 
 	@Test
@@ -4736,5 +4760,78 @@ public class TestXUserMgr {
 		Assert.assertNotNull(dbvxUser.getPassword());
 		Assert.assertEquals(dbvxUser.getUserSource(), RangerCommonEnums.USER_FEDERATED);
 		Mockito.verify(xUserService).readResourceWithOutLogin(userId);
+	}
+
+	@Test
+	public void test133updateXGroupUser_groupUserMappingNotFound() {
+		setup();
+
+		VXGroupUser vxGroupUser = vxGroupUser();
+
+		XXGroupUserDao xxGroupUserDao = Mockito.mock(XXGroupUserDao.class);
+
+		Mockito.when(daoManager.getXXGroupUser()).thenReturn(xxGroupUserDao);
+		Mockito.when(xxGroupUserDao.getById(vxGroupUser.getId())).thenReturn(null);
+
+		Mockito.when(restErrorUtil.createRESTException(Mockito.contains("Group-User mapping not found"), Mockito.eq(MessageEnums.DATA_NOT_FOUND))).thenThrow(new WebApplicationException());
+
+		Assert.assertThrows(WebApplicationException.class, () -> {
+			xUserMgr.updateXGroupUser(vxGroupUser);
+		});
+	}
+
+	@Test
+	public void test134updateXGroupUser_groupNotFound() {
+		setup();
+
+		VXGroupUser vxGroupUser = vxGroupUser();
+
+		XXGroupUserDao xxGroupUserDao = Mockito.mock(XXGroupUserDao.class);
+		XXGroupUser xxGroupUser = new XXGroupUser();
+
+		Mockito.when(daoManager.getXXGroupUser()).thenReturn(xxGroupUserDao);
+		Mockito.when(xxGroupUserDao.getById(vxGroupUser.getId())).thenReturn(xxGroupUser);
+
+		XXGroupDao xxGroupDao = Mockito.mock(XXGroupDao.class);
+
+		Mockito.when(daoManager.getXXGroup()).thenReturn(xxGroupDao);
+		Mockito.when(xxGroupDao.findByGroupName(vxGroupUser.getName())).thenReturn(null);
+
+		Mockito.when(restErrorUtil.createRESTException(Mockito.contains("Group not found"), Mockito.eq(MessageEnums.DATA_NOT_FOUND))).thenThrow(new WebApplicationException());
+
+		Assert.assertThrows(WebApplicationException.class, () -> {
+			xUserMgr.updateXGroupUser(vxGroupUser);
+		});
+	}
+
+	@Test
+	public void test135updateXGroupUser_userNotFound() {
+		setup();
+
+		VXGroupUser vxGroupUser = vxGroupUser();
+
+		XXGroupUserDao xxGroupUserDao = Mockito.mock(XXGroupUserDao.class);
+		XXGroupUser xxGroupUser = new XXGroupUser();
+
+		Mockito.when(daoManager.getXXGroupUser()).thenReturn(xxGroupUserDao);
+		Mockito.when(xxGroupUserDao.getById(vxGroupUser.getId())).thenReturn(xxGroupUser);
+
+		XXGroupDao xxGroupDao = Mockito.mock(XXGroupDao.class);
+		XXGroup xxGroup = new XXGroup();
+		xxGroup.setId(1L);
+
+		Mockito.when(daoManager.getXXGroup()).thenReturn(xxGroupDao);
+		Mockito.when(xxGroupDao.findByGroupName(vxGroupUser.getName())).thenReturn(xxGroup);
+
+		XXUserDao xxUserDao = Mockito.mock(XXUserDao.class);
+
+		Mockito.when(daoManager.getXXUser()).thenReturn(xxUserDao);
+		Mockito.when(xxUserDao.getById(vxGroupUser.getUserId())).thenReturn(null);
+
+		Mockito.when(restErrorUtil.createRESTException(Mockito.contains("User not found"), Mockito.eq(MessageEnums.DATA_NOT_FOUND))).thenThrow(new WebApplicationException());
+
+		Assertions.assertThrows(WebApplicationException.class, () -> {
+			xUserMgr.updateXGroupUser(vxGroupUser);
+		});
 	}
 }


### PR DESCRIPTION
When updating a user-group relationship using the PUT /service/xusers/groupusers API, the backend updates successfully and the UI "Users" tab looks fine. However, the "Groups" tab shows old data—it still lists the user under their old group and doesn't show them in the new one. This happens because the "Groups" view isn't getting the right group reference to trigger a proper refresh.

Solved it by:
Declared XXGroupuser and added validation checks for all mandatory fields to make sure the data is clean.

Explicitly added parentGroupId to vxGroupuser so the UI has the correct group context to update both tabs properly.

Verified that updating a user-group mapping now correctly updates both the "Users" and "Groups" tabs in the UI without leaving any stale data.