### PR TITLE
RANGER-5688: maven-source-plugin.version property is referenced but never defined

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,6 +174,7 @@
         <maven-plugin-sortpom.version>3.0.1</maven-plugin-sortpom.version>
         <maven-resources-plugin.version>3.2.0</maven-resources-plugin.version>
         <maven-shade-plugin.version>3.4.1</maven-shade-plugin.version>
+        <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
         <maven-war-plugin.version>3.4.0</maven-war-plugin.version>
         <maven.exec.plugin.version>1.6.0</maven.exec.plugin.version>
         <maven.pmd.plugin.version>3.15.0</maven.pmd.plugin.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?
<!--
(Please fill in changes proposed in this fix. Create an issue in ASF JIRA before opening a pull request and
set the title of the pull request which starts with
the corresponding JIRA issue number. (e.g. RANGER-XXXX: Fix a typo in YYY))
-->

RANGER-4076 replaced the hardcoded maven-source-plugin version in the root pom's pluginManagement with a property reference, but the property was never defined:

```xml
<plugin>
<groupId>org.apache.maven.plugins</groupId>
<artifactId>maven-source-plugin</artifactId>
<version>${maven-source-plugin.version}</version>
```

git grep '<maven-source-plugin.version>' returns nothing.

Since pluginManagement entries are only resolved when the plugin is actually invoked, normal builds are unaffected. But any invocation of the plugin by prefix, e.g.:

```
mvn install source:jar -DskipTests -Denunciate.disable.sourcepath=true
```

fails at startup, because the undefined property survives as a literal and Maven tries to resolve version ${maven-source-plugin.version} from central:

```
[ERROR] Plugin org.apache.maven.plugins:maven-source-plugin:${maven-source-plugin.version} or one of its dependencies could not be resolved
```

Fix: define the property alongside the other plugin versions in the root pom, e.g. <maven-source-plugin.version>3.3.1</maven-source-plugin.version>.


## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)
