### PR TITLE
RANGER-5666: update graalvm version to 25.1.3 - part 2

### DIFF
--- a/distro/src/main/assembly/kms.xml
+++ b/distro/src/main/assembly/kms.xml
@@ -345,6 +345,21 @@
                             <include>joda-time:joda-time</include>
                             <include>com.carrotsearch:hppc</include>
                             <include>io.airlift:aircompressor:jar:${aircompressor.version}</include>
+                            <!-- GraalJS 25.x runtime (js is now a POM, not a JAR) -->
+                            <include>org.graalvm.js:js-language:jar:${graalvm.version}</include>
+                            <include>org.graalvm.js:js-scriptengine:jar:${graalvm.version}</include>
+                            <include>org.graalvm.polyglot:polyglot:jar:${graalvm.version}</include>
+                            <include>org.graalvm.regex:regex:jar:${graalvm.version}</include>
+                            <include>org.graalvm.truffle:truffle-api:jar:${graalvm.version}</include>
+                            <include>org.graalvm.truffle:truffle-runtime:jar:${graalvm.version}</include>
+                            <include>org.graalvm.truffle:truffle-compiler:jar:${graalvm.version}</include>
+                            <include>org.graalvm.sdk:jniutils:jar:${graalvm.version}</include>
+                            <include>org.graalvm.sdk:collections:jar:${graalvm.version}</include>
+                            <include>org.graalvm.sdk:nativeimage:jar:${graalvm.version}</include>
+                            <include>org.graalvm.sdk:word:jar:${graalvm.version}</include>
+                            <include>org.graalvm.shadowed:icu4j:jar:${graalvm.version}</include>
+                            <include>org.graalvm.shadowed:xz:jar:${graalvm.version}</include>
+
                         </includes>
                     </dependencySet>
                     <dependencySet>

--- a/distro/src/main/assembly/knox-agent.xml
+++ b/distro/src/main/assembly/knox-agent.xml
@@ -99,6 +99,21 @@
           <include>org.glassfish.jersey.ext:jersey-entity-filtering:jar:${jersey-client.version}</include>
           <include>org.glassfish.jersey.inject:jersey-hk2</include>
           <include>org.glassfish.jersey.media:jersey-media-json-jackson:jar:${jersey-client.version}</include>
+          <!-- GraalJS 25.x runtime (js is now a POM, not a JAR) -->
+          <include>org.graalvm.js:js-language:jar:${graalvm.version}</include>
+          <include>org.graalvm.js:js-scriptengine:jar:${graalvm.version}</include>
+          <include>org.graalvm.polyglot:polyglot:jar:${graalvm.version}</include>
+          <include>org.graalvm.regex:regex:jar:${graalvm.version}</include>
+          <include>org.graalvm.truffle:truffle-api:jar:${graalvm.version}</include>
+          <include>org.graalvm.truffle:truffle-runtime:jar:${graalvm.version}</include>
+          <include>org.graalvm.truffle:truffle-compiler:jar:${graalvm.version}</include>
+          <include>org.graalvm.sdk:jniutils:jar:${graalvm.version}</include>
+          <include>org.graalvm.sdk:collections:jar:${graalvm.version}</include>
+          <include>org.graalvm.sdk:nativeimage:jar:${graalvm.version}</include>
+          <include>org.graalvm.sdk:word:jar:${graalvm.version}</include>
+          <include>org.graalvm.shadowed:icu4j:jar:${graalvm.version}</include>
+          <include>org.graalvm.shadowed:xz:jar:${graalvm.version}</include>
+
         </includes>
       </binaries>
     </moduleSet>

--- a/distro/src/main/assembly/pdp.xml
+++ b/distro/src/main/assembly/pdp.xml
@@ -129,6 +129,21 @@
                     <include>org.slf4j:slf4j-api:jar:${slf4j.version}</include>
                     <include>ch.qos.logback:logback-classic:jar:${logback.version}</include>
                     <include>ch.qos.logback:logback-core:jar:${logback.version}</include>
