### PR TITLE
RANGER-5691: Incorrect response seen when admin tries to create a key

### DIFF
--- a/kms/src/main/java/org/apache/hadoop/crypto/key/kms/server/KMSMDCFilter.java
+++ b/kms/src/main/java/org/apache/hadoop/crypto/key/kms/server/KMSMDCFilter.java
@@ -78,7 +78,10 @@ public class KMSMDCFilter implements Filter {
             HttpServletRequest  req  = (HttpServletRequest) request;
             HttpServletResponse resp = (HttpServletResponse) response;
 
+            logger.debug("==> KMSMDCFilter:doFilter() path = {}", path);
+
             if (path.startsWith(RANGER_KMS_REST_API_PATH)) {
+                logger.debug("==> KMSMDCFilter: calling chain.doFilter() for path = {}", path);
                 chain.doFilter(request, resp);
             } else {
                 DATA_TL.remove();

--- a/security-admin/src/main/java/org/apache/ranger/biz/KmsKeyMgr.java
+++ b/security-admin/src/main/java/org/apache/ranger/biz/KmsKeyMgr.java
@@ -114,6 +114,7 @@ public class KmsKeyMgr {
             providers = getKMSURL(repoName);
         } catch (Exception e) {
             logger.error("getKey({}) failed", repoName, e);
+            throw restErrorUtil.createRESTException("Provider '" + repoName + "' not found or invalid: " + e.getMessage(), MessageEnums.DATA_NOT_FOUND);
         }
 
         List<VXKmsKey> vXKeys       = new ArrayList<>();
@@ -242,6 +243,7 @@ public class KmsKeyMgr {
             providers = getKMSURL(provider);
         } catch (Exception e) {
             logger.error("rolloverKey({}, {}) failed", provider, vXKey.getName(), e);
+            throw restErrorUtil.createRESTException("Provider '" + provider + "' not found or invalid: " + e.getMessage(), MessageEnums.DATA_NOT_FOUND);
         }
 
         VXKmsKey ret        = null;
@@ -310,6 +312,7 @@ public class KmsKeyMgr {
             providers = getKMSURL(provider);
         } catch (Exception e) {
             logger.error("deleteKey({}, {}) failed", provider, name, e);
+            throw restErrorUtil.createRESTException("Provider '" + provider + "' not found or invalid: " + e.getMessage(), MessageEnums.DATA_NOT_FOUND);
         }
 
         boolean isKerberos = false;
@@ -371,6 +374,7 @@ public class KmsKeyMgr {
             providers = getKMSURL(provider);
         } catch (Exception e) {
             logger.error("createKey({}, {}) failed", provider, vXKey.getName(), e);
+            throw restErrorUtil.createRESTException("Provider '" + provider + "' not found or invalid: " + e.getMessage(), MessageEnums.DATA_NOT_FOUND);
         }
 
         VXKmsKey ret        = null;
@@ -439,6 +443,7 @@ public class KmsKeyMgr {
             providers = getKMSURL(provider);
         } catch (Exception e) {
             logger.error("getKey({}, {}) failed", provider, name, e);
+            throw restErrorUtil.createRESTException("Provider '" + provider + "' not found or invalid: " + e.getMessage(), MessageEnums.DATA_NOT_FOUND);
         }
 
         boolean isKerberos = false;

--- a/security-admin/src/main/java/org/apache/ranger/rest/XKeyREST.java
+++ b/security-admin/src/main/java/org/apache/ranger/rest/XKeyREST.java
@@ -225,6 +225,13 @@ public class XKeyREST {
     private void handleError(Exception e) {
         String message = e.getMessage();
 
+        if (e instanceof WebApplicationException) {
+            WebApplicationException wae = (WebApplicationException) e;
+            if (wae.getResponse() != null && wae.getResponse().hasEntity()) {
+                throw wae;
+            }
+        }
+
         if (e instanceof ClientErrorException || e instanceof ServerErrorException || e instanceof WebApplicationException) {
             logger.error(e.getMessage());
 

--- a/security-admin/src/test/java/org/apache/ranger/biz/TestKmsKeyMgr.java
+++ b/security-admin/src/test/java/org/apache/ranger/biz/TestKmsKeyMgr.java
@@ -272,7 +272,7 @@ public class TestKmsKeyMgr {
     }
 
     @Test
-    public void testSearchKeys_ExceptionHandling() throws Exception {
+    public void testSearchKeys_ProviderNotFound() throws Exception {
         try (MockedStatic<ContextUtil> contextUtilMock = Mockito.mockStatic(ContextUtil.class);
                 MockedStatic<StringUtil> stringUtilMock = Mockito.mockStatic(StringUtil.class);
                 MockedStatic<PropertiesUtil> propertiesUtilMock = Mockito.mockStatic(PropertiesUtil.class)) {
@@ -282,11 +282,15 @@ public class TestKmsKeyMgr {
 
             Mockito.when(svcStore.getServiceByName(TEST_REPO_NAME)).thenThrow(new RuntimeException("Service not found"));
 
-            VXKmsKeyList result = kmsKeyMgr.searchKeys(request, TEST_REPO_NAME);
+            Exception mockException = new RuntimeException("Provider 'testKmsRepo' not found or invalid: Service not found");
+            Mockito.when(restErrorUtil.createRESTException(
+                    Mockito.contains("Provider 'testKmsRepo' not found or invalid"),
+                    Mockito.eq(MessageEnums.DATA_NOT_FOUND)
+            )).thenThrow(mockException);
 
-            Assertions.assertNotNull(result);
-            Assertions.assertNotNull(result.getVXKeys());
-            Assertions.assertTrue(result.getVXKeys().isEmpty());
+            Assertions.assertThrows(Exception.class, () -> {
+                kmsKeyMgr.searchKeys(request, TEST_REPO_NAME);
+            });
         }
     }
 
@@ -549,23 +553,6 @@ public class TestKmsKeyMgr {
                     kmsKeyMgr.getKey(TEST_REPO_NAME, TEST_KEY_NAME);
                 });
             }
-        }
-    }
-
-    @Test
-    public void testGetKey_ReturnsNull() throws Exception {
-        try (MockedStatic<ContextUtil> contextUtilMock = Mockito.mockStatic(ContextUtil.class);
-                MockedStatic<StringUtil> stringUtilMock = Mockito.mockStatic(StringUtil.class);
-                MockedStatic<PropertiesUtil> propertiesUtilMock = Mockito.mockStatic(PropertiesUtil.class)) {
-            contextUtilMock.when(ContextUtil::getCurrentUserLoginId).thenReturn(TEST_USERNAME);
-            stringUtilMock.when(() -> StringUtil.getUTFEncodedString(TEST_USERNAME)).thenReturn(TEST_USERNAME);
-            propertiesUtilMock.when(() -> PropertiesUtil.getProperty("hadoop.security.authentication", "simple")).thenReturn("simple");
-
-            Mockito.when(svcStore.getServiceByName(TEST_REPO_NAME)).thenThrow(new RuntimeException("Service not found"));
-
-            VXKmsKey result = kmsKeyMgr.getKey(TEST_REPO_NAME, TEST_KEY_NAME);
-
-            Assertions.assertNull(result);
         }
     }
 
@@ -1013,15 +1000,6 @@ public class TestKmsKeyMgr {
     }
 
     @Test
-    public void testSearchKeys_NullRequest() throws Exception {
-        VXKmsKeyList result = kmsKeyMgr.searchKeys(null, TEST_REPO_NAME);
-
-        Assertions.assertNotNull(result);
-        Assertions.assertNotNull(result.getVXKeys());
-        Assertions.assertTrue(result.getVXKeys().isEmpty());
-    }
-
-    @Test
     public void testSearchKeys_EmptyKeyList() throws Exception {
         RangerService rangerService = createMockRangerService();
         String jsonResponse = "[]";  // Empty array
@@ -1071,7 +1049,7 @@ public class TestKmsKeyMgr {
     }
 
     @Test
-    public void testRolloverKey_NullProviders() throws Exception {
+    public void testRolloverKey_ProviderNotFound() throws Exception {
         VXKmsKey inputKey = createMockVXKmsKey();
 
         try (MockedStatic<ContextUtil> contextUtilMock = Mockito.mockStatic(ContextUtil.class);
@@ -1081,17 +1059,24 @@ public class TestKmsKeyMgr {
             stringUtilMock.when(() -> StringUtil.getUTFEncodedString(TEST_USERNAME)).thenReturn(TEST_USERNAME);
             propertiesUtilMock.when(() -> PropertiesUtil.getProperty("hadoop.security.authentication", "simple")).thenReturn("simple");
 
-            Mockito.when(svcStore.getServiceByName(TEST_REPO_NAME)).thenReturn(null);
+            Mockito.when(svcStore.getServiceByName(TEST_REPO_NAME)).thenThrow(new RuntimeException("Service not found"));
 
-            VXKmsKey result = kmsKeyMgr.rolloverKey(TEST_REPO_NAME, inputKey);
+            Exception mockException = new RuntimeException("Provider 'testKmsRepo' not found or invalid: Service not found");
+            Mockito.when(restErrorUtil.createRESTException(
+                    Mockito.contains("Provider 'testKmsRepo' not found or invalid"),
+                    Mockito.eq(MessageEnums.DATA_NOT_FOUND)
+            )).thenThrow(mockException);
 
-            Assertions.assertNull(result);
+            Assertions.assertThrows(Exception.class, () -> {
+                kmsKeyMgr.rolloverKey(TEST_REPO_NAME, inputKey);
+            });
+
             Mockito.verify(rangerBizUtil).blockAuditorRoleUser();
         }
     }
 
     @Test
-    public void testCreateKey_NullProviders() throws Exception {
+    public void testCreateKey_ProviderNotFound() throws Exception {
         VXKmsKey inputKey = createMockVXKmsKey();
 
         try (MockedStatic<ContextUtil> contextUtilMock = Mockito.mockStatic(ContextUtil.class);
@@ -1101,17 +1086,24 @@ public class TestKmsKeyMgr {
             stringUtilMock.when(() -> StringUtil.getUTFEncodedString(TEST_USERNAME)).thenReturn(TEST_USERNAME);
             propertiesUtilMock.when(() -> PropertiesUtil.getProperty("hadoop.security.authentication", "simple")).thenReturn("simple");
 
-            Mockito.when(svcStore.getServiceByName(TEST_REPO_NAME)).thenReturn(null);
+            Mockito.when(svcStore.getServiceByName(TEST_REPO_NAME)).thenThrow(new RuntimeException("Service not found"));
 
-            VXKmsKey result = kmsKeyMgr.createKey(TEST_REPO_NAME, inputKey);
+            Exception mockException = new RuntimeException("Provider 'testKmsRepo' not found or invalid: Service not found");
+            Mockito.when(restErrorUtil.createRESTException(
+                    Mockito.contains("Provider 'testKmsRepo' not found or invalid"),
+                    Mockito.eq(MessageEnums.DATA_NOT_FOUND)
+            )).thenThrow(mockException);
 
-            Assertions.assertNull(result);
+            Assertions.assertThrows(Exception.class, () -> {
+                kmsKeyMgr.createKey(TEST_REPO_NAME, inputKey);
+            });
+
             Mockito.verify(rangerBizUtil).blockAuditorRoleUser();
         }
     }
 
     @Test
-    public void testDeleteKey_NullProviders() throws Exception {
+    public void testDeleteKey_ProviderNotFound() throws Exception {
         try (MockedStatic<ContextUtil> contextUtilMock = Mockito.mockStatic(ContextUtil.class);
                 MockedStatic<StringUtil> stringUtilMock = Mockito.mockStatic(StringUtil.class);
                 MockedStatic<PropertiesUtil> propertiesUtilMock = Mockito.mockStatic(PropertiesUtil.class)) {
@@ -1119,9 +1111,15 @@ public class TestKmsKeyMgr {
             stringUtilMock.when(() -> StringUtil.getUTFEncodedString(TEST_USERNAME)).thenReturn(TEST_USERNAME);
             propertiesUtilMock.when(() -> PropertiesUtil.getProperty("hadoop.security.authentication", "simple")).thenReturn("simple");
 
-            Mockito.when(svcStore.getServiceByName(TEST_REPO_NAME)).thenReturn(null);
+            Mockito.when(svcStore.getServiceByName(TEST_REPO_NAME)).thenThrow(new RuntimeException("Service not found"));
 
-            Assertions.assertDoesNotThrow(() -> {
+            Exception mockException = new RuntimeException("Provider 'testKmsRepo' not found or invalid: Service not found");
+            Mockito.when(restErrorUtil.createRESTException(
+                    Mockito.contains("Provider 'testKmsRepo' not found or invalid"),
+                    Mockito.eq(MessageEnums.DATA_NOT_FOUND)
+            )).thenThrow(mockException);
+
+            Assertions.assertThrows(Exception.class, () -> {
                 kmsKeyMgr.deleteKey(TEST_REPO_NAME, TEST_KEY_NAME);
             });
 
@@ -1130,7 +1128,7 @@ public class TestKmsKeyMgr {
     }
 
     @Test
-    public void testGetKey_NullProviders() throws Exception {
+    public void testGetKey_ProviderNotFound() throws Exception {
         try (MockedStatic<ContextUtil> contextUtilMock = Mockito.mockStatic(ContextUtil.class);
                 MockedStatic<StringUtil> stringUtilMock = Mockito.mockStatic(StringUtil.class);
                 MockedStatic<PropertiesUtil> propertiesUtilMock = Mockito.mockStatic(PropertiesUtil.class)) {
@@ -1138,11 +1136,17 @@ public class TestKmsKeyMgr {
             stringUtilMock.when(() -> StringUtil.getUTFEncodedString(TEST_USERNAME)).thenReturn(TEST_USERNAME);
             propertiesUtilMock.when(() -> PropertiesUtil.getProperty("hadoop.security.authentication", "simple")).thenReturn("simple");
 
-            Mockito.when(svcStore.getServiceByName(TEST_REPO_NAME)).thenReturn(null);
+            Mockito.when(svcStore.getServiceByName(TEST_REPO_NAME)).thenThrow(new RuntimeException("Service not found"));
 
-            VXKmsKey result = kmsKeyMgr.getKey(TEST_REPO_NAME, TEST_KEY_NAME);
+            Exception mockException = new RuntimeException("Provider 'testKmsRepo' not found or invalid: Service not found");
+            Mockito.when(restErrorUtil.createRESTException(
+                    Mockito.contains("Provider 'testKmsRepo' not found or invalid"),
+                    Mockito.eq(MessageEnums.DATA_NOT_FOUND)
+            )).thenThrow(mockException);
 
-            Assertions.assertNull(result);
+            Assertions.assertThrows(Exception.class, () -> {
+                kmsKeyMgr.getKey(TEST_REPO_NAME, TEST_KEY_NAME);
+            });
         }
     }
 


### PR DESCRIPTION
Incorrect response seen when admin tries to create a key even though he doesn't have permission

curl -ik -u admin:Admin123 --header Accept:application/json -H Content-Type:application/json -K POST '[https://<host>:6182/service/keys/key?provider=kmsdev](https://ccycloud-1.ch-102949.root.comops.site:6182/service/keys/key?provider=kmsdev)' -d '{"name":"testkey1","cipher":"AES/CTR/NoPadding","length":"128","attributes":{}}'

HTTP/1.1 200
Set-Cookie; Path=/; Secure; HttpOnly
X-Frame-Options: DENY
...
...
...

{"length":256,"versions":0}
Here the kmsdev provider is not there but still we get response as 200 this issue is seen in get and other api's as well

Fix: Fix is made to ensure that exception doesn't get swallowed and propagates to caller in KmsKeyMgr
and gives 400 Bad request when invalid provider is given

Also part of this PR added fix for RANGER-5692 : i.e added missing debug logs in KMSMDCFilter dofilter method.