### PR TITLE
RANGER-5690: UnixAuth service lacks rate limiting on authentication a…

### DIFF
--- a/unixauthservice/conf.dist/ranger-ugsync-default.xml
+++ b/unixauthservice/conf.dist/ranger-ugsync-default.xml
@@ -30,6 +30,26 @@
 		<value>TLSv1.2</value>
 	</property>
 	<property>
+		<name>ranger.usersync.unixauth.max.failed.attempts</name>
+		<value>5</value>
+	</property>
+	<property>
+		<name>ranger.usersync.unixauth.attempt.window.ms</name>
+		<value>60000</value>
+	</property>
+	<property>
+		<name>ranger.usersync.unixauth.lockout.duration.ms</name>
+		<value>30000</value>
+	</property>
+	<property>
+		<name>ranger.usersync.unixauth.require.client.auth</name>
+		<value>false</value>
+	</property>
+	<property>
+		<name>ranger.usersync.unixauth.socket.timeout.ms</name>
+		<value>10000</value>
+	</property>
+	<property>
 		<name>ranger.usersync.passwordvalidator.path</name>
 		<value>./native/credValidator.uexe</value>
 	</property>

--- a/unixauthservice/src/main/java/org/apache/ranger/authentication/LoginAttemptTracker.java
+++ b/unixauthservice/src/main/java/org/apache/ranger/authentication/LoginAttemptTracker.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.authentication;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class LoginAttemptTracker {
+    private static final long CLEANUP_INTERVAL_MS = TimeUnit.MINUTES.toMillis(5);
+    private final ConcurrentHashMap<String, Record> attemptsByIp = new ConcurrentHashMap<>();
+
+    private final int maxFailures;
+    private final long windowMs;
+    private final long lockoutMs;
+    private volatile long lastCleanupTime;
+
+    public LoginAttemptTracker(int maxFailures, long windowMs, long lockoutMs) {
+        this.maxFailures = maxFailures;
+        this.windowMs = windowMs;
+        this.lockoutMs = lockoutMs;
+        this.lastCleanupTime = System.currentTimeMillis();
+    }
+
+    public boolean isBlocked(String sourceIp) {
+        Record record = attemptsByIp.get(sourceIp);
+        if (record == null) {
+            return false;
+        }
+        return record.lockedUntil > System.currentTimeMillis();
+    }
+
+    public void recordFailure(String sourceIp) {
+        maybeCleanup();
+        long now = System.currentTimeMillis();
+        Record record = attemptsByIp.computeIfAbsent(sourceIp, k -> new Record(now));
+        synchronized (record) {
+            if (now - record.windowStart > windowMs) {
+                record.windowStart = now;
+                record.failCount.set(0);
+            }
+            record.lastActivity = now;
+            int count = record.failCount.incrementAndGet();
+            if (count >= maxFailures) {
+                record.lockedUntil = now + lockoutMs;
+            }
+        }
+    }
+
+    public void recordSuccess(String sourceIp) {
+        attemptsByIp.remove(sourceIp);
+    }
+
+    private void maybeCleanup() {
+        long now = System.currentTimeMillis();
+        if (now - lastCleanupTime < CLEANUP_INTERVAL_MS) {
+            return;
+        }
+        lastCleanupTime = now;
+        long cutoff = now - windowMs;
+        Iterator<Map.Entry<String, Record>> it = attemptsByIp.entrySet().iterator();
+        while (it.hasNext()) {
+            Record record = it.next().getValue();
+            if (record.lastActivity < cutoff && record.lockedUntil <= now) {
+                it.remove();
+            }
+        }
+    }
+
+    private static final class Record {
+        final AtomicInteger failCount = new AtomicInteger(0);
+        volatile long windowStart;
+        volatile long lastActivity;
+        volatile long lockedUntil;
+
+        Record(long now) {
+            this.windowStart = now;
+            this.lastActivity = now;
+        }
+    }
+}

