### PR TITLE
RANGER-5679: Document OpenSearch audit setup in docker README and per…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,7 @@ jobs:
           export RANGER_DB_TYPE=postgres
           docker compose \
           -f docker-compose.ranger.yml \
+          -f docker-compose.ranger-solr.yml \
           -f docker-compose.ranger-pdp.yml \
           -f docker-compose.ranger-usersync.yml \
           -f docker-compose.ranger-tagsync.yml \
@@ -126,6 +127,7 @@ jobs:
           export RANGER_DB_TYPE=postgres
           docker compose \
           -f docker-compose.ranger.yml \
+          -f docker-compose.ranger-solr.yml \
           -f docker-compose.ranger-pdp.yml \
           -f docker-compose.ranger-usersync.yml \
           -f docker-compose.ranger-tagsync.yml \
@@ -176,7 +178,7 @@ jobs:
       - name: Run download-archives.sh
         run: |
           cd dev-support/ranger-docker
-          ./download-archives.sh hadoop hive hbase kafka knox ozone
+          ./download-archives.sh hadoop hive hbase kafka knox ozone opensearch
 
   plugins-docker-build:
     needs:
@@ -214,7 +216,7 @@ jobs:
       - name: Verify plugin archives (download any cache misses)
         run: |
           cd dev-support/ranger-docker
-          ./download-archives.sh hadoop hive hbase kafka knox ozone
+          ./download-archives.sh hadoop hive hbase kafka knox ozone opensearch
 
       - name: Build all ranger-plugin images
         run: |
@@ -222,6 +224,7 @@ jobs:
           export RANGER_DB_TYPE=postgres
           docker compose \
           -f docker-compose.ranger.yml \
+          -f docker-compose.ranger-opensearch.yml \
           -f docker-compose.ranger-hadoop.yml \
           -f docker-compose.ranger-hbase.yml \
           -f docker-compose.ranger-kafka.yml \
@@ -236,6 +239,7 @@ jobs:
           export RANGER_DB_TYPE=postgres
           docker compose \
           -f docker-compose.ranger.yml \
+          -f docker-compose.ranger-opensearch.yml \
           -f docker-compose.ranger-hadoop.yml \
           -f docker-compose.ranger-hbase.yml \
           -f docker-compose.ranger-kafka.yml \
@@ -246,7 +250,7 @@ jobs:
       - name: Check status of containers and remove them
         run: |
           sleep 60
-          containers=(ranger ranger-zk ranger-solr ranger-postgres ranger-hadoop ranger-hbase ranger-kafka ranger-hive ranger-knox ozone-om ozone-scm ozone-datanode);
+          containers=(ranger ranger-zk ranger-opensearch ranger-postgres ranger-hadoop ranger-hbase ranger-kafka ranger-hive ranger-knox ozone-om ozone-scm ozone-datanode);
           flag=true;
           for container in "${containers[@]}"; do
               if [[ $(docker inspect -f '{{.State.Running}}' $container 2>/dev/null) == "true" ]]; then

--- a/dev-support/ranger-docker/README.md
+++ b/dev-support/ranger-docker/README.md
@@ -81,7 +81,7 @@ cd dev-support/ranger-docker
 
 # valid values for RANGER_DB_TYPE: mysql/postgres/oracle
 
-docker compose -f docker-compose.ranger.yml -f docker-compose.ranger-usersync.yml -f docker-compose.ranger-tagsync.yml -f docker-compose.ranger-pdp.yml -f docker-compose.ranger-kms.yml up -d
+docker compose -f docker-compose.ranger.yml -f docker-compose.ranger-solr.yml -f docker-compose.ranger-usersync.yml -f docker-compose.ranger-tagsync.yml -f docker-compose.ranger-pdp.yml -f docker-compose.ranger-kms.yml up -d
 
 # Ranger Admin can be accessed at http://localhost:6080 (admin/rangerR0cks!)
 ~~~