+                    <!-- GraalJS 25.x runtime (js is now a POM, not a JAR) -->
+                    <include>org.graalvm.js:js-language:jar:${graalvm.version}</include>
+                    <include>org.graalvm.js:js-scriptengine:jar:${graalvm.version}</include>
+                    <include>org.graalvm.polyglot:polyglot:jar:${graalvm.version}</include>
+                    <include>org.graalvm.regex:regex:jar:${graalvm.version}</include>
+                    <include>org.graalvm.truffle:truffle-api:jar:${graalvm.version}</include>
+                    <include>org.graalvm.truffle:truffle-runtime:jar:${graalvm.version}</include>
+                    <include>org.graalvm.truffle:truffle-compiler:jar:${graalvm.version}</include>
+                    <include>org.graalvm.sdk:jniutils:jar:${graalvm.version}</include>
+                    <include>org.graalvm.sdk:collections:jar:${graalvm.version}</include>
+                    <include>org.graalvm.sdk:nativeimage:jar:${graalvm.version}</include>
+                    <include>org.graalvm.sdk:word:jar:${graalvm.version}</include>
+                    <include>org.graalvm.shadowed:icu4j:jar:${graalvm.version}</include>
+                    <include>org.graalvm.shadowed:xz:jar:${graalvm.version}</include>
+
                 </includes>
                 <excludes>
                     <!-- avoid jersey-bundle because it conflicts with Jersey-2 -->

--- a/distro/src/main/assembly/plugin-atlas.xml
+++ b/distro/src/main/assembly/plugin-atlas.xml
@@ -75,6 +75,21 @@
           <include>org.apache.httpcomponents:httpmime:jar:${httpcomponents.httpmime.version}</include>
           <include>org.apache.solr:solr-solrj:jar:${solr.version}</include>
           <include>org.codehaus.woodstox:stax2-api:jar:${codehaus.woodstox.stax2api.version}</include>
+          <!-- GraalJS 25.x runtime (js is now a POM, not a JAR) -->
+          <include>org.graalvm.js:js-language:jar:${graalvm.version}</include>
+          <include>org.graalvm.js:js-scriptengine:jar:${graalvm.version}</include>
+          <include>org.graalvm.polyglot:polyglot:jar:${graalvm.version}</include>
+          <include>org.graalvm.regex:regex:jar:${graalvm.version}</include>
+          <include>org.graalvm.truffle:truffle-api:jar:${graalvm.version}</include>
+          <include>org.graalvm.truffle:truffle-runtime:jar:${graalvm.version}</include>
+          <include>org.graalvm.truffle:truffle-compiler:jar:${graalvm.version}</include>
+          <include>org.graalvm.sdk:jniutils:jar:${graalvm.version}</include>
+          <include>org.graalvm.sdk:collections:jar:${graalvm.version}</include>
+          <include>org.graalvm.sdk:nativeimage:jar:${graalvm.version}</include>
+          <include>org.graalvm.sdk:word:jar:${graalvm.version}</include>
+          <include>org.graalvm.shadowed:icu4j:jar:${graalvm.version}</include>
+          <include>org.graalvm.shadowed:xz:jar:${graalvm.version}</include>
+
         </includes>
       </binaries>
     </moduleSet>

--- a/distro/src/main/assembly/plugin-elasticsearch.xml
+++ b/distro/src/main/assembly/plugin-elasticsearch.xml
@@ -100,6 +100,21 @@
           <include>org.elasticsearch:elasticsearch-x-content</include>
           <include>org.elasticsearch:elasticsearch</include>
           <include>org.noggit:noggit:jar:${noggit.version}</include>
