### PR TITLE
RANGER-5668:INSERT INTO External Hive Table Fails for Table/Database Owner When Access Is Granted Through Ranger {OWNER} Policy

### DIFF
--- a/hive-agent/src/main/java/org/apache/ranger/authorization/hive/authorizer/RangerHiveAuthorizer.java
+++ b/hive-agent/src/main/java/org/apache/ranger/authorization/hive/authorizer/RangerHiveAuthorizer.java
@@ -200,6 +200,7 @@ public class RangerHiveAuthorizer extends RangerHiveAuthorizerBase {
 
                 case TABLE_OR_VIEW:
                 case COLUMN:
+                case PARTITION:
                     try {
                         objName = hiveObj.getDbname() + "." + hiveObj.getObjectName();
                         if (StringUtils.isBlank(owner) && objOwners != null) {
@@ -1681,6 +1682,7 @@ public class RangerHiveAuthorizer extends RangerHiveAuthorizerBase {
             case PARTITION:
             case INDEX:
                 ret = new RangerHiveResource(objectType, hiveObj.getDbname(), hiveObj.getObjectName());
+                setOwnerUser(ret, hiveObj, getMetaStoreClient(), objOwners);
                 break;
 
             case COLUMN:


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch fixes an issue where INSERT operations on newly created external Hive tables fail for the table/database owner even when a Ranger Hive policy grants permissions through the {OWNER} policy.

The issue occurred because owner-based authorization was not being correctly honored immediately after creating a new external table. As a result, the table owner received a HiveAccessControlException indicating that the UPDATE privilege was missing until the Ranger policy was manually refreshed.

This change ensures that owner information is correctly evaluated during authorization so that {OWNER}-based policies are applied immediately after table creation, eliminating the need for a manual Ranger policy refresh.


## How was this patch tested?

The project was built successfully using mvn clean compile package install