@@ -121,7 +121,7 @@ docker compose -f docker-compose.ranger-build.yml up
    `scripts/admin/ranger-admin-install-<db>.properties` and recreate Admin so
    setup runs again:
    ~~~
-   docker compose -f docker-compose.ranger.yml -f docker-compose.ranger-ozone.yml \
+   docker compose -f docker-compose.ranger.yml -f docker-compose.ranger-solr.yml -f docker-compose.ranger-ozone.yml \
      up -d --build --force-recreate ranger
    ~~~
    Works even if the DB already exists; setup re-runs on a fresh container.
@@ -135,7 +135,7 @@ service-def.
 
 ~~~
 ./scripts/ozone/ozone-plugin-docker-setup.sh
-docker compose -f docker-compose.ranger.yml -f docker-compose.ranger-ozone.yml up -d
+docker compose -f docker-compose.ranger.yml -f docker-compose.ranger-solr.yml -f docker-compose.ranger-ozone.yml up -d
 ~~~
 
 Verify (after login):
@@ -147,6 +147,10 @@ curl -s -u admin:rangerR0cks! http://localhost:6080/service/plugins/definitions/
 #### Bring up trino container (requires docker build with jdk 11):
 ~~~
 docker compose -f docker-compose.ranger.yml -f docker-compose.ranger-trino.yml up -d
+~~~
+#### Bring up solr container:
+~~~
+docker compose -f docker-compose.ranger.yml -f docker-compose.ranger-solr.yml up -d
 ~~~
 #### Bring up opensearch container:
 ~~~
@@ -165,10 +169,13 @@ used by the Solr audit path.
 
 ##### Setup
 
+With the default `RANGER_DB_TYPE=postgres`, OpenSearch auditing is preconfigured and runs
+out of the box — the commands below need no `install.properties` changes.
+
 ~~~
-# Prerequisites: build the audit-dispatcher tarball and download archives
+# Prerequisites: build Ranger artifacts (admin, audit ingestor/dispatcher, ...) and download archives
 mvn clean package -DskipTests -pl distro -am
-cp target/ranger-*-audit-dispatcher.tar.gz dev-support/ranger-docker/dist/
+cp target/ranger-* dev-support/ranger-docker/dist/
 cd dev-support/ranger-docker
 ./download-archives.sh kafka opensearch hadoop
 
@@ -177,7 +184,7 @@ export RANGER_DB_TYPE=postgres
 # 1. Start OpenSearch first (Ranger Admin's bootstrapper needs it on startup)
 docker compose -f docker-compose.ranger.yml -f docker-compose.ranger-opensearch.yml \
   -f docker-compose.ranger-kafka.yml -f docker-compose.ranger-hadoop.yml \
-  -f docker-compose.ranger-audit-server.yml \
+  -f docker-compose.ranger-audit-ingestor.yml \
   -f docker-compose.ranger-audit-dispatcher-opensearch.yml up -d ranger-opensearch
 
 # 2. Start core stack (Ranger Admin, Kafka, Hadoop)
@@ -185,37 +192,38 @@ docker compose -f docker-compose.ranger.yml -f docker-compose.ranger-opensearch.
 #    Ranger Admin auto-creates the OpenSearch index via OpenSearchIndexBootStrapper.
 docker compose -f docker-compose.ranger.yml -f docker-compose.ranger-opensearch.yml \
   -f docker-compose.ranger-kafka.yml -f docker-compose.ranger-hadoop.yml \
-  -f docker-compose.ranger-audit-server.yml \
+  -f docker-compose.ranger-audit-ingestor.yml \
   -f docker-compose.ranger-audit-dispatcher-opensearch.yml up -d ranger ranger-kafka ranger-hadoop
 
 # 3. Start audit ingestor and OpenSearch dispatcher
 docker compose -f docker-compose.ranger.yml -f docker-compose.ranger-opensearch.yml \
   -f docker-compose.ranger-kafka.yml -f docker-compose.ranger-hadoop.yml \