+          <!-- GraalJS 25.x runtime (js is now a POM, not a JAR) -->
+          <include>org.graalvm.js:js-language:jar:${graalvm.version}</include>
+          <include>org.graalvm.js:js-scriptengine:jar:${graalvm.version}</include>
+          <include>org.graalvm.polyglot:polyglot:jar:${graalvm.version}</include>
+          <include>org.graalvm.regex:regex:jar:${graalvm.version}</include>
+          <include>org.graalvm.truffle:truffle-api:jar:${graalvm.version}</include>
+          <include>org.graalvm.truffle:truffle-runtime:jar:${graalvm.version}</include>
+          <include>org.graalvm.truffle:truffle-compiler:jar:${graalvm.version}</include>
+          <include>org.graalvm.sdk:jniutils:jar:${graalvm.version}</include>
+          <include>org.graalvm.sdk:collections:jar:${graalvm.version}</include>
+          <include>org.graalvm.sdk:nativeimage:jar:${graalvm.version}</include>
+          <include>org.graalvm.sdk:word:jar:${graalvm.version}</include>
+          <include>org.graalvm.shadowed:icu4j:jar:${graalvm.version}</include>
+          <include>org.graalvm.shadowed:xz:jar:${graalvm.version}</include>
+
         </includes>
       </binaries>
     </moduleSet>

--- a/distro/src/main/assembly/plugin-kafka.xml
+++ b/distro/src/main/assembly/plugin-kafka.xml
@@ -78,6 +78,21 @@
 					<include>org.apache.solr:solr-solrj:jar:${solr.version}</include>
 					<include>org.codehaus.woodstox:stax2-api</include>
 					<include>org.eclipse.jetty:jetty-client:jar:${jetty-client.version}</include>
+					<!-- GraalJS 25.x runtime (js is now a POM, not a JAR) -->
+					<include>org.graalvm.js:js-language:jar:${graalvm.version}</include>
+					<include>org.graalvm.js:js-scriptengine:jar:${graalvm.version}</include>
+					<include>org.graalvm.polyglot:polyglot:jar:${graalvm.version}</include>
+					<include>org.graalvm.regex:regex:jar:${graalvm.version}</include>
+					<include>org.graalvm.truffle:truffle-api:jar:${graalvm.version}</include>
+					<include>org.graalvm.truffle:truffle-runtime:jar:${graalvm.version}</include>
+					<include>org.graalvm.truffle:truffle-compiler:jar:${graalvm.version}</include>
+					<include>org.graalvm.sdk:jniutils:jar:${graalvm.version}</include>
+					<include>org.graalvm.sdk:collections:jar:${graalvm.version}</include>
+					<include>org.graalvm.sdk:nativeimage:jar:${graalvm.version}</include>
+					<include>org.graalvm.sdk:word:jar:${graalvm.version}</include>
+					<include>org.graalvm.shadowed:icu4j:jar:${graalvm.version}</include>
+					<include>org.graalvm.shadowed:xz:jar:${graalvm.version}</include>
+
 				</includes>
                 <excludes>
 					<exclude>com.fasterxml.jackson.core:*</exclude>

--- a/distro/src/main/assembly/plugin-kms.xml
+++ b/distro/src/main/assembly/plugin-kms.xml
@@ -89,6 +89,21 @@
           <include>org.glassfish.jersey.inject:jersey-hk2</include>
           <include>org.glassfish.jersey.media:jersey-media-json-jackson</include>
           <include>org.noggit:noggit:jar:${noggit.version}</include>