--- a/unixauthservice/src/main/java/org/apache/ranger/authentication/PasswordValidator.java
+++ b/unixauthservice/src/main/java/org/apache/ranger/authentication/PasswordValidator.java
@@ -32,15 +32,19 @@ import java.util.List;
 
 public class PasswordValidator implements Runnable {
     private static final Logger LOG = LoggerFactory.getLogger(PasswordValidator.class);
+    private static final String GENERIC_FAILURE_RESPONSE = "FAILED: Authentication failed.";
+    private static final String LOCKED_OUT_RESPONSE = "FAILED: Too many attempts. Try again later.";
 
     private static List<String> adminUserList;
     private static String adminRoleNames;
     private static String validatorProgram;
 
+    private final LoginAttemptTracker loginAttemptTracker;
     private Socket client;
 
-    public PasswordValidator(Socket client) {
+    public PasswordValidator(Socket client, LoginAttemptTracker loginAttemptTracker) {
         this.client = client;
+        this.loginAttemptTracker = loginAttemptTracker;
     }
 
     public static String getValidatorProgram() {
@@ -74,11 +78,24 @@ public class PasswordValidator implements Runnable {
 
         String userName = null;
 
+        String remoteIp = client.getInetAddress() != null ? client.getInetAddress().getHostAddress() : "unknown";
         try {
             reader = new BufferedReader(new InputStreamReader(client.getInputStream()));
             writer = new PrintWriter(new OutputStreamWriter(client.getOutputStream()));
             String request = reader.readLine();
-
+            if (loginAttemptTracker.isBlocked(remoteIp)) {
+                LOG.warn("Rejected UnixAuth attempt from [{}] - source IP is temporarily locked out due to repeated failures.", remoteIp);
+                writer.println(LOCKED_OUT_RESPONSE);
+                writer.flush();
+                return;
+            }
+            if (request == null) {
+                loginAttemptTracker.recordFailure(remoteIp);
+                LOG.warn("Rejected UnixAuth attempt from [{}] - connection closed before sending any data.", remoteIp);
+                writer.println(GENERIC_FAILURE_RESPONSE);
+                writer.flush();
+                return;
+            }
             if (request.startsWith("LOGIN:")) {
                 String line       = request.substring(6).trim();
                 int    passwordAt = line.indexOf(' ');
@@ -88,10 +105,10 @@ public class PasswordValidator implements Runnable {
             }
 
             if (validatorProgram == null) {
-                String res = "FAILED: Unable to validate credentials.";
-                writer.println(res);
+                loginAttemptTracker.recordFailure(remoteIp);
+                LOG.error("Response [{}] for user: {} from [{}] as ValidatorProgram is not defined in configuration.", GENERIC_FAILURE_RESPONSE, userName, remoteIp);
+                writer.println(GENERIC_FAILURE_RESPONSE);
                 writer.flush();
-                LOG.error("Response [{}] for user: {} as ValidatorProgram is not defined in configuration", res, userName);
             } else {
                 BufferedReader pReader;
                 PrintWriter    pWriter;
@@ -109,14 +126,18 @@ public class PasswordValidator implements Runnable {
                     String res = pReader.readLine();
 
                     if (res != null && res.startsWith("OK")) {
+                        loginAttemptTracker.recordSuccess(remoteIp);
                         if (adminRoleNames != null && adminUserList != null) {
                             if (adminUserList.contains(userName)) {
                                 res = res + " " + adminRoleNames;
                             }
                         }
+                    } else {
+                        loginAttemptTracker.recordFailure(remoteIp);
+                        res = GENERIC_FAILURE_RESPONSE;
                     }
 
-                    LOG.info("Response [{}] for user: {}", res, userName);
+                    LOG.info("Response [{}] for user: {} from [{}]", res, userName, remoteIp);
 
                     writer.println(res);
                     writer.flush();
@@ -127,10 +148,11 @@ public class PasswordValidator implements Runnable {
                 }
             }
         } catch (Throwable t) {
+            loginAttemptTracker.recordFailure(remoteIp);
             if (userName != null && writer != null) {
-                String res = "FAILED: unable to validate due to error " + t.getMessage();
-                writer.println(res);
-                LOG.error("Response [{}] for user: {} message: {}", res, userName, t.getMessage());
+                LOG.error("Response [{}] for user: {} from [{}], {}", GENERIC_FAILURE_RESPONSE, userName, remoteIp, t.getMessage());
+                writer.println(GENERIC_FAILURE_RESPONSE);
+                writer.flush();
             }
         } finally {
             try {

--- a/unixauthservice/src/main/java/org/apache/ranger/authentication/UnixAuthenticationService.java
+++ b/unixauthservice/src/main/java/org/apache/ranger/authentication/UnixAuthenticationService.java
@@ -70,6 +70,11 @@ public class UnixAuthenticationService {
     private static final String SSL_ENABLED_PARAM                    = "ranger.usersync.ssl";
     private static final String CREDSTORE_FILENAME_PARAM             = "ranger.usersync.credstore.filename";
     private static final String[] UGSYNC_CONFIG_XML_FILES            = {"ranger-ugsync-default.xml", "ranger-ugsync-site.xml"};
+    private static final String UNIXAUTH_MAX_FAILED_ATTEMPTS_PARAM   = "ranger.usersync.unixauth.max.failed.attempts";
+    private static final String UNIXAUTH_ATTEMPT_WINDOW_MS_PARAM     = "ranger.usersync.unixauth.attempt.window.ms";
+    private static final String UNIXAUTH_LOCKOUT_DURATION_MS_PARAM   = "ranger.usersync.unixauth.lockout.duration.ms";
+    private static final String UNIXAUTH_REQUIRE_CLIENT_AUTH_PARAM   = "ranger.usersync.unixauth.require.client.auth";
+    private static final String UNIXAUTH_SOCKET_TIMEOUT_MS_PARAM     = "ranger.usersync.unixauth.socket.timeout.ms";
 
     private static boolean enableUnixAuth;
 
@@ -87,6 +92,9 @@ public class UnixAuthenticationService {
     private UserSyncHAInitializerImpl userSyncHAInitializerImpl;
     private int portNum;
     private boolean sslEnabled;
+    private boolean requireClientAuth;
+    private LoginAttemptTracker loginAttemptTracker;
+    private int socketTimeoutMs;
 
     public UnixAuthenticationService() {
     }
@@ -193,6 +201,13 @@ public class UnixAuthenticationService {
                         LOG.debug("Disabling CipherSuite : [{}]", enabledCipherSuite);
                     }
                 }
+                if (requireClientAuth) {
+                    if (trustStoreKeyStore == null) {
+                        throw new RuntimeException("[" + UNIXAUTH_REQUIRE_CLIENT_AUTH_PARAM + "] is enabled but [" + SSL_TRUSTSTORE_PATH_PARAM + "] is not configured - a truststore is required to validate client certificates.");
+                    }
+                    LOG.info("Enabling TLS client certificate authentication for UnixAuth listener.");
+                    secureSocket.setNeedClientAuth(true);
+                }
                 if (!allowedCipherSuites.isEmpty()) {
                     secureSocket.setEnabledCipherSuites(allowedCipherSuites.toArray(new String[0]));
                 }
@@ -202,7 +217,12 @@ public class UnixAuthenticationService {
 
             try {
                 while ((client = socket.accept()) != null) {
-                    Thread clientValidatorThread = new Thread(new PasswordValidator(client));
+                    try {
+                        client.setSoTimeout(socketTimeoutMs);
+                    } catch (java.net.SocketException se) {
+                        LOG.warn("Failed to set socket timeout for connection from [{}]: {}", client.getInetAddress(), se.getMessage());
+                    }
+                    Thread clientValidatorThread = new Thread(new PasswordValidator(client, loginAttemptTracker));
                     clientValidatorThread.start();
                 }
             } catch (IOException e) {
@@ -308,6 +328,15 @@ public class UnixAuthenticationService {
         String enabledCipherSuites     = prop.getProperty("ranger.usersync.https.ssl.enabled.cipher.suites", "");
         enabledProtocolsList           = new ArrayList<>(Arrays.asList(enabledProtocols.toUpperCase().trim().split("\\s*,\\s*")));
         enabledCipherSuiteList         = new ArrayList<>(Arrays.asList(enabledCipherSuites.toUpperCase().trim().split("\\s*,\\s*")));
+        int  maxFailedAttempts = Integer.parseInt(prop.getProperty(UNIXAUTH_MAX_FAILED_ATTEMPTS_PARAM, "5"));
+        long attemptWindowMs   = Long.parseLong(prop.getProperty(UNIXAUTH_ATTEMPT_WINDOW_MS_PARAM, "60000"));
+        long lockoutDurationMs = Long.parseLong(prop.getProperty(UNIXAUTH_LOCKOUT_DURATION_MS_PARAM, "30000"));
+        socketTimeoutMs = Integer.parseInt(prop.getProperty(UNIXAUTH_SOCKET_TIMEOUT_MS_PARAM, "10000"));
+
+        loginAttemptTracker = new LoginAttemptTracker(maxFailedAttempts, attemptWindowMs, lockoutDurationMs);
+
+        String requireClientAuthProp = prop.getProperty(UNIXAUTH_REQUIRE_CLIENT_AUTH_PARAM, "false");
+        requireClientAuth = requireClientAuthProp.trim().equalsIgnoreCase("true");
     }
 
     private InputStream getFileInputStream(String path) throws FileNotFoundException {

--- a/unixauthservice/src/test/java/org/apache/ranger/authentication/LoginAttemptTrackerTest.java
+++ b/unixauthservice/src/test/java/org/apache/ranger/authentication/LoginAttemptTrackerTest.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.authentication;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class LoginAttemptTrackerTest {
+    @Test
+    public void allowsAttemptsBelowThreshold() {
+        LoginAttemptTracker tracker = new LoginAttemptTracker(5, 60_000, 30_000);
+        String ip = "10.0.0.1";
+        for (int i = 0; i < 4; i++) {
+            assertFalse(tracker.isBlocked(ip), "should not be blocked before threshold");
+            tracker.recordFailure(ip);
+        }
+        assertFalse(tracker.isBlocked(ip), "still not blocked at 4 failures with threshold 5");
+    }
+
+    @Test
+    public void locksOutAfterThresholdReached() {
+        LoginAttemptTracker tracker = new LoginAttemptTracker(5, 60_000, 30_000);
+        String ip = "10.0.0.2";
+        for (int i = 0; i < 5; i++) {
+            tracker.recordFailure(ip);
+        }
+        assertTrue(tracker.isBlocked(ip), "should be locked out at threshold");
+    }
+
+    @Test
+    public void successClearsFailureHistory() {
+        LoginAttemptTracker tracker = new LoginAttemptTracker(5, 60_000, 30_000);
+        String ip = "10.0.0.3";
+        for (int i = 0; i < 4; i++) {
+            tracker.recordFailure(ip);
+        }
+        tracker.recordSuccess(ip);
+        assertFalse(tracker.isBlocked(ip));
+        // failure count should have reset - one more failure should not lock out
+        tracker.recordFailure(ip);
+        assertFalse(tracker.isBlocked(ip));
+    }
+
+    @Test
+    public void windowExpiryResetsFailureCount() throws InterruptedException {
+        // very short window so the test runs fast
+        LoginAttemptTracker tracker = new LoginAttemptTracker(3, 50, 30_000);
+        String ip = "10.0.0.4";
+        tracker.recordFailure(ip);
+        tracker.recordFailure(ip);
+        assertFalse(tracker.isBlocked(ip));
+        Thread.sleep(100); // let the window expire
+        tracker.recordFailure(ip); // should start a fresh window, count = 1
+        assertFalse(tracker.isBlocked(ip), "window should have reset the failure count");
+    }
+
+    @Test
+    public void reLocksImmediatelyIfRetriedRightAfterLockoutExpires() throws InterruptedException {
+        // short lockout, long window - so lockout expires but window doesn't
+        LoginAttemptTracker tracker = new LoginAttemptTracker(3, 60_000, 50);
+        String ip = "10.0.0.5";
+        tracker.recordFailure(ip);
+        tracker.recordFailure(ip);
+        tracker.recordFailure(ip);
+        assertTrue(tracker.isBlocked(ip));
+        Thread.sleep(100); // let the lockout expire, window is still active
+        assertFalse(tracker.isBlocked(ip), "lockout should have expired");
+        tracker.recordFailure(ip); // one more failure within the same window
+        assertTrue(tracker.isBlocked(ip), "should re-lock immediately since window's failure count carried over");
+    }
+
+    @Test
+    public void independentIpsTrackedSeparately() {
+        LoginAttemptTracker tracker = new LoginAttemptTracker(3, 60_000, 30_000);
+        for (int i = 0; i < 3; i++) {
+            tracker.recordFailure("10.0.0.6");
+        }
+        assertTrue(tracker.isBlocked("10.0.0.6"));
+        assertFalse(tracker.isBlocked("10.0.0.7"), "a different source IP must not be affected");
+    }
+}

--- a/unixauthservice/src/test/java/org/apache/ranger/authentication/TestPasswordValidator.java
+++ b/unixauthservice/src/test/java/org/apache/ranger/authentication/TestPasswordValidator.java
@@ -37,9 +37,11 @@ import java.util.Arrays;
 import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -52,6 +54,10 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class TestPasswordValidator {
+    private static LoginAttemptTracker permissiveTracker() {
+        return new LoginAttemptTracker(1000, 60_000, 30_000);
+    }
+
     @Test
     public void test00_staticGettersAndSetters() {
         PasswordValidator.setValidatorProgram("/tmp/prog");
@@ -72,10 +78,10 @@ public class TestPasswordValidator {
         ByteArrayOutputStream out    = new ByteArrayOutputStream();
         Socket                socket = buildSocket("LOGIN: alice secret", out);
 
-        new PasswordValidator(socket).run();
+        new PasswordValidator(socket, permissiveTracker()).run();
 
         String response = out.toString(StandardCharsets.UTF_8.name()).trim();
-        assertEquals("FAILED: Unable to validate credentials.", response);
+        assertEquals("FAILED: Authentication failed.", response);
         verify(socket, times(1)).close();
     }
 
@@ -98,10 +104,10 @@ public class TestPasswordValidator {
             runtimeStatic.when(Runtime::getRuntime).thenReturn(rt);
             when(rt.exec("/bin/validator")).thenReturn(process);
 
-            new PasswordValidator(socket).run();
+            new PasswordValidator(socket, permissiveTracker()).run();
         }
 
-        String response = out.toString(StandardCharsets.UTF_8.name()).trim();
+        String response = out.toString(StandardCharsets.UTF_8).trim();
         assertEquals("OK ROLE_ADMIN", response);
         verify(process, times(1)).destroy();
         verify(socket, times(1)).close();
@@ -126,7 +132,7 @@ public class TestPasswordValidator {
             runtimeStatic.when(Runtime::getRuntime).thenReturn(rt);
             when(rt.exec("/bin/validator")).thenReturn(process);
 
-            new PasswordValidator(socket).run();
+            new PasswordValidator(socket, permissiveTracker()).run();
         }
 
         String response = out.toString(StandardCharsets.UTF_8.name()).trim();
@@ -149,10 +155,11 @@ public class TestPasswordValidator {
             runtimeStatic.when(Runtime::getRuntime).thenReturn(rt);
             when(rt.exec("/bin/validator")).thenThrow(new IOException("boom"));
 
-            new PasswordValidator(socket).run();
+            new PasswordValidator(socket, permissiveTracker()).run();
         }
 
-        // Output may not be flushed in catch path; verify socket is closed indicating catch executed
+        String response = out.toString(StandardCharsets.UTF_8).trim();
+        assertEquals("FAILED: Authentication failed.", response);
         verify(socket, times(1)).close();
     }
 
@@ -166,10 +173,87 @@ public class TestPasswordValidator {
         Socket                socket = buildSocket("LOGIN: alice secret", out);
         doThrow(new IOException("close failure")).when(socket).close();
 
-        new PasswordValidator(socket).run();
+        new PasswordValidator(socket, permissiveTracker()).run();
 
         // No exception should be thrown even if close() fails; nothing to assert besides method completed
         verify(socket, times(1)).close();
+    }
+
+    @Test
+    public void test06_blockedIpSkipsValidatorAndReturnsLockedOutResponse() throws Exception {
+        PasswordValidator.setValidatorProgram("/bin/validator");
+        PasswordValidator.setAdminUserList(null);
+        PasswordValidator.setAdminRoleNames(null);
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        Socket socket = buildSocket("LOGIN: alice secret", out);
+        LoginAttemptTracker tracker = mock(LoginAttemptTracker.class);
+        when(tracker.isBlocked(anyString())).thenReturn(true);
+        new PasswordValidator(socket, tracker).run();
+        String response = out.toString(StandardCharsets.UTF_8).trim();
+        assertEquals("FAILED: Too many attempts. Try again later.", response);
+        verify(socket, times(1)).close();
+    }
+
+    @Test
+    public void test07_failedValidatorResponseRecordsFailureOnTracker() throws Exception {
+        PasswordValidator.setValidatorProgram("/bin/validator");
+        PasswordValidator.setAdminUserList(null);
+        PasswordValidator.setAdminRoleNames(null);
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        Socket socket = buildSocket("LOGIN: alice secret", out);
+
+        Process process = mock(Process.class);
+        ByteArrayInputStream processStdout = new ByteArrayInputStream("FAILED: Password did not match.".getBytes(StandardCharsets.UTF_8));
+        when(process.getInputStream()).thenReturn(processStdout);
+        when(process.getOutputStream()).thenReturn(new ByteArrayOutputStream());
+
+        LoginAttemptTracker tracker = mock(LoginAttemptTracker.class);
+        when(tracker.isBlocked(anyString())).thenReturn(false);
+
+        try (MockedStatic<Runtime> runtimeStatic = mockStatic(Runtime.class)) {
+            Runtime rt = mock(Runtime.class);
+            runtimeStatic.when(Runtime::getRuntime).thenReturn(rt);
+            when(rt.exec("/bin/validator")).thenReturn(process);
+            new PasswordValidator(socket, tracker).run();
+        }
+
+        String response = out.toString(StandardCharsets.UTF_8).trim();
+        assertEquals("FAILED: Authentication failed.", response);
+        verify(tracker, times(1)).recordFailure(anyString());
+        verify(tracker, never()).recordSuccess(anyString());
+    }
+
+    @Test
+    public void test08_okValidatorResponseRecordsSuccessOnTracker() throws Exception {
+        PasswordValidator.setValidatorProgram("/bin/validator");
+        PasswordValidator.setAdminUserList(null);
+        PasswordValidator.setAdminRoleNames(null);
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        Socket socket = buildSocket("LOGIN: alice secret", out);
+
+        Process process = mock(Process.class);
+        ByteArrayInputStream processStdout = new ByteArrayInputStream("OK".getBytes(StandardCharsets.UTF_8));
+        when(process.getInputStream()).thenReturn(processStdout);
+        when(process.getOutputStream()).thenReturn(new ByteArrayOutputStream());
+
+        LoginAttemptTracker tracker = mock(LoginAttemptTracker.class);
+        when(tracker.isBlocked(anyString())).thenReturn(false);
+
+        try (MockedStatic<Runtime> runtimeStatic = mockStatic(Runtime.class)) {
+            Runtime rt = mock(Runtime.class);
+            runtimeStatic.when(Runtime::getRuntime).thenReturn(rt);
+            when(rt.exec("/bin/validator")).thenReturn(process);
+
+            new PasswordValidator(socket, tracker).run();
+        }
+
+        String response = out.toString(StandardCharsets.UTF_8).trim();
+        assertEquals("OK", response);
+        verify(tracker, times(1)).recordSuccess(anyString());
+        verify(tracker, never()).recordFailure(anyString());
     }
 
     private Socket buildSocket(String requestLine, ByteArrayOutputStream responseOut) throws IOException {


### PR DESCRIPTION
## What changes were proposed in this pull request?

UnixAuthenticationService accepted unlimited authentication attempts with no rate limiting, delay, or lockout. Any network client that could reach the UnixAuth listener could guess OS passwords at native `crypt()` speed, with a username-enumeration side channel from distinct failure responses.

This PR adds:

1. **Per-source-IP rate limiting and lockout** — `LoginAttemptTracker` tracks failed attempts per source IP within a sliding window (default: 5 failures / 60s window / 30s lockout, all configurable via `ranger-ugsync-default.xml`). Once the threshold is hit, further attempts are rejected before the OS credential validator is invoked. Covers wrong password, validator errors, malformed/empty requests, and connection timeouts.

2. **Closed username-enumeration side channel** — Network clients now receive a single generic `FAILED: Authentication failed.` regardless of whether the password was wrong or the user does not exist. Full detail remains in server-side logs with source IP.

3. **Optional TLS client-certificate enforcement** — Opt-in `ranger.usersync.unixauth.require.client.auth` (default `false`) requires clients to present a certificate trusted by the configured truststore.

4. **Socket read timeout** — Connections that send no data within a configurable window (default 10s) are closed and counted as a failed attempt.

### New / modified files

| File | Change |
|------|--------|
| `LoginAttemptTracker.java` | New per-IP sliding-window tracker |
| `PasswordValidator.java` | Generic responses, lockout check, failure/success recording |
| `UnixAuthenticationService.java` | Tracker init, socket timeout, optional client-auth |
| `ranger-ugsync-default.xml` | New config keys for rate limit / lockout / timeout |
| `LoginAttemptTrackerTest.java` | Unit tests for tracker |
| `TestPasswordValidator.java` | Extended for lockout and generic failure paths |

### Config keys (defaults)

| Property | Default |
|----------|---------|
| `ranger.usersync.unixauth.max.failed.attempts` | `5` |
| `ranger.usersync.unixauth.attempt.window.ms` | `60000` |
| `ranger.usersync.unixauth.lockout.duration.ms` | `30000` |
| `ranger.usersync.unixauth.socket.timeout.ms` | `10000` |
| `ranger.usersync.unixauth.require.client.auth` | `false` |

---

## How was this patch tested?

### Unit tests (automated)

```bash
cd unixauthservice && mvn clean test
cd ../unixauthclient && mvn test
```

| Module | Result |
|--------|--------|
| `unixauthservice` | **25/25 pass** |
| `unixauthclient` | **32/32 pass** |

**`LoginAttemptTrackerTest` (6 tests):** threshold below lockout, lockout at threshold, success clears history, window expiry resets count, re-lock after lockout expires, independent per-IP tracking.

**`TestPasswordValidator` (9 tests):** generic failure when validator returns distinct message, blocked IP returns `FAILED: Too many attempts. Try again later.` without invoking validator, failure/success recorded on tracker, null program / exec errors counted as failures.

**`TestUnixAuthenticationService` (10 tests):** config loading, `LoginAttemptTracker` wiring, socket timeout via `setSoTimeout`, validator thread spawn on accept.

---

### End-to-end testing (manual, reproducible)

E2E exercises the **real** `UnixAuthenticationService.startService()` listener (TCP accept → `setSoTimeout` → `PasswordValidator` thread → `LoginAttemptTracker`). It does **not** require the full usersync tarball, Docker stack, or native `credValidator.uexe` — a mock shell validator is used instead.

**Prerequisites:** JDK 8+, Maven, Python 3, checkout of this PR branch.

```bash
git fetch origin pull/1080/head:RANGER-5690
git checkout RANGER-5690
cd unixauthservice
mvn package -DskipTests
mvn dependency:build-classpath -Dmdep.outputFile=target/test-cp.txt
```

#### Wire protocol (unchanged)

```
Client → Server:  LOGIN:<username> <password>\n
Server → Client:  OK: ... | FAILED: Authentication failed. | FAILED: Too many attempts. Try again later.
```

#### Step 1 — Mock validator scripts

Save as `mock-validator-fail.sh` (always fails with a **distinct internal** message):

```bash
#!/bin/bash
read -r line
echo "FAILED: Password did not match."
```

Save as `mock-validator-ok.sh` (returns `OK` for `gooduser`, fails for others):

```bash
#!/bin/bash
read -r line
if echo "$line" | grep -q "gooduser"; then
  echo "OK"
else
  echo "FAILED: Password did not match."
fi
```

```bash
chmod +x mock-validator-fail.sh mock-validator-ok.sh
```

#### Step 2 — Start test listener (plain TCP)

The harness below starts `UnixAuthenticationService.startService()` with `ssl=false`, threshold **3** (faster demo; production default is 5), and the mock validator. Save as `UnixAuthE2eServer.java` in `unixauthservice/`:

```java
import org.apache.ranger.authentication.LoginAttemptTracker;
import org.apache.ranger.authentication.PasswordValidator;
import org.apache.ranger.authentication.UnixAuthenticationService;
import java.lang.reflect.Field;
import java.util.ArrayList;

public class UnixAuthE2eServer {
    private static void set(Object target, String name, Object value) throws Exception {
        Field f = UnixAuthenticationService.class.getDeclaredField(name);
        f.setAccessible(true);
        f.set(target, value);
    }
    public static void main(String[] args) throws Throwable {
        String validator = args.length > 0 ? args[0] : "mock-validator-fail.sh";
        int port = args.length > 1 ? Integer.parseInt(args[1]) : 15151;
        int threshold = args.length > 2 ? Integer.parseInt(args[2]) : 3;

        PasswordValidator.setValidatorProgram(validator);
        PasswordValidator.setAdminUserList(null);
        PasswordValidator.setAdminRoleNames(null);

        UnixAuthenticationService svc = new UnixAuthenticationService();
        set(svc, "sslEnabled", false);
        set(svc, "portNum", port);
        set(svc, "enabledProtocolsList", new ArrayList<>());
        set(svc, "enabledCipherSuiteList", new ArrayList<>());
        set(svc, "keyStorePath", "");
        set(svc, "trustStorePath", "");
        set(svc, "keyStoreType", "JKS");
        set(svc, "trustStoreType", "JKS");
        set(svc, "keyStorePathPassword", "");
        set(svc, "trustStorePathPassword", "");
        set(svc, "requireClientAuth", false);
        set(svc, "socketTimeoutMs", 10_000);
        set(svc, "loginAttemptTracker", new LoginAttemptTracker(threshold, 60_000, 30_000));

        System.out.println("READY port=" + port + " threshold=" + threshold);
        svc.startService();
    }
}
```

Compile and start (background):

```bash
CP="target/classes:$(cat target/test-cp.txt)"
javac -cp "$CP" UnixAuthE2eServer.java
java -cp ".:$CP" UnixAuthE2eServer "$(pwd)/mock-validator-fail.sh" 15151 3 &
sleep 2
grep READY *.log 2>/dev/null || true   # server prints READY to stdout
```

#### Step 3 — External TCP client (Python)

Save as `unixauth-e2e-client.py`:

```python
#!/usr/bin/env python3
import socket
import sys

host = sys.argv[1] if len(sys.argv) > 1 else "127.0.0.1"
port = int(sys.argv[2]) if len(sys.argv) > 2 else 15151
user = sys.argv[3] if len(sys.argv) > 3 else "baduser"
password = sys.argv[4] if len(sys.argv) > 4 else "wrongpass"
attempts = int(sys.argv[5]) if len(sys.argv) > 5 else 5

for i in range(1, attempts + 1):
    s = socket.create_connection((host, port), timeout=10)
    s.sendall(f"LOGIN: {user} {password}\n".encode())
    resp = s.recv(4096).decode().strip()
    s.close()
    print(f"ATTEMPT_{i}={resp}")
```

Run lockout test:

```bash
python3 unixauth-e2e-client.py 127.0.0.1 15151 baduser wrongpass 5
```

**Expected output:**

```
ATTEMPT_1=FAILED: Authentication failed.
ATTEMPT_2=FAILED: Authentication failed.
ATTEMPT_3=FAILED: Authentication failed.
ATTEMPT_4=FAILED: Too many attempts. Try again later.
ATTEMPT_5=FAILED: Too many attempts. Try again later.
```

**Verified:** attempts 1–3 call mock validator but client sees generic message only; attempt 4+ locked out before validator runs.

#### Step 4 — Enumeration masking + success clears counter

Restart server with `mock-validator-ok.sh`, then:

```bash
python3 unixauth-e2e-client.py 127.0.0.1 15151 nobody wrong 1   # → FAILED: Authentication failed.
python3 unixauth-e2e-client.py 127.0.0.1 15151 gooduser good 1  # → OK
python3 unixauth-e2e-client.py 127.0.0.1 15151 nobody wrong 1   # → FAILED: Authentication failed. (counter reset)
```

#### All-in-one runner (optional)

Save as `run-unixauth-e2e.sh` in `unixauthservice/`:

```bash
#!/usr/bin/env bash
set -euo pipefail
cd "$(dirname "$0")"
mvn -q package -DskipTests
mvn -q dependency:build-classpath -Dmdep.outputFile=target/test-cp.txt
CP="target/classes:$(cat target/test-cp.txt)"

cat > mock-validator-fail.sh <<'EOF'
#!/bin/bash
read -r line
echo "FAILED: Password did not match."
EOF
chmod +x mock-validator-fail.sh

# UnixAuthE2eServer.java — paste from Step 2 above, or keep as separate file
javac -cp "$CP" UnixAuthE2eServer.java
java -cp ".:$CP" UnixAuthE2eServer "$(pwd)/mock-validator-fail.sh" 15151 3 &
PID=$!
trap 'kill $PID 2>/dev/null || true' EXIT
sleep 2

python3 unixauth-e2e-client.py 127.0.0.1 15151 baduser wrongpass 5
```

```bash
chmod +x run-unixauth-e2e.sh && ./run-unixauth-e2e.sh
```

---

### What was NOT covered by the manual E2E harness

| Item | Notes |
|------|-------|
| Full `UnixAuthenticationService -enableUnixAuth` daemon | Needs JCEKS credential store, SSL keystores, usersync + Admin config |
| Docker usersync stack | Full Ranger compose |
| Native `credValidator.uexe` | Linux `/etc/shadow` binary; mock script substitutes |
| TLS on port 5151 | Same auth logic; needs truststore for TLS clients |
| `ranger.usersync.unixauth.require.client.auth=true` | Needs client CA in truststore |

---

### Regression scope

- Existing UnixAuth wire protocol — **unchanged** (`LOGIN:` prefix, `OK:` / `FAILED:` responses)
- Default config — backward compatible (rate limits use sensible defaults; client-auth opt-in)