-  -f docker-compose.ranger-audit-server.yml \
+  -f docker-compose.ranger-audit-ingestor.yml \
   -f docker-compose.ranger-audit-dispatcher-opensearch.yml up -d ranger-audit-ingestor ranger-audit-dispatcher-opensearch
 ~~~
 
-For **fresh Ranger installs** using OpenSearch for audits, set `audit_store=opensearch` in
-`scripts/admin/ranger-admin-install-postgres.properties` and configure the `audit_opensearch_*` properties.
+To use OpenSearch with **mysql or oracle** instead, enable the OpenSearch block in the matching
+`scripts/admin/ranger-admin-install-${RANGER_DB_TYPE}.properties` (uncomment the `audit_store=opensearch`
+and `audit_opensearch_*` lines and comment out the Solr block) before running the setup commands.
 
-For **existing Solr-based installs**, switching stores requires updating `audit_store=opensearch`
-in install.properties, configuring the `audit_opensearch_*` properties, and restarting Ranger Admin.
+For **existing Solr-based installs**, switch stores by setting `audit_store=opensearch` (and the
+`audit_opensearch_*` properties) in install.properties and restarting Ranger Admin.
 Similarly, check the `depends` section of the `docker-compose.ranger-service.yaml` file and add docker-compose files for these services when trying to bring up the `service` container.
 
 #### Bring up all containers
 ~~~
 ./scripts/ozone/ozone-plugin-docker-setup.sh
-docker compose -f docker-compose.ranger.yml -f docker-compose.ranger-usersync.yml -f docker-compose.ranger-tagsync.yml -f docker-compose.ranger-pdp.yml -f docker-compose.ranger-kms.yml -f docker-compose.ranger-hadoop.yml -f docker-compose.ranger-hbase.yml -f docker-compose.ranger-kafka.yml -f docker-compose.ranger-hive.yml -f docker-compose.ranger-knox.yml -f docker-compose.ranger-ozone.yml up -d
+docker compose -f docker-compose.ranger.yml -f docker-compose.ranger-solr.yml -f docker-compose.ranger-usersync.yml -f docker-compose.ranger-tagsync.yml -f docker-compose.ranger-pdp.yml -f docker-compose.ranger-kms.yml -f docker-compose.ranger-hadoop.yml -f docker-compose.ranger-hbase.yml -f docker-compose.ranger-kafka.yml -f docker-compose.ranger-hive.yml -f docker-compose.ranger-knox.yml -f docker-compose.ranger-ozone.yml up -d
 ~~~
           
 #### To rebuild specific images and start containers with the new image:
 ~~~
-docker compose -f docker-compose.ranger.yml -f docker-compose.ranger-usersync.yml -f docker-compose.ranger-tagsync.yml -f docker-compose.ranger-kms.yml -f docker-compose.ranger-hadoop.yml -f docker-compose.ranger-hbase.yml -f docker-compose.ranger-kafka.yml -f docker-compose.ranger-hive.yml -f docker-compose.ranger-trino.yml -f docker-compose.ranger-knox.yml up -d --no-deps --force-recreate --build <service-1> <service-2>
+docker compose -f docker-compose.ranger.yml -f docker-compose.ranger-solr.yml -f docker-compose.ranger-usersync.yml -f docker-compose.ranger-tagsync.yml -f docker-compose.ranger-kms.yml -f docker-compose.ranger-hadoop.yml -f docker-compose.ranger-hbase.yml -f docker-compose.ranger-kafka.yml -f docker-compose.ranger-hive.yml -f docker-compose.ranger-trino.yml -f docker-compose.ranger-knox.yml up -d --no-deps --force-recreate --build <service-1> <service-2>
 ~~~
 
 #### To bring up audit server ingestor + dispatchers. Make sure kafka, solr, and hdfs containers are running before bringing up audit server services.
 ~~~