+          <!-- GraalJS 25.x runtime (js is now a POM, not a JAR) -->
+          <include>org.graalvm.js:js-language:jar:${graalvm.version}</include>
+          <include>org.graalvm.js:js-scriptengine:jar:${graalvm.version}</include>
+          <include>org.graalvm.polyglot:polyglot:jar:${graalvm.version}</include>
+          <include>org.graalvm.regex:regex:jar:${graalvm.version}</include>
+          <include>org.graalvm.truffle:truffle-api:jar:${graalvm.version}</include>
+          <include>org.graalvm.truffle:truffle-runtime:jar:${graalvm.version}</include>
+          <include>org.graalvm.truffle:truffle-compiler:jar:${graalvm.version}</include>
+          <include>org.graalvm.sdk:jniutils:jar:${graalvm.version}</include>
+          <include>org.graalvm.sdk:collections:jar:${graalvm.version}</include>
+          <include>org.graalvm.sdk:nativeimage:jar:${graalvm.version}</include>
+          <include>org.graalvm.sdk:word:jar:${graalvm.version}</include>
+          <include>org.graalvm.shadowed:icu4j:jar:${graalvm.version}</include>
+          <include>org.graalvm.shadowed:xz:jar:${graalvm.version}</include>
+
         </includes>
       </binaries>
     </moduleSet>

--- a/distro/src/main/assembly/plugin-kylin.xml
+++ b/distro/src/main/assembly/plugin-kylin.xml
@@ -86,6 +86,21 @@
               <include>org.glassfish.jersey.core:jersey-common</include>
               <include>org.glassfish.jersey.ext:jersey-entity-filtering</include>
               <include>org.glassfish.jersey.inject:jersey-hk2</include>
+              <!-- GraalJS 25.x runtime (js is now a POM, not a JAR) -->
+              <include>org.graalvm.js:js-language:jar:${graalvm.version}</include>
+              <include>org.graalvm.js:js-scriptengine:jar:${graalvm.version}</include>
+              <include>org.graalvm.polyglot:polyglot:jar:${graalvm.version}</include>
+              <include>org.graalvm.regex:regex:jar:${graalvm.version}</include>
+              <include>org.graalvm.truffle:truffle-api:jar:${graalvm.version}</include>
+              <include>org.graalvm.truffle:truffle-runtime:jar:${graalvm.version}</include>
+              <include>org.graalvm.truffle:truffle-compiler:jar:${graalvm.version}</include>
+              <include>org.graalvm.sdk:jniutils:jar:${graalvm.version}</include>
+              <include>org.graalvm.sdk:collections:jar:${graalvm.version}</include>
+              <include>org.graalvm.sdk:nativeimage:jar:${graalvm.version}</include>
+              <include>org.graalvm.sdk:word:jar:${graalvm.version}</include>
+              <include>org.graalvm.shadowed:icu4j:jar:${graalvm.version}</include>
+              <include>org.graalvm.shadowed:xz:jar:${graalvm.version}</include>
+
             </includes>
           </dependencySet>
           <dependencySet>

--- a/distro/src/main/assembly/plugin-ozone.xml
+++ b/distro/src/main/assembly/plugin-ozone.xml
@@ -125,6 +125,21 @@
                     <include>org.glassfish.jersey.inject:jersey-hk2</include>
                     <include>org.glassfish.jersey.media:jersey-media-json-jackson:jar:${jersey-client.version}</include>
                     <include>com.fasterxml.jackson.module:jackson-module-jaxb-annotations:jar:${fasterxml.jackson.version}</include>
+                    <!-- GraalJS 25.x runtime (js is now a POM, not a JAR) -->
+                    <include>org.graalvm.js:js-language:jar:${graalvm.version}</include>
+                    <include>org.graalvm.js:js-scriptengine:jar:${graalvm.version}</include>
+                    <include>org.graalvm.polyglot:polyglot:jar:${graalvm.version}</include>
+                    <include>org.graalvm.regex:regex:jar:${graalvm.version}</include>
+                    <include>org.graalvm.truffle:truffle-api:jar:${graalvm.version}</include>
+                    <include>org.graalvm.truffle:truffle-runtime:jar:${graalvm.version}</include>
+                    <include>org.graalvm.truffle:truffle-compiler:jar:${graalvm.version}</include>
+                    <include>org.graalvm.sdk:jniutils:jar:${graalvm.version}</include>
+                    <include>org.graalvm.sdk:collections:jar:${graalvm.version}</include>
+                    <include>org.graalvm.sdk:nativeimage:jar:${graalvm.version}</include>
+                    <include>org.graalvm.sdk:word:jar:${graalvm.version}</include>
+                    <include>org.graalvm.shadowed:icu4j:jar:${graalvm.version}</include>
+                    <include>org.graalvm.shadowed:xz:jar:${graalvm.version}</include>
+
                 </includes>
             </binaries>
         </moduleSet>

