### PR TITLE
RANGER-5596 : Blank resource type created during new global policy creation setup.

### DIFF
--- a/security-admin/src/main/webapp/react-webapp/src/views/PolicyListing/AddUpdatePolicyForm.jsx
+++ b/security-admin/src/main/webapp/react-webapp/src/views/PolicyListing/AddUpdatePolicyForm.jsx
@@ -174,32 +174,6 @@ export default function AddUpdatePolicyForm() {
     setShowDelete(false);
   };
 
-  const isDirtyFieldCheck = (dirtyFields, modified, values, initialValues) => {
-    let modifiedVal = false;
-    if (!isEmpty(dirtyFields)) {
-      for (let dirtyFieldVal in dirtyFields) {
-        modifiedVal = modified?.[dirtyFieldVal];
-        if (
-          values?.validitySchedules ||
-          modified?.validitySchedules ||
-          values?.conditions ||
-          modified?.conditions ||
-          modifiedVal == true
-        ) {
-          modifiedVal = true;
-          break;
-        }
-      }
-    }
-    if (
-      !isEqual(values?.validitySchedules, initialValues?.validitySchedules) ||
-      !isEqual(values?.conditions, initialValues?.conditions)
-    ) {
-      modifiedVal = true;
-    }
-    return modifiedVal;
-  };
-
   const fetchUsersData = async (inputValue) => {
     let params = { name: inputValue || "", isVisible: 1 };
     let op = [];
@@ -1051,21 +1025,13 @@ export default function AddUpdatePolicyForm() {
               form: {
                 mutators: { push: addPolicyItem }
               },
-              dirtyFields,
-              modified,
-              initialValues
+              initialValues,
+              pristine
             }) => (
               <>
                 <PromptDialog
                   isDirtyField={
-                    dirty == true || !isEqual(initialValues, values)
-                      ? isDirtyFieldCheck(
-                          dirtyFields,
-                          modified,
-                          values,
-                          initialValues
-                        )
-                      : false
+                    dirty && !isEqual(values, initialValues) && !pristine
                   }
                   isUnblock={preventUnBlock}
                 />
@@ -1536,6 +1502,8 @@ export default function AddUpdatePolicyForm() {
                                     </Button>
                                   </Col>
                                 )}
+                                {fields.length > 1 &&
+                                  index < fields.length - 1 && <hr />}
                               </Row>
                             ))
                           }