-docker compose -f docker-compose.ranger.yml -f docker-compose.ranger-hadoop.yml -f docker-compose.ranger-kafka.yml -f docker-compose.ranger-audit-server.yml up -d
+docker compose -f docker-compose.ranger.yml -f docker-compose.ranger-solr.yml -f docker-compose.ranger-hadoop.yml -f docker-compose.ranger-kafka.yml -f docker-compose.ranger-audit-server.yml up -d
 ~~~
 
 #### To bring up audit server services individually:
@@ -223,8 +231,11 @@ docker compose -f docker-compose.ranger.yml -f docker-compose.ranger-hadoop.yml 
 # Audit ingestor
 docker compose -f docker-compose.ranger.yml -f docker-compose.ranger-kafka.yml -f docker-compose.ranger-audit-ingestor.yml up -d
 
-# Solr dispatcher
-docker compose -f docker-compose.ranger.yml -f docker-compose.ranger-kafka.yml -f docker-compose.ranger-audit-dispatcher-solr.yml up -d
+# Solr dispatcher (requires the ranger-solr container; see "Bring up solr container" above)
+docker compose -f docker-compose.ranger.yml -f docker-compose.ranger-solr.yml -f docker-compose.ranger-kafka.yml -f docker-compose.ranger-audit-dispatcher-solr.yml up -d
+
+# OpenSearch dispatcher (requires the ranger-opensearch container; see "OpenSearch audit flow" above)
+docker compose -f docker-compose.ranger.yml -f docker-compose.ranger-opensearch.yml -f docker-compose.ranger-kafka.yml -f docker-compose.ranger-audit-dispatcher-opensearch.yml up -d
 
 # HDFS dispatcher
 docker compose -f docker-compose.ranger.yml -f docker-compose.ranger-hadoop.yml -f docker-compose.ranger-kafka.yml -f docker-compose.ranger-audit-dispatcher-hdfs.yml up -d

--- a/dev-support/ranger-docker/docker-compose.ranger-ozone.yml
+++ b/dev-support/ranger-docker/docker-compose.ranger-ozone.yml
@@ -50,8 +50,6 @@ services:
         condition: service_started
       ranger:
         condition: service_started
-      ranger-solr:
-        condition: service_started
     environment:
       OZONE_OPTS: -XX:-UseContainerSupport -Dcom.sun.net.ssl.checkRevocation=false
       OZONE_HOME: /opt/hadoop

--- a/dev-support/ranger-docker/docker-compose.ranger-pdp.yml
+++ b/dev-support/ranger-docker/docker-compose.ranger-pdp.yml
@@ -48,8 +48,6 @@ services:
     depends_on:
       ranger:
         condition: service_started
-      ranger-solr:
-        condition: service_started
     environment:
       - PDP_VERSION
       - KERBEROS_ENABLED