--- a/distro/src/main/assembly/plugin-presto.xml
+++ b/distro/src/main/assembly/plugin-presto.xml
@@ -96,6 +96,21 @@
                     <include>org.apache.solr:solr-solrj:jar:${solr.version}</include>
                     <include>org.apache.zookeeper:zookeeper:jar:${zookeeper.version}</include>
                     <include>org.eclipse.jetty:jetty-client:jar:${jetty-client.version}</include>
+                    <!-- GraalJS 25.x runtime (js is now a POM, not a JAR) -->
+                    <include>org.graalvm.js:js-language:jar:${graalvm.version}</include>
+                    <include>org.graalvm.js:js-scriptengine:jar:${graalvm.version}</include>
+                    <include>org.graalvm.polyglot:polyglot:jar:${graalvm.version}</include>
+                    <include>org.graalvm.regex:regex:jar:${graalvm.version}</include>
+                    <include>org.graalvm.truffle:truffle-api:jar:${graalvm.version}</include>
+                    <include>org.graalvm.truffle:truffle-runtime:jar:${graalvm.version}</include>
+                    <include>org.graalvm.truffle:truffle-compiler:jar:${graalvm.version}</include>
+                    <include>org.graalvm.sdk:jniutils:jar:${graalvm.version}</include>
+                    <include>org.graalvm.sdk:collections:jar:${graalvm.version}</include>
+                    <include>org.graalvm.sdk:nativeimage:jar:${graalvm.version}</include>
+                    <include>org.graalvm.sdk:word:jar:${graalvm.version}</include>
+                    <include>org.graalvm.shadowed:icu4j:jar:${graalvm.version}</include>
+                    <include>org.graalvm.shadowed:xz:jar:${graalvm.version}</include>
+
                 </includes>
             </binaries>
         </moduleSet>

--- a/distro/src/main/assembly/plugin-sqoop.xml
+++ b/distro/src/main/assembly/plugin-sqoop.xml
@@ -82,6 +82,21 @@
           <include>org.glassfish.jersey.core:jersey-common</include>
           <include>org.glassfish.jersey.ext:jersey-entity-filtering</include>
           <include>org.glassfish.jersey.inject:jersey-hk2</include>
+          <!-- GraalJS 25.x runtime (js is now a POM, not a JAR) -->
+          <include>org.graalvm.js:js-language:jar:${graalvm.version}</include>
+          <include>org.graalvm.js:js-scriptengine:jar:${graalvm.version}</include>
+          <include>org.graalvm.polyglot:polyglot:jar:${graalvm.version}</include>
+          <include>org.graalvm.regex:regex:jar:${graalvm.version}</include>
+          <include>org.graalvm.truffle:truffle-api:jar:${graalvm.version}</include>
+          <include>org.graalvm.truffle:truffle-runtime:jar:${graalvm.version}</include>
+          <include>org.graalvm.truffle:truffle-compiler:jar:${graalvm.version}</include>
+          <include>org.graalvm.sdk:jniutils:jar:${graalvm.version}</include>
+          <include>org.graalvm.sdk:collections:jar:${graalvm.version}</include>
+          <include>org.graalvm.sdk:nativeimage:jar:${graalvm.version}</include>
+          <include>org.graalvm.sdk:word:jar:${graalvm.version}</include>
+          <include>org.graalvm.shadowed:icu4j:jar:${graalvm.version}</include>
+          <include>org.graalvm.shadowed:xz:jar:${graalvm.version}</include>
+
         </includes>
       </binaries>
     </moduleSet>

