### PR TITLE
RANGER-5693: Stop logging full JWT bearer tokens on validation failure

### DIFF
--- a/ranger-authn/src/main/java/org/apache/ranger/authz/handler/jwt/RangerJwtAuthHandler.java
+++ b/ranger-authn/src/main/java/org/apache/ranger/authz/handler/jwt/RangerJwtAuthHandler.java
@@ -40,9 +40,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.text.ParseException;
 import java.util.Arrays;
 import java.util.Date;
@@ -130,7 +127,7 @@ public abstract class RangerJwtAuthHandler implements RangerAuthHandler {
                         }
                         return userName;
                     } else {
-                        LOG.warn("JWT validation failed ({})", safeJwtLogContext(jwtToken, serializedJWT));
+                        LOG.warn("JWT validation failed ({})", safeJwtLogContext(jwtToken));
                     }
                 } catch (ParseException pe) {
                     LOG.warn("RangerJwtAuthHandler.authenticate(): Unable to parse the JWT token", pe);
@@ -313,14 +310,12 @@ public abstract class RangerJwtAuthHandler implements RangerAuthHandler {
 
     /**
      * Build non-sensitive JWT metadata for operational logs.
-     * Never log the raw bearer token; a one-way hash is included for
-     * correlation across log lines.
+     * Never log the raw bearer token.
      *
      * @param jwtToken parsed JWT used to extract claim metadata
-     * @param serializedJwt original bearer string, hashed for correlation only
      * @return safe diagnostic string for log output
      */
-    protected String safeJwtLogContext(final SignedJWT jwtToken, final String serializedJwt) {
+    protected String safeJwtLogContext(final SignedJWT jwtToken) {
         try {
             JWTClaimsSet claims = jwtToken.getJWTClaimsSet();
             JWSHeader header = jwtToken.getHeader();
@@ -328,23 +323,9 @@ public abstract class RangerJwtAuthHandler implements RangerAuthHandler {
             List<String> tokenAudiences = claims.getAudience();
             String audience = tokenAudiences == null || tokenAudiences.isEmpty() ? null : StringUtils.join(tokenAudiences, ",");
 
-            return String.format("subject=%s, audience=%s, issuer=%s, keyId=%s, jwtId=%s, tokenHash=%s", claims.getSubject(), audience, claims.getIssuer(), keyId, claims.getJWTID(), sha256Hex(serializedJwt));
+            return String.format("subject=%s, audience=%s, issuer=%s, keyId=%s, jwtId=%s", claims.getSubject(), audience, claims.getIssuer(), keyId, claims.getJWTID());
         } catch (ParseException pe) {
             return "claims_unparseable";
-        }
-    }
-
-    private static String sha256Hex(final String value) {
-        try {
-            MessageDigest digest = MessageDigest.getInstance("SHA-256");
-            byte[] hash = digest.digest(value.getBytes(StandardCharsets.UTF_8));
-            StringBuilder sb = new StringBuilder(hash.length * 2);
-            for (byte b : hash) {
-                sb.append(String.format("%02x", b));
-            }
-            return sb.toString();
-        } catch (NoSuchAlgorithmException e) {
-            return "unavailable";
         }
     }
 

--- a/ranger-authn/src/main/java/org/apache/ranger/authz/handler/jwt/RangerJwtAuthHandler.java
+++ b/ranger-authn/src/main/java/org/apache/ranger/authz/handler/jwt/RangerJwtAuthHandler.java
@@ -19,6 +19,7 @@
 package org.apache.ranger.authz.handler.jwt;
 
 import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSHeader;
 import com.nimbusds.jose.JWSObject;
 import com.nimbusds.jose.JWSVerifier;
 import com.nimbusds.jose.crypto.RSASSAVerifier;
@@ -30,6 +31,7 @@ import com.nimbusds.jose.proc.JWSKeySelector;
 import com.nimbusds.jose.proc.JWSVerificationKeySelector;
 import com.nimbusds.jose.proc.SecurityContext;
 import com.nimbusds.jose.util.X509CertUtils;
+import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.jwt.proc.ConfigurableJWTProcessor;
 import org.apache.commons.lang3.StringUtils;
@@ -38,6 +40,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.text.ParseException;
 import java.util.Arrays;
 import java.util.Date;
@@ -125,7 +130,7 @@ public abstract class RangerJwtAuthHandler implements RangerAuthHandler {
                         }
                         return userName;
                     } else {
-                        LOG.warn("RangerJwtAuthHandler.authenticate(): Validation failed for JWT token: [{}] ", jwtToken.serialize());
+                        LOG.warn("JWT validation failed ({})", safeJwtLogContext(jwtToken, serializedJWT));
                     }
                 } catch (ParseException pe) {
                     LOG.warn("RangerJwtAuthHandler.authenticate(): Unable to parse the JWT token", pe);
@@ -260,13 +265,15 @@ public abstract class RangerJwtAuthHandler implements RangerAuthHandler {
                 valid = true;
             } else {
                 // if any of the configured audiences is found then consider it acceptable
-                for (String aud : tokenAudienceList) {
-                    if (audiences.contains(aud)) {
-                        if (LOG.isDebugEnabled()) {
-                            LOG.debug("JWT token audience has been successfully validated.");
+                if (tokenAudienceList != null) {
+                    for (String aud : tokenAudienceList) {
+                        if (audiences.contains(aud)) {
+                            if (LOG.isDebugEnabled()) {
+                                LOG.debug("JWT token audience has been successfully validated.");
+                            }
+                            valid = true;
+                            break;
                         }
-                        valid = true;
-                        break;
                     }
                 }
                 if (!valid) {
@@ -302,6 +309,43 @@ public abstract class RangerJwtAuthHandler implements RangerAuthHandler {
             LOG.warn("Unable to parse the JWT token.", pe);
         }
         return valid;
+    }
+
+    /**
+     * Build non-sensitive JWT metadata for operational logs.
+     * Never log the raw bearer token; a one-way hash is included for
+     * correlation across log lines.
+     *
+     * @param jwtToken parsed JWT used to extract claim metadata
+     * @param serializedJwt original bearer string, hashed for correlation only
+     * @return safe diagnostic string for log output
+     */
+    protected String safeJwtLogContext(final SignedJWT jwtToken, final String serializedJwt) {
+        try {
+            JWTClaimsSet claims = jwtToken.getJWTClaimsSet();
+            JWSHeader header = jwtToken.getHeader();
+            String keyId = header != null ? header.getKeyID() : null;
+            List<String> tokenAudiences = claims.getAudience();
+            String audience = tokenAudiences == null || tokenAudiences.isEmpty() ? null : StringUtils.join(tokenAudiences, ",");
+
+            return String.format("subject=%s, audience=%s, issuer=%s, keyId=%s, jwtId=%s, tokenHash=%s", claims.getSubject(), audience, claims.getIssuer(), keyId, claims.getJWTID(), sha256Hex(serializedJwt));
+        } catch (ParseException pe) {
+            return "claims_unparseable";
+        }
+    }
+
+    private static String sha256Hex(final String value) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(value.getBytes(StandardCharsets.UTF_8));
+            StringBuilder sb = new StringBuilder(hash.length * 2);
+            for (byte b : hash) {
+                sb.append(String.format("%02x", b));
+            }
+            return sb.toString();
+        } catch (NoSuchAlgorithmException e) {
+            return "unavailable";
+        }
     }
 
     /**

--- a/ranger-authn/src/test/java/org/apache/ranger/authz/handler/jwt/TestRangerJwtAuthHandler.java
+++ b/ranger-authn/src/test/java/org/apache/ranger/authz/handler/jwt/TestRangerJwtAuthHandler.java
@@ -30,9 +30,11 @@ import org.junit.jupiter.api.Test;
 
 import javax.servlet.http.HttpServletRequest;
 
+import java.util.Arrays;
 import java.util.Date;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestRangerJwtAuthHandler {
@@ -49,6 +51,14 @@ public class TestRangerJwtAuthHandler {
 
         boolean callValidateIssuer(SignedJWT jwt) {
             return validateIssuer(jwt);
+        }
+
+        boolean callValidateAudiences(SignedJWT jwt) {
+            return validateAudiences(jwt);
+        }
+
+        String callSafeJwtLogContext(SignedJWT jwt, String serializedJwt) {
+            return safeJwtLogContext(jwt, serializedJwt);
         }
     }
 
@@ -105,5 +115,38 @@ public class TestRangerJwtAuthHandler {
         SignedJWT badJwt = SignedJWT.parse(header + "." + payload + "." + signature);
 
         assertFalse(handler.callValidateIssuer(badJwt));
+    }
+
+    @Test
+    void validateAudiencesFalse_whenTokenAudienceMissingAndAudiencesConfigured() {
+        TestHandler handler = new TestHandler();
+        handler.audiences = Arrays.asList("service-a");
+
+        SignedJWT jwt = jwtWithIssuer("test-issuer");
+
+        assertFalse(handler.callValidateAudiences(jwt));
+    }
+
+    @Test
+    void safeJwtLogContext_includesMetadataWithoutRawToken() throws Exception {
+        TestHandler handler = new TestHandler();
+        String header = "eyJhbGciOiJSUzI1NiIsImtpZCI6ImtpZC1hYmMifQ";
+        String payload = "eyJzdWIiOiJmMDE1X3JlcGxheV91c2VyIiwiYXVkIjoic2VydmljZS1hIiwiaXNzIjoidGVzdC1pc3N1ZXIiLCJqdGkiOiJqdGktMTIzIiwiZXhwIjoxOTk5OTk5OTk5fQ";
+        String signature = "abcd";
+        String serialized = header + "." + payload + "." + signature;
+
+        String context = handler.callSafeJwtLogContext(SignedJWT.parse(serialized), serialized);
+
+        assertNotNull(context);
+        assertTrue(context.contains("subject=f015_replay_user"));
+        assertTrue(context.contains("audience=service-a"));
+        assertTrue(context.contains("issuer=test-issuer"));
+        assertTrue(context.contains("keyId=kid-abc"));
+        assertTrue(context.contains("jwtId=jti-123"));
+        assertTrue(context.contains("tokenHash="));
+        assertFalse(context.contains(serialized));
+        assertFalse(context.contains(header));
+        assertFalse(context.contains(payload));
+        assertFalse(context.contains(signature));
     }
 }

--- a/ranger-authn/src/test/java/org/apache/ranger/authz/handler/jwt/TestRangerJwtAuthHandler.java
+++ b/ranger-authn/src/test/java/org/apache/ranger/authz/handler/jwt/TestRangerJwtAuthHandler.java
@@ -143,7 +143,6 @@ public class TestRangerJwtAuthHandler {
         assertTrue(context.contains("issuer=test-issuer"));
         assertTrue(context.contains("keyId=kid-abc"));
         assertTrue(context.contains("jwtId=jti-123"));
-        assertFalse(context.contains("tokenHash="));
         assertFalse(context.contains(serialized));
         assertFalse(context.contains(header));
         assertFalse(context.contains(payload));

--- a/ranger-authn/src/test/java/org/apache/ranger/authz/handler/jwt/TestRangerJwtAuthHandler.java
+++ b/ranger-authn/src/test/java/org/apache/ranger/authz/handler/jwt/TestRangerJwtAuthHandler.java
@@ -57,8 +57,8 @@ public class TestRangerJwtAuthHandler {
             return validateAudiences(jwt);
         }
 
-        String callSafeJwtLogContext(SignedJWT jwt, String serializedJwt) {
-            return safeJwtLogContext(jwt, serializedJwt);
+        String callSafeJwtLogContext(SignedJWT jwt) {
+            return safeJwtLogContext(jwt);
         }
     }
 
@@ -135,7 +135,7 @@ public class TestRangerJwtAuthHandler {
         String signature = "abcd";
         String serialized = header + "." + payload + "." + signature;
 
-        String context = handler.callSafeJwtLogContext(SignedJWT.parse(serialized), serialized);
+        String context = handler.callSafeJwtLogContext(SignedJWT.parse(serialized));
 
         assertNotNull(context);
         assertTrue(context.contains("subject=f015_replay_user"));
@@ -143,7 +143,7 @@ public class TestRangerJwtAuthHandler {
         assertTrue(context.contains("issuer=test-issuer"));
         assertTrue(context.contains("keyId=kid-abc"));
         assertTrue(context.contains("jwtId=jti-123"));
-        assertTrue(context.contains("tokenHash="));
+        assertFalse(context.contains("tokenHash="));
         assertFalse(context.contains(serialized));
         assertFalse(context.contains(header));
         assertFalse(context.contains(payload));


### PR DESCRIPTION
## Summary

- Remove logging of the full serialized JWT bearer token (`header.payload.signature`) when `RangerJwtAuthHandler` validation fails.
- Log only non-sensitive metadata: `subject`, `audience`, `issuer`, `keyId`, `jwtId`.

**JIRA:** https://issues.apache.org/jira/browse/RANGER-5693

## Problem

On validation failure, `RangerJwtAuthHandler.authenticate()` logged:

```
RangerJwtAuthHandler.authenticate(): Validation failed for JWT token: [<full serialized JWT>]
```

`validateToken()` checks claims in order: **expiration → signature → audience → issuer**. A cryptographically valid, unexpired token rejected only for **audience mismatch** still hit this WARN path. The full bearer credential in logs could be replayed against another Ranger JWT consumer that trusts the same signing material and accepts the token's audience.

## Fix

**Before:**

```java
LOG.warn("... Validation failed for JWT token: [{}] ", jwtToken.serialize());
```

**After:**

```java
LOG.warn("JWT validation failed ({})", safeJwtLogContext(jwtToken));
```

`safeJwtLogContext()` emits diagnostic fields only, for example:

```
JWT validation failed (subject=f015_replay_user, audience=service-a, issuer=test-issuer, keyId=kid-abc, jwtId=jti-123)
```

The raw bearer string is never written to operational logs. `jwtId` (`jti` claim) provides log correlation when present.

### Null-safety

- `validateAudiences()`: guard `tokenAudienceList != null` before iterating (avoids NPE when `aud` claim is absent).
- `safeJwtLogContext()`: guard `jwtToken.getHeader()` before reading `keyId`; use `StringUtils.join()` for audience list (JDK 8 compatible, tolerates null list entries).

## Files changed (2)

| File | Change |
|------|--------|
| `ranger-authn/.../RangerJwtAuthHandler.java` | Safe logging, `safeJwtLogContext()`, audience null guard |
| `ranger-authn/.../TestRangerJwtAuthHandler.java` | Unit tests for safe context and missing audience |

## Test plan

### Unit tests (automated)

```bash
mvn -pl ranger-authn test -Dtest=TestRangerJwtAuthHandler
mvn verify -pl ranger-authn -Dtest=TestRangerJwtAuthHandler -Drat.skip=true
```