--- a/dev-support/ranger-docker/docker-compose.ranger-solr.yml
+++ b/dev-support/ranger-docker/docker-compose.ranger-solr.yml
@@ -1,0 +1,66 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+services:
+  ranger-solr:
+    build:
+      context: .
+      dockerfile: Dockerfile.ranger-solr
+      args:
+        - RANGER_BASE_IMAGE=${RANGER_BASE_IMAGE}
+        - RANGER_BASE_VERSION=${RANGER_BASE_VERSION}
+        - SOLR_VERSION=${SOLR_VERSION}
+        - SOLR_PLUGIN_VERSION=${SOLR_PLUGIN_VERSION}
+        - KERBEROS_ENABLED=${KERBEROS_ENABLED}
+    image: ranger-solr
+    container_name: ranger-solr
+    hostname: ranger-solr.rangernw
+    volumes:
+      - ./dist/keytabs/ranger-solr:/etc/keytabs
+      - ./scripts/solr/solr-ranger_audits:/opt/solr/server/solr/configsets/ranger_audits/conf
+      # Core conf is copied once by solr-precreate; mount so Solr 9 cache updates apply without recreating the core
+      - ./scripts/solr/solr-ranger_audits:/var/solr/data/ranger_audits/conf
+      - ./scripts/solr/ranger_audits/core.properties:/var/solr/data/ranger_audits/core.properties
+      - ./scripts/solr/ranger-solr-plugin-install.properties:/opt/ranger/ranger-solr-plugin/install.properties
+      # Keep enable templates in sync with repo (image tarball may be stale)
+      - ../../plugin-solr/conf/ranger-solr-security-changes.cfg:/opt/ranger/ranger-solr-plugin/install/conf.templates/enable/ranger-solr-security-changes.cfg:ro
+      - ./scripts/solr/core-site.xml:/opt/solr/server/resources/core-site.xml
+      - ./scripts/solr/solr-jaas.conf:/var/solr/data/jaas.conf
+      - ./scripts/solr/solr-security.json:/var/solr/data/security.json
+      - ./scripts/solr/ranger-solr.sh:/opt/ranger/ranger-solr.sh
+      - ./scripts/kdc/krb5.conf:/etc/krb5.conf
+    networks:
+      - ranger
+    ports:
+      - "8983:8983"
+    depends_on:
+      ranger-kdc:
+        condition: service_started
+      ranger-zk:
+        condition: service_started
+    environment:
+      - KERBEROS_ENABLED
+      - KRB5_CONFIG=/etc/krb5.conf
+      # Solr 9 enables Java SecurityManager by default; Ranger keytab login and policy cache need broader access
+      - SOLR_SECURITY_MANAGER_ENABLED=false
+    command:
+      - solr-precreate
+      - ranger_audits
+      - /opt/solr/server/solr/configsets/ranger_audits/
+
+networks:
+  ranger:
+    name: rangernw

--- a/dev-support/ranger-docker/docker-compose.ranger.yml
+++ b/dev-support/ranger-docker/docker-compose.ranger.yml
@@ -31,8 +31,6 @@ services:
         condition: service_started
       ranger-db:
         condition: service_healthy
-      ranger-solr:
-        condition: service_started
     environment:
       - RANGER_VERSION
       - RANGER_DB_TYPE
@@ -96,52 +94,6 @@ services:
       - "2181:2181"
     environment:
       - KERBEROS_ENABLED
-
-  ranger-solr:
-    build:
-      context: .
-      dockerfile: Dockerfile.ranger-solr
-      args:
-        - RANGER_BASE_IMAGE=${RANGER_BASE_IMAGE}
-        - RANGER_BASE_VERSION=${RANGER_BASE_VERSION}
-        - SOLR_VERSION=${SOLR_VERSION}
-        - SOLR_PLUGIN_VERSION=${SOLR_PLUGIN_VERSION}
-        - KERBEROS_ENABLED=${KERBEROS_ENABLED}
-    image: ranger-solr
-    container_name: ranger-solr
-    hostname: ranger-solr.rangernw
-    volumes:
-      - ./dist/keytabs/ranger-solr:/etc/keytabs
-      - ./scripts/solr/solr-ranger_audits:/opt/solr/server/solr/configsets/ranger_audits/conf
-      # Core conf is copied once by solr-precreate; mount so Solr 9 cache updates apply without recreating the core
-      - ./scripts/solr/solr-ranger_audits:/var/solr/data/ranger_audits/conf
-      - ./scripts/solr/ranger_audits/core.properties:/var/solr/data/ranger_audits/core.properties
-      - ./scripts/solr/ranger-solr-plugin-install.properties:/opt/ranger/ranger-solr-plugin/install.properties
-      # Keep enable templates in sync with repo (image tarball may be stale)
-      - ../../plugin-solr/conf/ranger-solr-security-changes.cfg:/opt/ranger/ranger-solr-plugin/install/conf.templates/enable/ranger-solr-security-changes.cfg:ro
-      - ./scripts/solr/core-site.xml:/opt/solr/server/resources/core-site.xml
-      - ./scripts/solr/solr-jaas.conf:/var/solr/data/jaas.conf
-      - ./scripts/solr/solr-security.json:/var/solr/data/security.json
-      - ./scripts/solr/ranger-solr.sh:/opt/ranger/ranger-solr.sh
-      - ./scripts/kdc/krb5.conf:/etc/krb5.conf
-    networks:
-      - ranger
-    ports:
-      - "8983:8983"
-    depends_on:
-      ranger-kdc:
-        condition: service_started
-      ranger-zk:
-        condition: service_started
-    environment:
-      - KERBEROS_ENABLED
-      - KRB5_CONFIG=/etc/krb5.conf
-      # Solr 9 enables Java SecurityManager by default; Ranger keytab login and policy cache need broader access
-      - SOLR_SECURITY_MANAGER_ENABLED=false
-    command:
-      - solr-precreate
-      - ranger_audits
-      - /opt/solr/server/solr/configsets/ranger_audits/
 
 networks:
   ranger:

