### PR TITLE
RANGER-5678: Concurrent policy-engine rebuild on shared serviceDef ca…

### DIFF
--- a/security-admin/src/main/java/org/apache/ranger/biz/RangerPolicyAdminCache.java
+++ b/security-admin/src/main/java/org/apache/ranger/biz/RangerPolicyAdminCache.java
@@ -193,11 +193,13 @@ public class RangerPolicyAdminCache {
     }
 
     private RangerPolicyAdmin addPolicyAdmin(ServicePolicies policies, RangerRoles roles, RangerPolicyEngineOptions options) {
-        RangerServiceDef    serviceDef          = policies.getServiceDef();
-        String              serviceType         = (serviceDef != null) ? serviceDef.getName() : "";
-        RangerPluginContext rangerPluginContext = new RangerPluginContext(new RangerPluginConfig(serviceType, null, "ranger-admin", null, null, options));
+        synchronized (policies) {
+            RangerServiceDef    serviceDef          = policies.getServiceDef();
+            String              serviceType         = (serviceDef != null) ? serviceDef.getName() : "";
+            RangerPluginContext rangerPluginContext = new RangerPluginContext(new RangerPluginConfig(serviceType, null, "ranger-admin", null, null, options));
 
-        return new RangerPolicyAdminImpl(policies, rangerPluginContext, roles);
+            return new RangerPolicyAdminImpl(policies, rangerPluginContext, roles);
+        }
     }
 
     static class RangerPolicyAdminWrapper {


### PR DESCRIPTION
…uses CME/NPE for delegated-admin User

## What changes were proposed in this pull request?

Fixes concurrent policy-engine rebuilds mutating the shared cached RangerServiceDef during ServiceDefUtil.normalize(), which caused CME/NPE and getPolicyAdmin failures.

Changes: Added ServiceDefUtil.copyServiceDef() (JSON deep copy) and updated RangerPolicyRepository to normalize a private copy of serviceDef instead of the cache object. Added a unit test to ensure the source is not mutated.


## How was this patch tested?

Local build passed, Unit tests added and tested.