--- a/security-admin/src/main/webapp/react-webapp/src/views/PolicyListing/NewPolicyForm/EditNewPolicyForm/EditPolicyForm.jsx
+++ b/security-admin/src/main/webapp/react-webapp/src/views/PolicyListing/NewPolicyForm/EditNewPolicyForm/EditPolicyForm.jsx
@@ -43,7 +43,9 @@ import {
   has,
   maxBy,
   forIn,
-  includes
+  includes,
+  filter,
+  isEqual
 } from "lodash";
 import moment from "moment";
 import {
@@ -354,7 +356,7 @@ const getPolicyItemsVal = (formData, name, finalAccessTypes) => {
         );
       } else if (isArray(key.accesses) && key.accesses.length > 0) {
         const validValues = map(finalAccessTypes, "value");
-        const result = _.filter(key.accesses, (item) =>
+        const result = filter(key.accesses, (item) =>
           includes(validValues, item.type)
         );
         obj.accesses = result.map((a) => {
@@ -713,11 +715,14 @@ export default function EditPolicyForm() {
             invalid,
             errors,
             dirty,
-            pristine
+            pristine,
+            initialValues
           }) => (
             <form onSubmit={submitForm} noValidate>
               <PromptDialog
-                isDirtyField={dirty && !pristine}
+                isDirtyField={
+                  dirty && !isEqual(values, initialValues) && !pristine
+                }
                 isUnblock={preventUnBlock}
               />
 

--- a/security-admin/src/main/webapp/react-webapp/src/views/Resources/ResourceComp.jsx
+++ b/security-admin/src/main/webapp/react-webapp/src/views/Resources/ResourceComp.jsx
@@ -179,18 +179,24 @@ export default function ResourceComp(props) {
         as={Row}
         className="mb-4 align-items-start"
         controlId={`Resource-${levelKey}`}
-        key={`Resource-${levelKey}`}
+        key={`${name}-${levelKey}`}
       >
         <Col className="column-1-fixed">
           <Field
-            defaultValue={!policyId && getResourceLabelOp(levelKey, index)[0]}
+            initialValue={
+              !policyId && !formValues?.[resourceKey]
+                ? getResourceLabelOp(levelKey, index)[0]
+                : undefined
+            }
             name={
               isMultiResources
                 ? `${name}.resourceName-${levelKey}`
                 : `resourceName-${levelKey}`
             }
-            render={({ input }) =>
-              formValues[resourceKey] ? (
+            render={({ input }) => {
+              const hasResourceData = Boolean(formValues?.[resourceKey]);
+
+              return hasResourceData ? (
                 renderResourceSelect(levelKey, index) ? (
                   <span className="float-end fnt-14">
                     <FormB.Label className="position-relative">
@@ -217,8 +223,8 @@ export default function ResourceComp(props) {
                     <RenderValidateField name={`resourceName-${levelKey}`} />
                   </div>
                 )
-              ) : null
-            }
+              ) : null;
+            }}
           />
         </Col>
 
@@ -249,6 +255,14 @@ export default function ResourceComp(props) {
                         ? `${name}.isExcludesSupport-${levelKey}`
                         : `isExcludesSupport-${levelKey}`
                     }
+                    key={
+                      isMultiResources
+                        ? `${name}.isExcludesSupport-${levelKey}`
+                        : `isExcludesSupport-${levelKey}`
+                    }
+                    initialValue={
+                      formValues?.[`isExcludesSupport-${levelKey}`] ?? true
+                    }
                     render={({ input }) => (
                       <BootstrapSwitchButton
                         {...input}
@@ -273,6 +287,14 @@ export default function ResourceComp(props) {
                       isMultiResources
                         ? `${name}.isRecursiveSupport-${levelKey}`
                         : `isRecursiveSupport-${levelKey}`
+                    }
+                    key={
+                      isMultiResources
+                        ? `${name}.isRecursiveSupport-${levelKey}`
+                        : `isRecursiveSupport-${levelKey}`
+                    }
+                    initialValue={
+                      formValues?.[`isRecursiveSupport-${levelKey}`] ?? true
                     }
                     render={({ input }) => (
                       <BootstrapSwitchButton

--- a/security-admin/src/main/webapp/react-webapp/src/views/Resources/ResourceSelectComp.jsx
+++ b/security-admin/src/main/webapp/react-webapp/src/views/Resources/ResourceSelectComp.jsx
@@ -167,11 +167,12 @@ export default function ResourceSelectComp(props) {
 
   return (
     <Field
-      key={formValues[`resourceName-${levelKey}`].name}
+      key={isMultiResources ? `${name}-value-${levelKey}` : `value-${levelKey}`}
       className="form-control"
       name={
         isMultiResources ? `${name}.value-${levelKey}` : `value-${levelKey}`
       }
+      initialValue={formValues?.[`value-${levelKey}`] || []}
       validate={
         formValues &&
         formValues[`resourceName-${levelKey}`]?.mandatory &&


### PR DESCRIPTION
## What changes were proposed in this pull request?
A blank resource type is created when users try to add a new resource type in the global policy creation form. This prevents users from successfully adding resources. It leads to confusion and potential policy errors.

Steps to reproduce
Login to Ranger Admin with role_admin user.

Click on the create new policy button below the Ranger icon on the left-hand side.

Follow these steps in the global policy creation form:

Step 1 (Service): Select Service Type (Atlas), Service Name (atlas) and click Next.

Step 2 (Resources): Add type-category and atlas-service resources. Click Next.

Step 3 (Configure Access Rules): Go back to Step 2, delete anyone or both the original resources, and add a new resource type.

Observe that a blank resource type gets created.

Expected behaviour
The resource type drop down should display available options when adding a new resource type.

Actual behaviour
A blank space is created instead of showing the resource type options when trying to add a new resource type.


## How was this patch tested?
1) Applied the patch locally.
2) Verified that the build completed successfully.
3) Checked that the development server started and worked properly.
4) Performed UI-level sanity testing on the following modules and pages.

- Service
- Policy
- User, Group, Role