--- a/dev-support/ranger-docker/scripts/admin/ranger-admin-install-mysql.properties
+++ b/dev-support/ranger-docker/scripts/admin/ranger-admin-install-mysql.properties
@@ -56,6 +56,15 @@ audit_elasticsearch_password=elasticsearch
 audit_elasticsearch_index=ranger_audits
 audit_elasticsearch_bootstrap_enabled=true
 
+# audit_store=opensearch
+# audit_opensearch_urls=ranger-opensearch
+# audit_opensearch_port=9200
+# audit_opensearch_protocol=http
+# audit_opensearch_user=admin
+# audit_opensearch_password=admin
+# audit_opensearch_index=ranger_audits
+# audit_opensearch_bootstrap_enabled=true
+
 policymgr_external_url=http://ranger-admin:6080
 policymgr_http_enabled=true
 

--- a/dev-support/ranger-docker/scripts/admin/ranger-admin-install-oracle.properties
+++ b/dev-support/ranger-docker/scripts/admin/ranger-admin-install-oracle.properties
@@ -58,6 +58,15 @@ audit_elasticsearch_password=elasticsearch
 audit_elasticsearch_index=ranger_audits
 audit_elasticsearch_bootstrap_enabled=true
 
+# audit_store=opensearch
+# audit_opensearch_urls=ranger-opensearch
+# audit_opensearch_port=9200
+# audit_opensearch_protocol=http
+# audit_opensearch_user=admin
+# audit_opensearch_password=admin
+# audit_opensearch_index=ranger_audits
+# audit_opensearch_bootstrap_enabled=true
+
 policymgr_external_url=http://ranger-admin:6080
 policymgr_http_enabled=true
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
RANGER-5679: Document the OpenSearch audit setup in the `dev-support/ranger-docker` README and decouple Solr from the core compose stack.

Docker-compose and docs only; no runtime/product code changes.

### How was this patch tested?
Manual test from a fresh clone using `dev-support/ranger-docker`, and `docker compose ... config` validation of every documented flow (core stack, hive, hbase, ozone, trino, solr, opensearch, OpenSearch audit flow, all-containers, rebuild, audit-server stack, and each individual dispatcher) — all resolve cleanly, and the OpenSearch flow no longer references an undefined `ranger-solr` service.

~~~
mvn clean package -DskipTests -pl distro -am
cp target/ranger-* dev-support/ranger-docker/dist/
export RANGER_DB_TYPE=postgres
./download-archives.sh kafka opensearch hadoop
# OpenSearch audit compose stack (see README)
~~~

Verified:
- OpenSearch `ranger_audits/_count` → 3 documents
- Ranger Admin `GET /service/assets/accessAudit?pageSize=10` → same 3 audits from OpenSearch

Note: Kafka topic authz can race on first startup; restarting `ranger-audit-dispatcher-opensearch` after ~1 min may be needed (existing docker stack behavior).