--- a/distro/src/main/assembly/plugin-trino.xml
+++ b/distro/src/main/assembly/plugin-trino.xml
@@ -98,6 +98,21 @@
                     <include>org.slf4j:jcl-over-slf4j:jar:${slf4j.version}</include>
                     <include>org.slf4j:slf4j-api:jar:${slf4j-api.version}</include>
                     <include>org.slf4j:slf4j-api:jar:${slf4j-api.version}</include>
+                    <!-- GraalJS 25.x runtime (js is now a POM, not a JAR) -->
+                    <include>org.graalvm.js:js-language:jar:${graalvm.version}</include>
+                    <include>org.graalvm.js:js-scriptengine:jar:${graalvm.version}</include>
+                    <include>org.graalvm.polyglot:polyglot:jar:${graalvm.version}</include>
+                    <include>org.graalvm.regex:regex:jar:${graalvm.version}</include>
+                    <include>org.graalvm.truffle:truffle-api:jar:${graalvm.version}</include>
+                    <include>org.graalvm.truffle:truffle-runtime:jar:${graalvm.version}</include>
+                    <include>org.graalvm.truffle:truffle-compiler:jar:${graalvm.version}</include>
+                    <include>org.graalvm.sdk:jniutils:jar:${graalvm.version}</include>
+                    <include>org.graalvm.sdk:collections:jar:${graalvm.version}</include>
+                    <include>org.graalvm.sdk:nativeimage:jar:${graalvm.version}</include>
+                    <include>org.graalvm.sdk:word:jar:${graalvm.version}</include>
+                    <include>org.graalvm.shadowed:icu4j:jar:${graalvm.version}</include>
+                    <include>org.graalvm.shadowed:xz:jar:${graalvm.version}</include>
+
                 </includes>
             </binaries>
         </moduleSet>

--- a/distro/src/main/assembly/storm-agent.xml
+++ b/distro/src/main/assembly/storm-agent.xml
@@ -101,6 +101,21 @@
               <include>org.glassfish.jersey.core:jersey-common</include>
               <include>org.glassfish.jersey.ext:jersey-entity-filtering</include>
               <include>org.glassfish.jersey.inject:jersey-hk2</include>
+              <!-- GraalJS 25.x runtime (js is now a POM, not a JAR) -->
+              <include>org.graalvm.js:js-language:jar:${graalvm.version}</include>
+              <include>org.graalvm.js:js-scriptengine:jar:${graalvm.version}</include>
+              <include>org.graalvm.polyglot:polyglot:jar:${graalvm.version}</include>
+              <include>org.graalvm.regex:regex:jar:${graalvm.version}</include>
+              <include>org.graalvm.truffle:truffle-api:jar:${graalvm.version}</include>
+              <include>org.graalvm.truffle:truffle-runtime:jar:${graalvm.version}</include>
+              <include>org.graalvm.truffle:truffle-compiler:jar:${graalvm.version}</include>
+              <include>org.graalvm.sdk:jniutils:jar:${graalvm.version}</include>
+              <include>org.graalvm.sdk:collections:jar:${graalvm.version}</include>
+              <include>org.graalvm.sdk:nativeimage:jar:${graalvm.version}</include>
+              <include>org.graalvm.sdk:word:jar:${graalvm.version}</include>
+              <include>org.graalvm.shadowed:icu4j:jar:${graalvm.version}</include>
+              <include>org.graalvm.shadowed:xz:jar:${graalvm.version}</include>
+
             </includes>
           </dependencySet>
           <dependencySet>


### PR DESCRIPTION
## Summary

Backfill the GraalJS **25.1.3** runtime JAR whitelist into **13** remaining plugin/server assembly descriptors so JavaScript policy conditions work on **JDK 17+**.

**Part 1** ([PR #1052](https://github.com/apache/ranger/pull/1052)) updated hdfs, hive, hbase, yarn, and solr. **This PR** covers:

| Assembly | Whitelist output |
|----------|------------------|
| `knox-agent.xml` | `lib/ranger-knox-plugin-impl` |
| `storm-agent.xml` | `lib/ranger-storm-plugin-impl` |
| `plugin-kafka.xml` | `lib/ranger-kafka-plugin-impl` |
| `plugin-atlas.xml` | `lib/ranger-atlas-plugin-impl` |
| `plugin-elasticsearch.xml` | `lib/ranger-elasticsearch-plugin/ranger-elasticsearch-plugin-impl` |
| `plugin-kylin.xml` | `lib/ranger-kylin-plugin-impl` |
| `plugin-ozone.xml` | `lib/libext/ranger-ozone-plugin-impl` |
| `plugin-presto.xml` | `lib/ranger-presto-plugin-impl` |
| `plugin-sqoop.xml` | `lib/ranger-sqoop-plugin-impl` |
| `plugin-kms.xml` | `lib/ranger-kms-plugin-impl` |
| `plugin-trino.xml` | `lib` |
| `kms.xml` | `ews/webapp/WEB-INF/lib/ranger-kms-plugin-impl` |
| `pdp.xml` | `lib` |

## Why

- **RANGER-3970** added GraalJS to `agents-common` for JavaScript policy condition evaluation when Nashorn is unavailable (JDK 15+).
- **RANGER-4076 / PR #872** bumped `graalvm.version` and added GraalVM JAR includes to hdfs, hive, hbase, and yarn.
- **RANGER-5603 / PR #981** added the same block to `plugin-solr.xml`.
- **RANGER-5666 / PR #1052** refreshed the 13-jar block for GraalVM **25.1.3** (`js-language`, etc.) in those five assemblies.

`agents-common/pom.xml` declares GraalJS dependencies, but most plugin tarballs are built with Maven Assembly **explicit JAR whitelists** (`includeDependencies=true` + `<includes>`). Transitive deps from `ranger-plugins-common` are **not** bundled unless listed.

Any plugin extending `RangerBasePlugin` that evaluates JS policy conditions on JDK 17+ needs GraalJS on the classpath at runtime. Reference: `distro/src/main/assembly/hdfs-agent.xml`.

### GraalVM block added (per assembly)

```xml
<!-- GraalJS 25.x runtime (js is now a POM, not a JAR) -->
<include>org.graalvm.js:js-language:jar:${graalvm.version}</include>
<include>org.graalvm.js:js-scriptengine:jar:${graalvm.version}</include>
<include>org.graalvm.polyglot:polyglot:jar:${graalvm.version}</include>
<include>org.graalvm.regex:regex:jar:${graalvm.version}</include>
<include>org.graalvm.truffle:truffle-api:jar:${graalvm.version}</include>
<include>org.graalvm.truffle:truffle-runtime:jar:${graalvm.version}</include>
<include>org.graalvm.truffle:truffle-compiler:jar:${graalvm.version}</include>
<include>org.graalvm.sdk:jniutils:jar:${graalvm.version}</include>
<include>org.graalvm.sdk:collections:jar:${graalvm.version}</include>
<include>org.graalvm.sdk:nativeimage:jar:${graalvm.version}</include>
<include>org.graalvm.sdk:word:jar:${graalvm.version}</include>
<include>org.graalvm.shadowed:icu4j:jar:${graalvm.version}</include>
<include>org.graalvm.shadowed:xz:jar:${graalvm.version}</include>
```
## Test plan

- [x] `mvn -pl agents-common test -Dtest=RangerRequestScriptEvaluatorTest`
- [x] `mvn -f distro/pom.xml package -Pranger-kafka-plugin -DskipTests` (assembly BUILD SUCCESS)
- [ ] CI `build-17` full reactor verify
- [ ] Confirm Graal JARs in a built plugin tarball, e.g. `tar tzf target/ranger-*-kafka-plugin.tar.gz | grep graalvm`
