### PR TITLE
RANGER-5700: Support SPIFFE-based authn via HTTP headers

### DIFF
--- a/common-utils/src/main/java/org/apache/ranger/plugin/util/SpiffeIdUtil.java
+++ b/common-utils/src/main/java/org/apache/ranger/plugin/util/SpiffeIdUtil.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.plugin.util;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Helper for extracting a service-account identity from a SPIFFE ID.
+ *
+ * <p>A SPIFFE ID has the form {@code spiffe://<trust-domain>/ns/<namespace>/sa/<service-account>};
+ * for service-to-service authentication the receiving server trusts the workload
+ * identity carried in a header (e.g. {@code x-service-spiffe-id}) and uses
+ * the trailing service-account segment as the authenticated principal.
+ */
+public final class SpiffeIdUtil {
+    private static final String SPIFFE_SCHEME     = "spiffe://";
+    private static final String HEADER_NAMES_SEP  = ",";
+
+    private SpiffeIdUtil() {
+        // to block instantiation
+    }
+
+    /**
+     * Parses a configured, comma-separated list of SPIFFE header names into an ordered list of
+     * trimmed, non-empty names. Supports a single header name as a list of length one.
+     *
+     * @param configValue the raw config value (e.g. {@code x-awc-source-workload-id, x-other-id})
+     * @return an ordered, immutable list of header names; empty when the input is blank
+     */
+    public static List<String> parseHeaderNames(String configValue) {
+        if (StringUtils.isBlank(configValue)) {
+            return Collections.emptyList();
+        }
+
+        List<String> ret = new ArrayList<>();
+
+        for (String name : configValue.split(HEADER_NAMES_SEP)) {
+            String trimmed = StringUtils.trimToNull(name);
+
+            if (trimmed != null) {
+                ret.add(trimmed);
+            }
+        }
+
+        return Collections.unmodifiableList(ret);
+    }
+
+    /**
+     * Extracts the service-account name (the last non-empty path segment) from a
+     * SPIFFE ID such as {@code spiffe://my-cluster/ns/service-namespace/sa/service-sa}.
+     *
+     * @param spiffeId the raw SPIFFE ID value from the request header
+     * @return the trailing service-account segment (e.g. {@code service-sa}), or
+     *         {@code null} if the input is blank or not a well-formed SPIFFE ID
+     */
+    public static String extractServiceAccount(String spiffeId) {
+        if (StringUtils.isBlank(spiffeId)) {
+            return null;
+        }
+
+        String trimmed = spiffeId.trim();
+
+        if (!trimmed.startsWith(SPIFFE_SCHEME)) {
+            return null;
+        }
+
+        String path = StringUtils.stripEnd(trimmed, "/");
+        int    idx  = path.lastIndexOf('/');
+
+        return idx >= 0 && idx < path.length() - 1 ? path.substring(idx + 1) : null;
+    }
+}

--- a/common-utils/src/main/java/org/apache/ranger/plugin/util/SpiffeIdUtil.java
+++ b/common-utils/src/main/java/org/apache/ranger/plugin/util/SpiffeIdUtil.java
@@ -39,16 +39,20 @@ public final class SpiffeIdUtil {
     private static final String  HEADER_NAMES_SEP  = ",";
 
     /**
-     * Matches {@code spiffe://<trust-domain>/ns/<namespace>/sa/<service-account>}.
-     *
-     * <p>The trust-domain is a DNS-style label set (lowercase alphanumerics, {@code -} and {@code .});
-     * the namespace and service-account are RFC-1123 labels (lowercase alphanumerics and {@code -},
-     * not starting or ending with {@code -}), matching Kubernetes naming. This deliberately excludes
-     * uppercase, whitespace and control characters so the extracted principal is well-formed.
-     * The service-account is exposed via the named group {@code sa}.
+     * Matches {@code spiffe://<trust-domain>/ns/<namespace>/sa/<service-account>} using the character
+     * sets from the SPIFFE-ID specification:
+     * <ul>
+     *   <li>trust-domain: lowercase letters, digits, {@code .}, {@code -}, {@code _} (the spec requires
+     *       the trust domain to be lowercase);
+     *   <li>namespace and service-account: ASCII letters (any case), digits, {@code .}, {@code -}, {@code _}
+     *       (SPIFFE path segments are case-sensitive).
+     * </ul>
+     * All segments must be non-empty. This is an allow-list of safe characters, so whitespace, control
+     * characters and {@code /} are excluded, keeping the extracted principal well-formed. The
+     * service-account is exposed via the named group {@code sa}.
      */
     private static final Pattern SPIFFE_ID_PATTERN = Pattern.compile(
-            "^spiffe://[a-z0-9]([-.a-z0-9]*[a-z0-9])?/ns/[a-z0-9]([-a-z0-9]*[a-z0-9])?/sa/(?<sa>[a-z0-9]([-a-z0-9]*[a-z0-9])?)$");
+            "^spiffe://[a-z0-9._-]+/ns/[A-Za-z0-9._-]+/sa/(?<sa>[A-Za-z0-9._-]+)$");
 
     private SpiffeIdUtil() {
         // to block instantiation

--- a/common-utils/src/main/java/org/apache/ranger/plugin/util/SpiffeIdUtil.java
+++ b/common-utils/src/main/java/org/apache/ranger/plugin/util/SpiffeIdUtil.java
@@ -64,7 +64,7 @@ public final class SpiffeIdUtil {
      * Parses a configured, comma-separated list of SPIFFE header names into an ordered list of
      * trimmed, non-empty names. Supports a single header name as a list of length one.
      *
-     * @param configValue the raw config value (e.g. {@code x-awc-source-workload-id, x-other-id})
+     * @param configValue the raw config value (e.g. {@code X-Spiffe-Id, X-Workload-Id})
      * @return an ordered, immutable list of header names; empty when the input is blank
      */
     public static List<String> parseHeaderNames(String configValue) {

--- a/common-utils/src/main/java/org/apache/ranger/plugin/util/SpiffeIdUtil.java
+++ b/common-utils/src/main/java/org/apache/ranger/plugin/util/SpiffeIdUtil.java
@@ -39,10 +39,16 @@ public final class SpiffeIdUtil {
     private static final String  HEADER_NAMES_SEP  = ",";
 
     /**
-     * Matches {@code spiffe://<trust-domain>/ns/<namespace>/sa/<service-account>}, where each of the
-     * three segments is non-empty and contains no {@code /}. Group 3 is the service-account name.
+     * Matches {@code spiffe://<trust-domain>/ns/<namespace>/sa/<service-account>}.
+     *
+     * <p>The trust-domain is a DNS-style label set (lowercase alphanumerics, {@code -} and {@code .});
+     * the namespace and service-account are RFC-1123 labels (lowercase alphanumerics and {@code -},
+     * not starting or ending with {@code -}), matching Kubernetes naming. This deliberately excludes
+     * uppercase, whitespace and control characters so the extracted principal is well-formed.
+     * The service-account is exposed via the named group {@code sa}.
      */
-    private static final Pattern SPIFFE_ID_PATTERN = Pattern.compile("^spiffe://([^/]+)/ns/([^/]+)/sa/([^/]+)$");
+    private static final Pattern SPIFFE_ID_PATTERN = Pattern.compile(
+            "^spiffe://[a-z0-9]([-.a-z0-9]*[a-z0-9])?/ns/[a-z0-9]([-a-z0-9]*[a-z0-9])?/sa/(?<sa>[a-z0-9]([-a-z0-9]*[a-z0-9])?)$");
 
     private SpiffeIdUtil() {
         // to block instantiation
@@ -96,7 +102,7 @@ public final class SpiffeIdUtil {
     public static String extractServiceAccount(String spiffeId) {
         Matcher matcher = matchSpiffeId(spiffeId);
 
-        return matcher != null ? matcher.group(3) : null;
+        return matcher != null ? matcher.group("sa") : null;
     }
 
     /**

--- a/common-utils/src/main/java/org/apache/ranger/plugin/util/SpiffeIdUtil.java
+++ b/common-utils/src/main/java/org/apache/ranger/plugin/util/SpiffeIdUtil.java
@@ -48,11 +48,13 @@ public final class SpiffeIdUtil {
      *       (SPIFFE path segments are case-sensitive).
      * </ul>
      * All segments must be non-empty. This is an allow-list of safe characters, so whitespace, control
-     * characters and {@code /} are excluded, keeping the extracted principal well-formed. The
-     * service-account is exposed via the named group {@code sa}.
+     * characters and {@code /} are excluded, keeping the extracted principal well-formed. Per the spec,
+     * the namespace and service-account path segments must not be the relative modifiers {@code .} or
+     * {@code ..} (enforced by the leading negative look-aheads). The service-account is exposed via the
+     * named group {@code sa}.
      */
     private static final Pattern SPIFFE_ID_PATTERN = Pattern.compile(
-            "^spiffe://[a-z0-9._-]+/ns/[A-Za-z0-9._-]+/sa/(?<sa>[A-Za-z0-9._-]+)$");
+            "^spiffe://[a-z0-9._-]+/ns/(?!\\.{1,2}/)[A-Za-z0-9._-]+/sa/(?<sa>(?!\\.{1,2}$)[A-Za-z0-9._-]+)$");
 
     private SpiffeIdUtil() {
         // to block instantiation

--- a/common-utils/src/main/java/org/apache/ranger/plugin/util/SpiffeIdUtil.java
+++ b/common-utils/src/main/java/org/apache/ranger/plugin/util/SpiffeIdUtil.java
@@ -24,18 +24,25 @@ import org.apache.commons.lang3.StringUtils;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
- * Helper for extracting a service-account identity from a SPIFFE ID.
+ * Helper for validating a SPIFFE ID and extracting the service-account identity from it.
  *
- * <p>A SPIFFE ID has the form {@code spiffe://<trust-domain>/ns/<namespace>/sa/<service-account>};
+ * <p>A SPIFFE ID is expected in the exact form {@code spiffe://<trust-domain>/ns/<namespace>/sa/<service-account>};
  * for service-to-service authentication the receiving server trusts the workload
  * identity carried in a header (e.g. {@code x-service-spiffe-id}) and uses
  * the trailing service-account segment as the authenticated principal.
  */
 public final class SpiffeIdUtil {
-    private static final String SPIFFE_SCHEME     = "spiffe://";
-    private static final String HEADER_NAMES_SEP  = ",";
+    private static final String  HEADER_NAMES_SEP  = ",";
+
+    /**
+     * Matches {@code spiffe://<trust-domain>/ns/<namespace>/sa/<service-account>}, where each of the
+     * three segments is non-empty and contains no {@code /}. Group 3 is the service-account name.
+     */
+    private static final Pattern SPIFFE_ID_PATTERN = Pattern.compile("^spiffe://([^/]+)/ns/([^/]+)/sa/([^/]+)$");
 
     private SpiffeIdUtil() {
         // to block instantiation
@@ -67,27 +74,45 @@ public final class SpiffeIdUtil {
     }
 
     /**
-     * Extracts the service-account name (the last non-empty path segment) from a
-     * SPIFFE ID such as {@code spiffe://my-cluster/ns/service-namespace/sa/service-sa}.
+     * Validates that the given value is a well-formed SPIFFE ID in the exact form
+     * {@code spiffe://<trust-domain>/ns/<namespace>/sa/<service-account>} with non-empty segments.
      *
      * @param spiffeId the raw SPIFFE ID value from the request header
-     * @return the trailing service-account segment (e.g. {@code service-sa}), or
+     * @return {@code true} if the value matches the expected SPIFFE ID format; {@code false} otherwise
+     */
+    public static boolean isValidSpiffeId(String spiffeId) {
+        return matchSpiffeId(spiffeId) != null;
+    }
+
+    /**
+     * Extracts the service-account name from a SPIFFE ID such as
+     * {@code spiffe://my-cluster/ns/service-namespace/sa/service-sa}. The value must match the exact
+     * SPIFFE ID format (see {@link #isValidSpiffeId(String)}); otherwise {@code null} is returned.
+     *
+     * @param spiffeId the raw SPIFFE ID value from the request header
+     * @return the service-account segment (e.g. {@code service-sa}), or
      *         {@code null} if the input is blank or not a well-formed SPIFFE ID
      */
     public static String extractServiceAccount(String spiffeId) {
+        Matcher matcher = matchSpiffeId(spiffeId);
+
+        return matcher != null ? matcher.group(3) : null;
+    }
+
+    /**
+     * Matches the given value against the expected SPIFFE ID format, computing the {@link Matcher} once.
+     *
+     * @param spiffeId the raw SPIFFE ID value from the request header
+     * @return a matched {@link Matcher} (with groups available) if the value is a well-formed SPIFFE ID;
+     *         {@code null} if the value is blank or does not match
+     */
+    private static Matcher matchSpiffeId(String spiffeId) {
         if (StringUtils.isBlank(spiffeId)) {
             return null;
         }
 
-        String trimmed = spiffeId.trim();
+        Matcher matcher = SPIFFE_ID_PATTERN.matcher(spiffeId.trim());
 
-        if (!trimmed.startsWith(SPIFFE_SCHEME)) {
-            return null;
-        }
-
-        String path = StringUtils.stripEnd(trimmed, "/");
-        int    idx  = path.lastIndexOf('/');
-
-        return idx >= 0 && idx < path.length() - 1 ? path.substring(idx + 1) : null;
+        return matcher.matches() ? matcher : null;
     }
 }

--- a/common-utils/src/test/java/org/apache/ranger/plugin/util/SpiffeIdUtilTest.java
+++ b/common-utils/src/test/java/org/apache/ranger/plugin/util/SpiffeIdUtilTest.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.plugin.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SpiffeIdUtilTest {
+    private static final String VALID = "spiffe://my-cluster/ns/service-namespace/sa/service-sa";
+
+    @Test
+    void isValidSpiffeId_acceptsExactFormat() {
+        assertTrue(SpiffeIdUtil.isValidSpiffeId(VALID));
+        assertTrue(SpiffeIdUtil.isValidSpiffeId("  " + VALID + "  ")); // trimmed
+    }
+
+    @Test
+    void isValidSpiffeId_rejectsMalformed() {
+        assertFalse(SpiffeIdUtil.isValidSpiffeId(null));
+        assertFalse(SpiffeIdUtil.isValidSpiffeId(""));
+        assertFalse(SpiffeIdUtil.isValidSpiffeId("   "));
+        assertFalse(SpiffeIdUtil.isValidSpiffeId("not-a-spiffe-id"));
+        assertFalse(SpiffeIdUtil.isValidSpiffeId("https://my-cluster/ns/n/sa/s"));   // wrong scheme
+        assertFalse(SpiffeIdUtil.isValidSpiffeId("spiffe://my-cluster/sa/service-sa")); // missing /ns/
+        assertFalse(SpiffeIdUtil.isValidSpiffeId("spiffe://my-cluster/ns/n"));       // missing /sa/
+        assertFalse(SpiffeIdUtil.isValidSpiffeId("spiffe://my-cluster/ns//sa/s"));   // empty namespace
+        assertFalse(SpiffeIdUtil.isValidSpiffeId("spiffe:///ns/n/sa/s"));            // empty trust domain
+        assertFalse(SpiffeIdUtil.isValidSpiffeId("spiffe://my-cluster/ns/n/sa/"));   // empty service account
+        assertFalse(SpiffeIdUtil.isValidSpiffeId(VALID + "/"));                      // trailing slash
+        assertFalse(SpiffeIdUtil.isValidSpiffeId(VALID + "/extra"));                 // extra segment
+        assertFalse(SpiffeIdUtil.isValidSpiffeId("spiffe://my-cluster/sa/s/ns/n"));  // wrong order
+    }
+
+    @Test
+    void isValidSpiffeId_rejectsUnsafeOrIllegalCharacters() {
+        assertFalse(SpiffeIdUtil.isValidSpiffeId("spiffe://my-cluster/ns/prod/sa/service sa"));   // embedded space
+        assertFalse(SpiffeIdUtil.isValidSpiffeId("spiffe://my-cluster/ns/prod/sa/service\tsa"));  // embedded tab
+        assertFalse(SpiffeIdUtil.isValidSpiffeId("spiffe://my-cluster/ns/prod/sa/service\nsa"));  // embedded newline
+        assertFalse(SpiffeIdUtil.isValidSpiffeId("spiffe://my-cluster/ns/prod/sa/svc@admin"));    // illegal char '@'
+        assertFalse(SpiffeIdUtil.isValidSpiffeId("spiffe://My-Cluster/ns/prod/sa/service-sa"));   // trust domain must be lowercase per spec
+
+        assertNull(SpiffeIdUtil.extractServiceAccount("spiffe://my-cluster/ns/prod/sa/service sa"));
+        assertNull(SpiffeIdUtil.extractServiceAccount("spiffe://my-cluster/ns/prod/sa/service\nsa"));
+    }
+
+    @Test
+    void isValidSpiffeId_acceptsSpecAllowedCharacters() {
+        // SPIFFE path segments are case-sensitive and allow letters (any case), digits, '.', '-', '_'.
+        assertTrue(SpiffeIdUtil.isValidSpiffeId("spiffe://my-cluster.example.com/ns/service-namespace/sa/service-sa"));
+        assertEquals("Service-SA", SpiffeIdUtil.extractServiceAccount("spiffe://my-cluster/ns/Prod/sa/Service-SA")); // mixed case
+        assertEquals("svc_01", SpiffeIdUtil.extractServiceAccount("spiffe://cluster1/ns/ns_2/sa/svc_01"));           // underscore
+        assertEquals("svc-01", SpiffeIdUtil.extractServiceAccount("spiffe://cluster1/ns/ns-2/sa/svc-01"));           // hyphen/digits
+    }
+
+    @Test
+    void extractServiceAccount_returnsSaOnlyForValidId() {
+        assertEquals("service-sa", SpiffeIdUtil.extractServiceAccount(VALID));
+        assertEquals("service-sa", SpiffeIdUtil.extractServiceAccount("  " + VALID + "  "));
+    }
+
+    @Test
+    void extractServiceAccount_returnsNullForMalformedId() {
+        assertNull(SpiffeIdUtil.extractServiceAccount(null));
+        assertNull(SpiffeIdUtil.extractServiceAccount(""));
+        assertNull(SpiffeIdUtil.extractServiceAccount("not-a-spiffe-id"));
+        assertNull(SpiffeIdUtil.extractServiceAccount("spiffe://my-cluster/sa/service-sa"));
+        assertNull(SpiffeIdUtil.extractServiceAccount("spiffe://my-cluster/ns/n/sa/"));
+        assertNull(SpiffeIdUtil.extractServiceAccount(VALID + "/extra"));
+    }
+
+    @Test
+    void extractServiceAccount_handlesRealisticProductionIds() {
+        // Kubernetes trust domain with a DNS-style cluster name and typical namespace/service-account names.
+        assertEquals("nginx-ingress",
+                SpiffeIdUtil.extractServiceAccount("spiffe://prod-cluster.k8s.example.com/ns/ingress-nginx/sa/nginx-ingress"));
+
+        // Cloud/mesh style trust domain (e.g. the header value from the PR description).
+        assertEquals("service-sa",
+                SpiffeIdUtil.extractServiceAccount("spiffe://my-cluster/ns/service-namespace/sa/service-sa"));
+
+        // Istio-style default service account in an application namespace.
+        assertEquals("default",
+                SpiffeIdUtil.extractServiceAccount("spiffe://cluster.local/ns/payments/sa/default"));
+
+        // Namespace and service-account with digits and hyphens, as commonly generated by platforms.
+        assertEquals("spark-driver-01",
+                SpiffeIdUtil.extractServiceAccount("spiffe://data-plane.internal/ns/team-analytics-42/sa/spark-driver-01"));
+
+        assertTrue(SpiffeIdUtil.isValidSpiffeId("spiffe://prod-cluster.k8s.example.com/ns/ingress-nginx/sa/nginx-ingress"));
+        assertTrue(SpiffeIdUtil.isValidSpiffeId("spiffe://cluster.local/ns/payments/sa/default"));
+    }
+
+    @Test
+    void rejectsSpecValidButNonConformingSpiffeId() {
+        // These are well-formed SPIFFE IDs per the SPIFFE spec (valid scheme + trust domain + path),
+        // but they do not follow the expected spiffe://<trust-domain>/ns/<namespace>/sa/<service-account>
+        // layout, so Ranger must reject them.
+        String workloadPath = "spiffe://example.org/workload/frontend"; // arbitrary path, no /ns//sa/
+        String nsOnly       = "spiffe://example.org/ns/prod";           // has /ns/ but no /sa/ segment
+
+        assertFalse(SpiffeIdUtil.isValidSpiffeId(workloadPath));
+        assertFalse(SpiffeIdUtil.isValidSpiffeId(nsOnly));
+        assertNull(SpiffeIdUtil.extractServiceAccount(workloadPath));
+        assertNull(SpiffeIdUtil.extractServiceAccount(nsOnly));
+    }
+
+    @Test
+    void parseHeaderNames_handlesSingleAndMultiple() {
+        assertTrue(SpiffeIdUtil.parseHeaderNames(null).isEmpty());
+        assertTrue(SpiffeIdUtil.parseHeaderNames("   ").isEmpty());
+
+        assertEquals(List.of("x-spiffe"), SpiffeIdUtil.parseHeaderNames("x-spiffe"));
+
+        List<String> names = SpiffeIdUtil.parseHeaderNames(" x-source , x-upstream ,");
+
+        assertEquals(List.of("x-source", "x-upstream"), names);
+    }
+}

--- a/common-utils/src/test/java/org/apache/ranger/plugin/util/SpiffeIdUtilTest.java
+++ b/common-utils/src/test/java/org/apache/ranger/plugin/util/SpiffeIdUtilTest.java
@@ -67,6 +67,22 @@ class SpiffeIdUtilTest {
     }
 
     @Test
+    void isValidSpiffeId_rejectsRelativePathModifierSegments() {
+        // Per SPIFFE spec 2.2, path segments must not be the relative modifiers '.' or '..'.
+        assertFalse(SpiffeIdUtil.isValidSpiffeId("spiffe://my-cluster/ns/./sa/service-sa"));   // namespace '.'
+        assertFalse(SpiffeIdUtil.isValidSpiffeId("spiffe://my-cluster/ns/../sa/service-sa"));  // namespace '..'
+        assertFalse(SpiffeIdUtil.isValidSpiffeId("spiffe://my-cluster/ns/prod/sa/."));         // service-account '.'
+        assertFalse(SpiffeIdUtil.isValidSpiffeId("spiffe://my-cluster/ns/prod/sa/.."));        // service-account '..'
+
+        assertNull(SpiffeIdUtil.extractServiceAccount("spiffe://my-cluster/ns/prod/sa/."));
+        assertNull(SpiffeIdUtil.extractServiceAccount("spiffe://my-cluster/ns/../sa/service-sa"));
+
+        // Dots inside a segment (not a bare '.'/'..') remain valid.
+        assertTrue(SpiffeIdUtil.isValidSpiffeId("spiffe://my-cluster/ns/prod/sa/svc.v1"));
+        assertEquals("svc.v1", SpiffeIdUtil.extractServiceAccount("spiffe://my-cluster/ns/..prod/sa/svc.v1"));
+    }
+
+    @Test
     void isValidSpiffeId_acceptsSpecAllowedCharacters() {
         // SPIFFE path segments are case-sensitive and allow letters (any case), digits, '.', '-', '_'.
         assertTrue(SpiffeIdUtil.isValidSpiffeId("spiffe://my-cluster.example.com/ns/service-namespace/sa/service-sa"));

--- a/dev-support/ranger-docker/scripts/pdp/ranger-pdp-site.xml
+++ b/dev-support/ranger-docker/scripts/pdp/ranger-pdp-site.xml
@@ -115,6 +115,12 @@
     <value>X-Forwarded-User</value>
   </property>
 
+  <!-- service-to-service authentication via SPIFFE ID (comma-separated header names) -->
+  <property>
+    <name>ranger.pdp.authn.header.spiffe</name>
+    <value>x-awc-source-workload-id</value>
+  </property>
+
   <!-- JWT bearer token authentication for incoming REST requests -->
   <property>
     <name>ranger.pdp.authn.jwt.enabled</name>

--- a/dev-support/ranger-docker/scripts/pdp/ranger-pdp-site.xml
+++ b/dev-support/ranger-docker/scripts/pdp/ranger-pdp-site.xml
@@ -118,7 +118,7 @@
   <!-- service-to-service authentication via SPIFFE ID (comma-separated header names) -->
   <property>
     <name>ranger.pdp.authn.header.spiffe</name>
-    <value>x-awc-source-workload-id</value>
+    <value>X-Spiffe-Id</value>
   </property>
 
   <!-- JWT bearer token authentication for incoming REST requests -->

--- a/pdp/conf.dist/README-k8s.md
+++ b/pdp/conf.dist/README-k8s.md
@@ -82,6 +82,7 @@ When configuring inbound PDP authentication in `ranger-pdp-site.xml`, use the
 - `ranger.pdp.authn.types`
 - `ranger.pdp.authn.header.enabled`
 - `ranger.pdp.authn.header.username`
+- `ranger.pdp.authn.header.spiffe`
 - `ranger.pdp.authn.jwt.enabled`
 - `ranger.pdp.authn.jwt.provider.url`
 - `ranger.pdp.authn.jwt.public.key`

--- a/pdp/conf.dist/ranger-pdp-site.xml
+++ b/pdp/conf.dist/ranger-pdp-site.xml
@@ -145,6 +145,13 @@
     <description>HTTP header name from which the authenticated username is read.</description>
   </property>
 
+  <!-- optional; enables service-to-service authentication via SPIFFE ID -->
+  <property>
+    <name>ranger.pdp.authn.header.spiffe</name>
+    <value></value>
+    <description>Comma-separated list of HTTP header name(s) carrying a SPIFFE ID (e.g. spiffe://cluster/ns/&lt;ns&gt;/sa/&lt;service-account&gt;). A single header name is also valid. The trailing service-account segment is used as the authenticated principal. When multiple headers are configured, the first one carrying a well-formed SPIFFE ID is used. Consulted only when the username header is absent.</description>
+  </property>
+
   <!-- JWT bearer token authentication for incoming REST requests -->
   <property>
     <name>ranger.pdp.authn.jwt.enabled</name>

--- a/pdp/src/main/java/org/apache/ranger/pdp/RangerPdpServer.java
+++ b/pdp/src/main/java/org/apache/ranger/pdp/RangerPdpServer.java
@@ -225,6 +225,7 @@ public class RangerPdpServer {
         // HTTP Header auth
         authFilterDef.addInitParameter(RangerPdpConstants.PROP_AUTHN_HEADER_ENABLED, Boolean.toString(config.isHeaderAuthnEnabled()));
         authFilterDef.addInitParameter(RangerPdpConstants.PROP_AUTHN_HEADER_USERNAME, config.getHeaderAuthnUsername());
+        authFilterDef.addInitParameter(RangerPdpConstants.PROP_AUTHN_HEADER_SPIFFE, config.getHeaderAuthnSpiffe());
 
         // JWT bearer token auth
         authFilterDef.addInitParameter(RangerPdpConstants.PROP_AUTHN_JWT_ENABLED, Boolean.toString(config.isJwtAuthnEnabled()));

--- a/pdp/src/main/java/org/apache/ranger/pdp/config/RangerPdpConfig.java
+++ b/pdp/src/main/java/org/apache/ranger/pdp/config/RangerPdpConfig.java
@@ -143,6 +143,10 @@ public class RangerPdpConfig {
         return get(RangerPdpConstants.PROP_AUTHN_HEADER_USERNAME, "");
     }
 
+    public String getHeaderAuthnSpiffe() {
+        return get(RangerPdpConstants.PROP_AUTHN_HEADER_SPIFFE, "");
+    }
+
     // --- JWT bearer token auth ---
     public boolean isJwtAuthnEnabled() {
         return getBoolean(RangerPdpConstants.PROP_AUTHN_JWT_ENABLED, false);

--- a/pdp/src/main/java/org/apache/ranger/pdp/config/RangerPdpConstants.java
+++ b/pdp/src/main/java/org/apache/ranger/pdp/config/RangerPdpConstants.java
@@ -65,6 +65,7 @@ public final class RangerPdpConstants {
     public static final String PROP_AUTHN_HEADER_PREFIX   = PROP_AUTHN_PREFIX + "header.";
     public static final String PROP_AUTHN_HEADER_ENABLED  = PROP_AUTHN_HEADER_PREFIX + "enabled";
     public static final String PROP_AUTHN_HEADER_USERNAME = PROP_AUTHN_HEADER_PREFIX + "username";
+    public static final String PROP_AUTHN_HEADER_SPIFFE   = PROP_AUTHN_HEADER_PREFIX + "spiffe";
 
     // JWT auth
     public static final String PROP_AUTHN_JWT_PREFIX       = PROP_AUTHN_PREFIX + "jwt.";

--- a/pdp/src/main/java/org/apache/ranger/pdp/security/HttpHeaderAuthNHandler.java
+++ b/pdp/src/main/java/org/apache/ranger/pdp/security/HttpHeaderAuthNHandler.java
@@ -21,12 +21,14 @@ package org.apache.ranger.pdp.security;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.ranger.pdp.config.RangerPdpConstants;
+import org.apache.ranger.plugin.util.SpiffeIdUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import java.util.List;
 import java.util.Properties;
 
 /**
@@ -44,24 +46,44 @@ import java.util.Properties;
 public class HttpHeaderAuthNHandler implements PdpAuthNHandler {
     private static final Logger LOG = LoggerFactory.getLogger(HttpHeaderAuthNHandler.class);
 
-    public static final String AUTH_TYPE = "HEADER";
+    public static final String AUTH_TYPE        = "HEADER";
+    public static final String AUTH_TYPE_SPIFFE = "SPIFFE";
 
-    private String usernameHeader;
+    private String       usernameHeader;
+    private List<String> spiffeHeaders;
 
     @Override
     public void init(Properties config) {
         usernameHeader = config.getProperty(RangerPdpConstants.PROP_AUTHN_HEADER_USERNAME);
+        spiffeHeaders  = SpiffeIdUtil.parseHeaderNames(config.getProperty(RangerPdpConstants.PROP_AUTHN_HEADER_SPIFFE));
 
-        LOG.info("HttpHeaderAuthHandler initialized; username header={}", usernameHeader);
+        LOG.info("HttpHeaderAuthHandler initialized; username header={}, spiffe headers={}", usernameHeader, spiffeHeaders);
     }
 
     @Override
     public Result authenticate(HttpServletRequest request, HttpServletResponse response) {
-        String userName = request.getHeader(usernameHeader);
+        String userName = StringUtils.isNotBlank(usernameHeader) ? request.getHeader(usernameHeader) : null;
 
-        LOG.debug("authenticate(): user={} (from header {})", userName, usernameHeader);
+        if (StringUtils.isNotBlank(userName)) {
+            LOG.debug("authenticate(): user={} (from header {})", userName, usernameHeader);
 
-        return StringUtils.isBlank(userName) ? Result.skip() : Result.authenticated(userName.trim(), AUTH_TYPE);
+            return Result.authenticated(userName.trim(), AUTH_TYPE);
+        }
+
+        for (String spiffeHeader : spiffeHeaders) {
+            String spiffeId       = request.getHeader(spiffeHeader);
+            String serviceAccount = SpiffeIdUtil.extractServiceAccount(spiffeId);
+
+            if (StringUtils.isNotBlank(serviceAccount)) {
+                LOG.debug("authenticate(): service-account={} (from SPIFFE header {})", serviceAccount, spiffeHeader);
+
+                return Result.authenticated(serviceAccount, AUTH_TYPE_SPIFFE);
+            } else if (StringUtils.isNotBlank(spiffeId)) {
+                LOG.warn("SPIFFE header '{}' value is not a well-formed SPIFFE ID", spiffeHeader);
+            }
+        }
+
+        return Result.skip();
     }
 
     @Override

--- a/pdp/src/main/java/org/apache/ranger/pdp/security/RangerPdpAuthNFilter.java
+++ b/pdp/src/main/java/org/apache/ranger/pdp/security/RangerPdpAuthNFilter.java
@@ -151,7 +151,8 @@ public class RangerPdpAuthNFilter implements Filter {
         switch (type) {
             case "header":
                 ret = getBoolean(filterConfig, RangerPdpConstants.PROP_AUTHN_HEADER_ENABLED) &&
-                        StringUtils.isNotBlank(filterConfig.getInitParameter(RangerPdpConstants.PROP_AUTHN_HEADER_USERNAME))
+                        (StringUtils.isNotBlank(filterConfig.getInitParameter(RangerPdpConstants.PROP_AUTHN_HEADER_USERNAME)) ||
+                                StringUtils.isNotBlank(filterConfig.getInitParameter(RangerPdpConstants.PROP_AUTHN_HEADER_SPIFFE)))
                         ? new HttpHeaderAuthNHandler() : null;
                 break;
             case "jwt":

--- a/pdp/src/main/resources/ranger-pdp-default.xml
+++ b/pdp/src/main/resources/ranger-pdp-default.xml
@@ -145,6 +145,13 @@
     <description>HTTP header name from which the authenticated username is read.</description>
   </property>
 
+  <!-- optional; enables service-to-service authentication via SPIFFE ID -->
+  <property>
+    <name>ranger.pdp.authn.header.spiffe</name>
+    <value></value>
+    <description>Comma-separated list of HTTP header name(s) carrying a SPIFFE ID (e.g. spiffe://cluster/ns/&lt;ns&gt;/sa/&lt;service-account&gt;). A single header name is also valid. The trailing service-account segment is used as the authenticated principal. When multiple headers are configured, the first one carrying a well-formed SPIFFE ID is used. Consulted only when the username header is absent.</description>
+  </property>
+
   <!-- JWT bearer token authentication for incoming REST requests -->
   <property>
     <name>ranger.pdp.authn.jwt.enabled</name>

--- a/pdp/src/test/java/org/apache/ranger/pdp/security/HttpHeaderAuthNHandlerTest.java
+++ b/pdp/src/test/java/org/apache/ranger/pdp/security/HttpHeaderAuthNHandlerTest.java
@@ -143,6 +143,23 @@ public class HttpHeaderAuthNHandlerTest {
         assertNull(result.getUserName());
     }
 
+    @Test
+    void testAuthenticate_specValidButNonConformingSpiffeHeaderSkips() {
+        HttpHeaderAuthNHandler handler = new HttpHeaderAuthNHandler();
+        Properties             config  = new Properties();
+
+        config.setProperty(RangerPdpConstants.PROP_AUTHN_HEADER_SPIFFE, "x-awc-source-workload-id");
+
+        handler.init(config);
+
+        // Valid SPIFFE ID per the SPIFFE spec, but not in the expected /ns/<ns>/sa/<sa> layout.
+        HttpServletRequest     request = requestWithHeader("x-awc-source-workload-id", "spiffe://example.org/workload/frontend");
+        PdpAuthNHandler.Result result  = handler.authenticate(request, null);
+
+        assertEquals(PdpAuthNHandler.Result.Status.SKIP, result.getStatus());
+        assertNull(result.getUserName());
+    }
+
     private static HttpServletRequest requestWithHeader(String expectedHeader, String headerValue) {
         return requestWithHeaders(Collections.singletonMap(expectedHeader, headerValue));
     }

--- a/pdp/src/test/java/org/apache/ranger/pdp/security/HttpHeaderAuthNHandlerTest.java
+++ b/pdp/src/test/java/org/apache/ranger/pdp/security/HttpHeaderAuthNHandlerTest.java
@@ -26,6 +26,9 @@ import javax.servlet.http.HttpServletRequest;
 
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Proxy;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -63,12 +66,93 @@ public class HttpHeaderAuthNHandlerTest {
         assertEquals("bob", result.getUserName());
     }
 
+    @Test
+    void testAuthenticate_usesSpiffeHeaderWhenUsernameAbsent() {
+        HttpHeaderAuthNHandler handler = new HttpHeaderAuthNHandler();
+        Properties             config  = new Properties();
+
+        config.setProperty(RangerPdpConstants.PROP_AUTHN_HEADER_USERNAME, "X-Authenticated-User");
+        config.setProperty(RangerPdpConstants.PROP_AUTHN_HEADER_SPIFFE, "x-awc-source-workload-id");
+
+        handler.init(config);
+
+        HttpServletRequest     request = requestWithHeader("x-awc-source-workload-id", "spiffe://my-cluster/ns/service-namespace/sa/service-sa");
+        PdpAuthNHandler.Result result  = handler.authenticate(request, null);
+
+        assertEquals(PdpAuthNHandler.Result.Status.AUTHENTICATED, result.getStatus());
+        assertEquals("service-sa", result.getUserName());
+        assertEquals(HttpHeaderAuthNHandler.AUTH_TYPE_SPIFFE, result.getAuthType());
+    }
+
+    @Test
+    void testAuthenticate_usernameTakesPrecedenceOverSpiffe() {
+        HttpHeaderAuthNHandler handler = new HttpHeaderAuthNHandler();
+        Properties             config  = new Properties();
+
+        config.setProperty(RangerPdpConstants.PROP_AUTHN_HEADER_USERNAME, "X-Authenticated-User");
+        config.setProperty(RangerPdpConstants.PROP_AUTHN_HEADER_SPIFFE, "x-awc-source-workload-id");
+
+        handler.init(config);
+
+        Map<String, String> headers = new HashMap<>();
+
+        headers.put("X-Authenticated-User", "bob");
+        headers.put("x-awc-source-workload-id", "spiffe://my-cluster/ns/service-namespace/sa/service-sa");
+
+        PdpAuthNHandler.Result result = handler.authenticate(requestWithHeaders(headers), null);
+
+        assertEquals(PdpAuthNHandler.Result.Status.AUTHENTICATED, result.getStatus());
+        assertEquals("bob", result.getUserName());
+        assertEquals(HttpHeaderAuthNHandler.AUTH_TYPE, result.getAuthType());
+    }
+
+    @Test
+    void testAuthenticate_multipleSpiffeHeadersUsesFirstValid() {
+        HttpHeaderAuthNHandler handler = new HttpHeaderAuthNHandler();
+        Properties             config  = new Properties();
+
+        config.setProperty(RangerPdpConstants.PROP_AUTHN_HEADER_SPIFFE, "x-awc-source-workload-id, x-awc-upstream-workload-id");
+
+        handler.init(config);
+
+        Map<String, String> headers = new HashMap<>();
+
+        headers.put("x-awc-source-workload-id", "not-a-spiffe-id");
+        headers.put("x-awc-upstream-workload-id", "spiffe://my-cluster/ns/service-namespace/sa/service-sa");
+
+        PdpAuthNHandler.Result result = handler.authenticate(requestWithHeaders(headers), null);
+
+        assertEquals(PdpAuthNHandler.Result.Status.AUTHENTICATED, result.getStatus());
+        assertEquals("service-sa", result.getUserName());
+        assertEquals(HttpHeaderAuthNHandler.AUTH_TYPE_SPIFFE, result.getAuthType());
+    }
+
+    @Test
+    void testAuthenticate_malformedSpiffeHeaderSkips() {
+        HttpHeaderAuthNHandler handler = new HttpHeaderAuthNHandler();
+        Properties             config  = new Properties();
+
+        config.setProperty(RangerPdpConstants.PROP_AUTHN_HEADER_SPIFFE, "x-awc-source-workload-id");
+
+        handler.init(config);
+
+        HttpServletRequest     request = requestWithHeader("x-awc-source-workload-id", "not-a-spiffe-id");
+        PdpAuthNHandler.Result result  = handler.authenticate(request, null);
+
+        assertEquals(PdpAuthNHandler.Result.Status.SKIP, result.getStatus());
+        assertNull(result.getUserName());
+    }
+
     private static HttpServletRequest requestWithHeader(String expectedHeader, String headerValue) {
+        return requestWithHeaders(Collections.singletonMap(expectedHeader, headerValue));
+    }
+
+    private static HttpServletRequest requestWithHeaders(Map<String, String> headers) {
         InvocationHandler invocationHandler = (proxy, method, args) -> {
             String methodName = method.getName();
 
             if ("getHeader".equals(methodName)) {
-                return expectedHeader.equals(args[0]) ? headerValue : null;
+                return headers.get(args[0]);
             } else if ("getHeaders".equals(methodName) || "getHeaderNames".equals(methodName)) {
                 return java.util.Collections.emptyEnumeration();
             } else if ("getMethod".equals(methodName)) {

--- a/pdp/src/test/java/org/apache/ranger/pdp/security/HttpHeaderAuthNHandlerTest.java
+++ b/pdp/src/test/java/org/apache/ranger/pdp/security/HttpHeaderAuthNHandlerTest.java
@@ -76,11 +76,12 @@ public class HttpHeaderAuthNHandlerTest {
 
         handler.init(config);
 
-        HttpServletRequest     request = requestWithHeader("x-awc-source-workload-id", "spiffe://my-cluster/ns/service-namespace/sa/service-sa");
+        // Realistic production SPIFFE ID: DNS-style Kubernetes cluster trust domain + namespace/service-account.
+        HttpServletRequest     request = requestWithHeader("x-awc-source-workload-id", "spiffe://prod-cluster.k8s.example.com/ns/ingress-nginx/sa/nginx-ingress");
         PdpAuthNHandler.Result result  = handler.authenticate(request, null);
 
         assertEquals(PdpAuthNHandler.Result.Status.AUTHENTICATED, result.getStatus());
-        assertEquals("service-sa", result.getUserName());
+        assertEquals("nginx-ingress", result.getUserName());
         assertEquals(HttpHeaderAuthNHandler.AUTH_TYPE_SPIFFE, result.getAuthType());
     }
 
@@ -161,7 +162,7 @@ public class HttpHeaderAuthNHandlerTest {
     }
 
     @Test
-    void testAuthenticate_nonRfc1123SpiffeHeaderSkips() {
+    void testAuthenticate_spiffeHeaderWithIllegalCharsSkips() {
         HttpHeaderAuthNHandler handler = new HttpHeaderAuthNHandler();
         Properties             config  = new Properties();
 
@@ -169,8 +170,8 @@ public class HttpHeaderAuthNHandlerTest {
 
         handler.init(config);
 
-        // Correct layout but the service-account is not an RFC-1123 label (contains an underscore).
-        HttpServletRequest     request = requestWithHeader("x-awc-source-workload-id", "spiffe://my-cluster/ns/prod/sa/service_sa");
+        // Correct layout but the service-account contains whitespace, which is not an allowed SPIFFE character.
+        HttpServletRequest     request = requestWithHeader("x-awc-source-workload-id", "spiffe://my-cluster/ns/prod/sa/service sa");
         PdpAuthNHandler.Result result  = handler.authenticate(request, null);
 
         assertEquals(PdpAuthNHandler.Result.Status.SKIP, result.getStatus());

--- a/pdp/src/test/java/org/apache/ranger/pdp/security/HttpHeaderAuthNHandlerTest.java
+++ b/pdp/src/test/java/org/apache/ranger/pdp/security/HttpHeaderAuthNHandlerTest.java
@@ -72,12 +72,12 @@ public class HttpHeaderAuthNHandlerTest {
         Properties             config  = new Properties();
 
         config.setProperty(RangerPdpConstants.PROP_AUTHN_HEADER_USERNAME, "X-Authenticated-User");
-        config.setProperty(RangerPdpConstants.PROP_AUTHN_HEADER_SPIFFE, "x-awc-source-workload-id");
+        config.setProperty(RangerPdpConstants.PROP_AUTHN_HEADER_SPIFFE, "X-Spiffe-Id");
 
         handler.init(config);
 
         // Realistic production SPIFFE ID: DNS-style Kubernetes cluster trust domain + namespace/service-account.
-        HttpServletRequest     request = requestWithHeader("x-awc-source-workload-id", "spiffe://prod-cluster.k8s.example.com/ns/ingress-nginx/sa/nginx-ingress");
+        HttpServletRequest     request = requestWithHeader("X-Spiffe-Id", "spiffe://prod-cluster.k8s.example.com/ns/ingress-nginx/sa/nginx-ingress");
         PdpAuthNHandler.Result result  = handler.authenticate(request, null);
 
         assertEquals(PdpAuthNHandler.Result.Status.AUTHENTICATED, result.getStatus());
@@ -91,14 +91,14 @@ public class HttpHeaderAuthNHandlerTest {
         Properties             config  = new Properties();
 
         config.setProperty(RangerPdpConstants.PROP_AUTHN_HEADER_USERNAME, "X-Authenticated-User");
-        config.setProperty(RangerPdpConstants.PROP_AUTHN_HEADER_SPIFFE, "x-awc-source-workload-id");
+        config.setProperty(RangerPdpConstants.PROP_AUTHN_HEADER_SPIFFE, "X-Spiffe-Id");
 
         handler.init(config);
 
         Map<String, String> headers = new HashMap<>();
 
         headers.put("X-Authenticated-User", "bob");
-        headers.put("x-awc-source-workload-id", "spiffe://my-cluster/ns/service-namespace/sa/service-sa");
+        headers.put("X-Spiffe-Id", "spiffe://my-cluster/ns/service-namespace/sa/service-sa");
 
         PdpAuthNHandler.Result result = handler.authenticate(requestWithHeaders(headers), null);
 
@@ -112,14 +112,14 @@ public class HttpHeaderAuthNHandlerTest {
         HttpHeaderAuthNHandler handler = new HttpHeaderAuthNHandler();
         Properties             config  = new Properties();
 
-        config.setProperty(RangerPdpConstants.PROP_AUTHN_HEADER_SPIFFE, "x-awc-source-workload-id, x-awc-upstream-workload-id");
+        config.setProperty(RangerPdpConstants.PROP_AUTHN_HEADER_SPIFFE, "X-Spiffe-Id, X-Workload-Id");
 
         handler.init(config);
 
         Map<String, String> headers = new HashMap<>();
 
-        headers.put("x-awc-source-workload-id", "not-a-spiffe-id");
-        headers.put("x-awc-upstream-workload-id", "spiffe://my-cluster/ns/service-namespace/sa/service-sa");
+        headers.put("X-Spiffe-Id", "not-a-spiffe-id");
+        headers.put("X-Workload-Id", "spiffe://my-cluster/ns/service-namespace/sa/service-sa");
 
         PdpAuthNHandler.Result result = handler.authenticate(requestWithHeaders(headers), null);
 
@@ -133,11 +133,11 @@ public class HttpHeaderAuthNHandlerTest {
         HttpHeaderAuthNHandler handler = new HttpHeaderAuthNHandler();
         Properties             config  = new Properties();
 
-        config.setProperty(RangerPdpConstants.PROP_AUTHN_HEADER_SPIFFE, "x-awc-source-workload-id");
+        config.setProperty(RangerPdpConstants.PROP_AUTHN_HEADER_SPIFFE, "X-Spiffe-Id");
 
         handler.init(config);
 
-        HttpServletRequest     request = requestWithHeader("x-awc-source-workload-id", "not-a-spiffe-id");
+        HttpServletRequest     request = requestWithHeader("X-Spiffe-Id", "not-a-spiffe-id");
         PdpAuthNHandler.Result result  = handler.authenticate(request, null);
 
         assertEquals(PdpAuthNHandler.Result.Status.SKIP, result.getStatus());
@@ -149,12 +149,12 @@ public class HttpHeaderAuthNHandlerTest {
         HttpHeaderAuthNHandler handler = new HttpHeaderAuthNHandler();
         Properties             config  = new Properties();
 
-        config.setProperty(RangerPdpConstants.PROP_AUTHN_HEADER_SPIFFE, "x-awc-source-workload-id");
+        config.setProperty(RangerPdpConstants.PROP_AUTHN_HEADER_SPIFFE, "X-Spiffe-Id");
 
         handler.init(config);
 
         // Valid SPIFFE ID per the SPIFFE spec, but not in the expected /ns/<ns>/sa/<sa> layout.
-        HttpServletRequest     request = requestWithHeader("x-awc-source-workload-id", "spiffe://example.org/workload/frontend");
+        HttpServletRequest     request = requestWithHeader("X-Spiffe-Id", "spiffe://example.org/workload/frontend");
         PdpAuthNHandler.Result result  = handler.authenticate(request, null);
 
         assertEquals(PdpAuthNHandler.Result.Status.SKIP, result.getStatus());
@@ -166,12 +166,12 @@ public class HttpHeaderAuthNHandlerTest {
         HttpHeaderAuthNHandler handler = new HttpHeaderAuthNHandler();
         Properties             config  = new Properties();
 
-        config.setProperty(RangerPdpConstants.PROP_AUTHN_HEADER_SPIFFE, "x-awc-source-workload-id");
+        config.setProperty(RangerPdpConstants.PROP_AUTHN_HEADER_SPIFFE, "X-Spiffe-Id");
 
         handler.init(config);
 
         // Correct layout but the service-account contains whitespace, which is not an allowed SPIFFE character.
-        HttpServletRequest     request = requestWithHeader("x-awc-source-workload-id", "spiffe://my-cluster/ns/prod/sa/service sa");
+        HttpServletRequest     request = requestWithHeader("X-Spiffe-Id", "spiffe://my-cluster/ns/prod/sa/service sa");
         PdpAuthNHandler.Result result  = handler.authenticate(request, null);
 
         assertEquals(PdpAuthNHandler.Result.Status.SKIP, result.getStatus());

--- a/pdp/src/test/java/org/apache/ranger/pdp/security/HttpHeaderAuthNHandlerTest.java
+++ b/pdp/src/test/java/org/apache/ranger/pdp/security/HttpHeaderAuthNHandlerTest.java
@@ -160,6 +160,23 @@ public class HttpHeaderAuthNHandlerTest {
         assertNull(result.getUserName());
     }
 
+    @Test
+    void testAuthenticate_nonRfc1123SpiffeHeaderSkips() {
+        HttpHeaderAuthNHandler handler = new HttpHeaderAuthNHandler();
+        Properties             config  = new Properties();
+
+        config.setProperty(RangerPdpConstants.PROP_AUTHN_HEADER_SPIFFE, "x-awc-source-workload-id");
+
+        handler.init(config);
+
+        // Correct layout but the service-account is not an RFC-1123 label (contains an underscore).
+        HttpServletRequest     request = requestWithHeader("x-awc-source-workload-id", "spiffe://my-cluster/ns/prod/sa/service_sa");
+        PdpAuthNHandler.Result result  = handler.authenticate(request, null);
+
+        assertEquals(PdpAuthNHandler.Result.Status.SKIP, result.getStatus());
+        assertNull(result.getUserName());
+    }
+
     private static HttpServletRequest requestWithHeader(String expectedHeader, String headerValue) {
         return requestWithHeaders(Collections.singletonMap(expectedHeader, headerValue));
     }

--- a/security-admin/src/main/java/org/apache/ranger/security/web/filter/RangerHeaderPreAuthFilter.java
+++ b/security-admin/src/main/java/org/apache/ranger/security/web/filter/RangerHeaderPreAuthFilter.java
@@ -110,7 +110,7 @@ public class RangerHeaderPreAuthFilter extends GenericFilterBean {
 
     /**
      * Resolves the principal from trusted headers. The username header (user identity) takes
-     * precedence; when it is absent, the SPIFFE header (service identity) is used and
+     * precedence; when it is absent, the SPIFFE header (service-to-service identity) is used and
      * the trailing service-account segment of the SPIFFE ID becomes the principal.
      */
     private String resolvePrincipal(HttpServletRequest httpRequest) {

--- a/security-admin/src/main/java/org/apache/ranger/security/web/filter/RangerHeaderPreAuthFilter.java
+++ b/security-admin/src/main/java/org/apache/ranger/security/web/filter/RangerHeaderPreAuthFilter.java
@@ -22,6 +22,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.ranger.biz.UserMgr;
 import org.apache.ranger.common.PropertiesUtil;
 import org.apache.ranger.entity.XXAuthSession;
+import org.apache.ranger.plugin.util.SpiffeIdUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -51,10 +52,12 @@ public class RangerHeaderPreAuthFilter extends GenericFilterBean {
 
     public static final String PROP_HEADER_AUTH_ENABLED    = "ranger.admin.authn.header.enabled";
     public static final String PROP_USERNAME_HEADER_NAME   = "ranger.admin.authn.header.username";
+    public static final String PROP_SPIFFE_HEADER_NAME     = "ranger.admin.authn.header.spiffe";
     public static final String PROP_REQUEST_ID_HEADER_NAME = "ranger.admin.authn.header.requestid";
 
-    private boolean headerAuthEnabled;
-    private String  userNameHeaderName;
+    private boolean      headerAuthEnabled;
+    private String       userNameHeaderName;
+    private List<String> spiffeHeaderNames;
 
     @Autowired
     UserMgr userMgr;
@@ -65,9 +68,10 @@ public class RangerHeaderPreAuthFilter extends GenericFilterBean {
 
         if (headerAuthEnabled) {
             userNameHeaderName = PropertiesUtil.getProperty(PROP_USERNAME_HEADER_NAME);
+            spiffeHeaderNames  = SpiffeIdUtil.parseHeaderNames(PropertiesUtil.getProperty(PROP_SPIFFE_HEADER_NAME));
 
-            if (StringUtils.isBlank(userNameHeaderName)) {
-                LOG.warn("Disabling header-based authentication, as configuration {} is not set", PROP_USERNAME_HEADER_NAME);
+            if (StringUtils.isBlank(userNameHeaderName) && spiffeHeaderNames.isEmpty()) {
+                LOG.warn("Disabling header-based authentication, as neither {} nor {} is set", PROP_USERNAME_HEADER_NAME, PROP_SPIFFE_HEADER_NAME);
 
                 headerAuthEnabled = false;
             }
@@ -81,7 +85,7 @@ public class RangerHeaderPreAuthFilter extends GenericFilterBean {
 
             if (existingAuthn == null || !existingAuthn.isAuthenticated()) {
                 HttpServletRequest  httpRequest = (HttpServletRequest) request;
-                String              username    = StringUtils.trimToNull(httpRequest.getHeader(userNameHeaderName));
+                String              username    = resolvePrincipal(httpRequest);
 
                 if (StringUtils.isNotBlank(username)) {
                     List<GrantedAuthority>    grantedAuthorities = getAuthoritiesFromRanger(username);
@@ -94,7 +98,7 @@ public class RangerHeaderPreAuthFilter extends GenericFilterBean {
 
                     LOG.debug("Authenticated request using trusted headers for user={}", username);
                 } else {
-                    LOG.debug("Username header '{}' is missing or empty in the request!", userNameHeaderName);
+                    LOG.debug("No trusted identity header found in the request!");
                 }
             }
         } else {
@@ -102,6 +106,34 @@ public class RangerHeaderPreAuthFilter extends GenericFilterBean {
         }
 
         chain.doFilter(request, response);
+    }
+
+    /**
+     * Resolves the principal from trusted headers. The username header (user identity) takes
+     * precedence; when it is absent, the SPIFFE header (service identity) is used and
+     * the trailing service-account segment of the SPIFFE ID becomes the principal.
+     */
+    private String resolvePrincipal(HttpServletRequest httpRequest) {
+        String username = StringUtils.isNotBlank(userNameHeaderName) ? StringUtils.trimToNull(httpRequest.getHeader(userNameHeaderName)) : null;
+
+        if (StringUtils.isNotBlank(username)) {
+            return username;
+        }
+
+        for (String spiffeHeaderName : spiffeHeaderNames) {
+            String spiffeId       = StringUtils.trimToNull(httpRequest.getHeader(spiffeHeaderName));
+            String serviceAccount = SpiffeIdUtil.extractServiceAccount(spiffeId);
+
+            if (StringUtils.isNotBlank(serviceAccount)) {
+                LOG.debug("Resolved service-account '{}' from SPIFFE header '{}'", serviceAccount, spiffeHeaderName);
+
+                return serviceAccount;
+            } else if (StringUtils.isNotBlank(spiffeId)) {
+                LOG.warn("SPIFFE header '{}' value is not a well-formed SPIFFE ID", spiffeHeaderName);
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/security-admin/src/main/java/org/apache/ranger/security/web/filter/RangerHeaderPreAuthFilter.java
+++ b/security-admin/src/main/java/org/apache/ranger/security/web/filter/RangerHeaderPreAuthFilter.java
@@ -110,7 +110,7 @@ public class RangerHeaderPreAuthFilter extends GenericFilterBean {
 
     /**
      * Resolves the principal from trusted headers. The username header (user identity) takes
-     * precedence; when it is absent, the SPIFFE header (service-to-service identity) is used and
+     * precedence; when it is absent, the SPIFFE header (service identity) is used and
      * the trailing service-account segment of the SPIFFE ID becomes the principal.
      */
     private String resolvePrincipal(HttpServletRequest httpRequest) {

--- a/security-admin/src/main/resources/conf.dist/ranger-admin-site.xml
+++ b/security-admin/src/main/resources/conf.dist/ranger-admin-site.xml
@@ -326,6 +326,7 @@
 	<property>
 		<name>ranger.admin.authn.header.spiffe</name>
 		<value></value>
+		<description>Comma-separated list of HTTP header name(s) carrying a SPIFFE ID (e.g. spiffe://cluster/ns/&lt;ns&gt;/sa/&lt;service-account&gt;). A single header name is also valid. The trailing service-account segment is used as the authenticated principal. When multiple headers are configured, the first one carrying a well-formed SPIFFE ID is used. Consulted only when the username header is absent.</description>
 	</property>
 	<property>
 		<name>ranger.admin.authn.header.requestid</name>

--- a/security-admin/src/main/resources/conf.dist/ranger-admin-site.xml
+++ b/security-admin/src/main/resources/conf.dist/ranger-admin-site.xml
@@ -326,7 +326,6 @@
 	<property>
 		<name>ranger.admin.authn.header.spiffe</name>
 		<value></value>
-		<description>Comma-separated list of HTTP header name(s) carrying a SPIFFE ID (e.g. spiffe://cluster/ns/&lt;ns&gt;/sa/&lt;service-account&gt;). A single header name is also valid. The trailing service-account segment is used as the authenticated principal. When multiple headers are configured, the first one carrying a well-formed SPIFFE ID is used. Consulted only when the username header is absent.</description>
 	</property>
 	<property>
 		<name>ranger.admin.authn.header.requestid</name>

--- a/security-admin/src/main/resources/conf.dist/ranger-admin-site.xml
+++ b/security-admin/src/main/resources/conf.dist/ranger-admin-site.xml
@@ -324,6 +324,11 @@
 		<value></value>
 	</property>
 	<property>
+		<name>ranger.admin.authn.header.spiffe</name>
+		<value></value>
+		<description>Comma-separated list of HTTP header name(s) carrying a SPIFFE ID (e.g. spiffe://cluster/ns/&lt;ns&gt;/sa/&lt;service-account&gt;). A single header name is also valid. The trailing service-account segment is used as the authenticated principal. When multiple headers are configured, the first one carrying a well-formed SPIFFE ID is used. Consulted only when the username header is absent.</description>
+	</property>
+	<property>
 		<name>ranger.admin.authn.header.requestid</name>
 		<value></value>
 	</property>

--- a/security-admin/src/test/java/org/apache/ranger/security/web/filter/TestRangerHeaderPreAuthFilter.java
+++ b/security-admin/src/test/java/org/apache/ranger/security/web/filter/TestRangerHeaderPreAuthFilter.java
@@ -66,6 +66,7 @@ public class TestRangerHeaderPreAuthFilter {
 
         PropertiesUtil.getPropertiesMap().remove(RangerHeaderPreAuthFilter.PROP_HEADER_AUTH_ENABLED);
         PropertiesUtil.getPropertiesMap().remove(RangerHeaderPreAuthFilter.PROP_USERNAME_HEADER_NAME);
+        PropertiesUtil.getPropertiesMap().remove(RangerHeaderPreAuthFilter.PROP_SPIFFE_HEADER_NAME);
         PropertiesUtil.getPropertiesMap().remove(RangerHeaderPreAuthFilter.PROP_REQUEST_ID_HEADER_NAME);
     }
 
@@ -149,6 +150,132 @@ public class TestRangerHeaderPreAuthFilter {
         };
 
         filter.doFilter(request, response, chain);
+    }
+
+    @Test
+    public void testDoFilter_enabled_withSpiffeHeader_setsServiceAccountAuthentication() throws Exception {
+        PropertiesUtil.getPropertiesMap().put(RangerHeaderPreAuthFilter.PROP_HEADER_AUTH_ENABLED, "true");
+        PropertiesUtil.getPropertiesMap().put(RangerHeaderPreAuthFilter.PROP_USERNAME_HEADER_NAME, "x-awc-username");
+        PropertiesUtil.getPropertiesMap().put(RangerHeaderPreAuthFilter.PROP_SPIFFE_HEADER_NAME, "x-awc-source-workload-id");
+
+        RangerHeaderPreAuthFilter filter  = new RangerHeaderPreAuthFilter();
+        UserMgr                   userMgr = mock(UserMgr.class);
+
+        filter.userMgr = userMgr;
+        filter.initialize();
+
+        when(userMgr.getRolesByLoginId("service-sa")).thenReturn(Collections.singletonList("ROLE_USER"));
+
+        HttpServletRequest  request  = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        when(request.getHeader("x-awc-username")).thenReturn(null);
+        when(request.getHeader("x-awc-source-workload-id")).thenReturn("spiffe://my-cluster/ns/service-namespace/sa/service-sa");
+
+        FilterChain chain = new FilterChain() {
+            @Override
+            public void doFilter(ServletRequest req, ServletResponse res) {
+                org.springframework.security.core.Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+
+                assertNotNull(auth);
+                assertTrue(auth instanceof RangerAuthenticationToken);
+                RangerAuthenticationToken rangerAuth = (RangerAuthenticationToken) auth;
+                assertEquals(XXAuthSession.AUTH_TYPE_TRUSTED_PROXY, rangerAuth.getAuthType());
+                assertEquals("service-sa", auth.getName());
+            }
+        };
+
+        filter.doFilter(request, response, chain);
+    }
+
+    @Test
+    public void testDoFilter_enabled_usernameHeaderTakesPrecedenceOverSpiffe() throws Exception {
+        PropertiesUtil.getPropertiesMap().put(RangerHeaderPreAuthFilter.PROP_HEADER_AUTH_ENABLED, "true");
+        PropertiesUtil.getPropertiesMap().put(RangerHeaderPreAuthFilter.PROP_USERNAME_HEADER_NAME, "x-awc-username");
+        PropertiesUtil.getPropertiesMap().put(RangerHeaderPreAuthFilter.PROP_SPIFFE_HEADER_NAME, "x-awc-source-workload-id");
+
+        RangerHeaderPreAuthFilter filter  = new RangerHeaderPreAuthFilter();
+        UserMgr                   userMgr = mock(UserMgr.class);
+
+        filter.userMgr = userMgr;
+        filter.initialize();
+
+        when(userMgr.getRolesByLoginId("joeuser")).thenReturn(Collections.singletonList("ROLE_USER"));
+
+        HttpServletRequest  request  = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        when(request.getHeader("x-awc-username")).thenReturn("joeuser");
+
+        FilterChain chain = new FilterChain() {
+            @Override
+            public void doFilter(ServletRequest req, ServletResponse res) {
+                org.springframework.security.core.Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+
+                assertNotNull(auth);
+                assertEquals("joeuser", auth.getName());
+            }
+        };
+
+        filter.doFilter(request, response, chain);
+
+        verify(userMgr, never()).getRolesByLoginId("service-sa");
+    }
+
+    @Test
+    public void testDoFilter_enabled_multipleSpiffeHeaders_usesFirstValid() throws Exception {
+        PropertiesUtil.getPropertiesMap().put(RangerHeaderPreAuthFilter.PROP_HEADER_AUTH_ENABLED, "true");
+        PropertiesUtil.getPropertiesMap().put(RangerHeaderPreAuthFilter.PROP_SPIFFE_HEADER_NAME, "x-awc-source-workload-id, x-awc-upstream-workload-id");
+
+        RangerHeaderPreAuthFilter filter  = new RangerHeaderPreAuthFilter();
+        UserMgr                   userMgr = mock(UserMgr.class);
+
+        filter.userMgr = userMgr;
+        filter.initialize();
+
+        when(userMgr.getRolesByLoginId("service-sa")).thenReturn(Collections.singletonList("ROLE_USER"));
+
+        HttpServletRequest  request  = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        when(request.getHeader("x-awc-source-workload-id")).thenReturn("not-a-spiffe-id");
+        when(request.getHeader("x-awc-upstream-workload-id")).thenReturn("spiffe://my-cluster/ns/service-namespace/sa/service-sa");
+
+        FilterChain chain = new FilterChain() {
+            @Override
+            public void doFilter(ServletRequest req, ServletResponse res) {
+                org.springframework.security.core.Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+
+                assertNotNull(auth);
+                assertEquals("service-sa", auth.getName());
+            }
+        };
+
+        filter.doFilter(request, response, chain);
+    }
+
+    @Test
+    public void testDoFilter_enabled_malformedSpiffeHeader_passesThrough() throws Exception {
+        PropertiesUtil.getPropertiesMap().put(RangerHeaderPreAuthFilter.PROP_HEADER_AUTH_ENABLED, "true");
+        PropertiesUtil.getPropertiesMap().put(RangerHeaderPreAuthFilter.PROP_SPIFFE_HEADER_NAME, "x-awc-source-workload-id");
+
+        RangerHeaderPreAuthFilter filter  = new RangerHeaderPreAuthFilter();
+        UserMgr                   userMgr = mock(UserMgr.class);
+
+        filter.userMgr = userMgr;
+        filter.initialize();
+
+        HttpServletRequest  request  = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        FilterChain         chain    = mock(FilterChain.class);
+
+        when(request.getHeader("x-awc-source-workload-id")).thenReturn("not-a-spiffe-id");
+
+        filter.doFilter(request, response, chain);
+
+        verify(chain).doFilter(request, response);
+        verify(userMgr, never()).getRolesByLoginId(anyString());
+        assertNull(SecurityContextHolder.getContext().getAuthentication());
     }
 
     @Test

--- a/security-admin/src/test/java/org/apache/ranger/security/web/filter/TestRangerHeaderPreAuthFilter.java
+++ b/security-admin/src/test/java/org/apache/ranger/security/web/filter/TestRangerHeaderPreAuthFilter.java
@@ -304,6 +304,31 @@ public class TestRangerHeaderPreAuthFilter {
     }
 
     @Test
+    public void testDoFilter_enabled_nonRfc1123SpiffeHeader_passesThrough() throws Exception {
+        PropertiesUtil.getPropertiesMap().put(RangerHeaderPreAuthFilter.PROP_HEADER_AUTH_ENABLED, "true");
+        PropertiesUtil.getPropertiesMap().put(RangerHeaderPreAuthFilter.PROP_SPIFFE_HEADER_NAME, "x-awc-source-workload-id");
+
+        RangerHeaderPreAuthFilter filter  = new RangerHeaderPreAuthFilter();
+        UserMgr                   userMgr = mock(UserMgr.class);
+
+        filter.userMgr = userMgr;
+        filter.initialize();
+
+        HttpServletRequest  request  = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        FilterChain         chain    = mock(FilterChain.class);
+
+        // Correct layout but the service-account is not an RFC-1123 label (contains an underscore).
+        when(request.getHeader("x-awc-source-workload-id")).thenReturn("spiffe://my-cluster/ns/prod/sa/service_sa");
+
+        filter.doFilter(request, response, chain);
+
+        verify(chain).doFilter(request, response);
+        verify(userMgr, never()).getRolesByLoginId(anyString());
+        assertNull(SecurityContextHolder.getContext().getAuthentication());
+    }
+
+    @Test
     public void testDoFilter_enabled_existingAuthenticatedContext_doesNotOverrideAuthentication() throws Exception {
         PropertiesUtil.getPropertiesMap().put(RangerHeaderPreAuthFilter.PROP_HEADER_AUTH_ENABLED, "true");
         PropertiesUtil.getPropertiesMap().put(RangerHeaderPreAuthFilter.PROP_USERNAME_HEADER_NAME, "x-awc-username");

--- a/security-admin/src/test/java/org/apache/ranger/security/web/filter/TestRangerHeaderPreAuthFilter.java
+++ b/security-admin/src/test/java/org/apache/ranger/security/web/filter/TestRangerHeaderPreAuthFilter.java
@@ -164,13 +164,14 @@ public class TestRangerHeaderPreAuthFilter {
         filter.userMgr = userMgr;
         filter.initialize();
 
-        when(userMgr.getRolesByLoginId("service-sa")).thenReturn(Collections.singletonList("ROLE_USER"));
+        when(userMgr.getRolesByLoginId("nginx-ingress")).thenReturn(Collections.singletonList("ROLE_USER"));
 
         HttpServletRequest  request  = mock(HttpServletRequest.class);
         HttpServletResponse response = mock(HttpServletResponse.class);
 
         when(request.getHeader("x-awc-username")).thenReturn(null);
-        when(request.getHeader("x-awc-source-workload-id")).thenReturn("spiffe://my-cluster/ns/service-namespace/sa/service-sa");
+        // Realistic production SPIFFE ID: DNS-style Kubernetes cluster trust domain + namespace/service-account.
+        when(request.getHeader("x-awc-source-workload-id")).thenReturn("spiffe://prod-cluster.k8s.example.com/ns/ingress-nginx/sa/nginx-ingress");
 
         FilterChain chain = new FilterChain() {
             @Override
@@ -181,7 +182,7 @@ public class TestRangerHeaderPreAuthFilter {
                 assertTrue(auth instanceof RangerAuthenticationToken);
                 RangerAuthenticationToken rangerAuth = (RangerAuthenticationToken) auth;
                 assertEquals(XXAuthSession.AUTH_TYPE_TRUSTED_PROXY, rangerAuth.getAuthType());
-                assertEquals("service-sa", auth.getName());
+                assertEquals("nginx-ingress", auth.getName());
             }
         };
 
@@ -304,7 +305,7 @@ public class TestRangerHeaderPreAuthFilter {
     }
 
     @Test
-    public void testDoFilter_enabled_nonRfc1123SpiffeHeader_passesThrough() throws Exception {
+    public void testDoFilter_enabled_spiffeHeaderWithIllegalChars_passesThrough() throws Exception {
         PropertiesUtil.getPropertiesMap().put(RangerHeaderPreAuthFilter.PROP_HEADER_AUTH_ENABLED, "true");
         PropertiesUtil.getPropertiesMap().put(RangerHeaderPreAuthFilter.PROP_SPIFFE_HEADER_NAME, "x-awc-source-workload-id");
 
@@ -318,8 +319,8 @@ public class TestRangerHeaderPreAuthFilter {
         HttpServletResponse response = mock(HttpServletResponse.class);
         FilterChain         chain    = mock(FilterChain.class);
 
-        // Correct layout but the service-account is not an RFC-1123 label (contains an underscore).
-        when(request.getHeader("x-awc-source-workload-id")).thenReturn("spiffe://my-cluster/ns/prod/sa/service_sa");
+        // Correct layout but the service-account contains whitespace, which is not an allowed SPIFFE character.
+        when(request.getHeader("x-awc-source-workload-id")).thenReturn("spiffe://my-cluster/ns/prod/sa/service sa");
 
         filter.doFilter(request, response, chain);
 

--- a/security-admin/src/test/java/org/apache/ranger/security/web/filter/TestRangerHeaderPreAuthFilter.java
+++ b/security-admin/src/test/java/org/apache/ranger/security/web/filter/TestRangerHeaderPreAuthFilter.java
@@ -279,6 +279,31 @@ public class TestRangerHeaderPreAuthFilter {
     }
 
     @Test
+    public void testDoFilter_enabled_specValidButNonConformingSpiffeHeader_passesThrough() throws Exception {
+        PropertiesUtil.getPropertiesMap().put(RangerHeaderPreAuthFilter.PROP_HEADER_AUTH_ENABLED, "true");
+        PropertiesUtil.getPropertiesMap().put(RangerHeaderPreAuthFilter.PROP_SPIFFE_HEADER_NAME, "x-awc-source-workload-id");
+
+        RangerHeaderPreAuthFilter filter  = new RangerHeaderPreAuthFilter();
+        UserMgr                   userMgr = mock(UserMgr.class);
+
+        filter.userMgr = userMgr;
+        filter.initialize();
+
+        HttpServletRequest  request  = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        FilterChain         chain    = mock(FilterChain.class);
+
+        // Valid SPIFFE ID per the SPIFFE spec, but not in the expected /ns/<ns>/sa/<sa> layout.
+        when(request.getHeader("x-awc-source-workload-id")).thenReturn("spiffe://example.org/workload/frontend");
+
+        filter.doFilter(request, response, chain);
+
+        verify(chain).doFilter(request, response);
+        verify(userMgr, never()).getRolesByLoginId(anyString());
+        assertNull(SecurityContextHolder.getContext().getAuthentication());
+    }
+
+    @Test
     public void testDoFilter_enabled_existingAuthenticatedContext_doesNotOverrideAuthentication() throws Exception {
         PropertiesUtil.getPropertiesMap().put(RangerHeaderPreAuthFilter.PROP_HEADER_AUTH_ENABLED, "true");
         PropertiesUtil.getPropertiesMap().put(RangerHeaderPreAuthFilter.PROP_USERNAME_HEADER_NAME, "x-awc-username");

--- a/security-admin/src/test/java/org/apache/ranger/security/web/filter/TestRangerHeaderPreAuthFilter.java
+++ b/security-admin/src/test/java/org/apache/ranger/security/web/filter/TestRangerHeaderPreAuthFilter.java
@@ -92,7 +92,7 @@ public class TestRangerHeaderPreAuthFilter {
     @Test
     public void testDoFilter_enabled_missingUsername_passesThrough() throws Exception {
         PropertiesUtil.getPropertiesMap().put(RangerHeaderPreAuthFilter.PROP_HEADER_AUTH_ENABLED, "true");
-        PropertiesUtil.getPropertiesMap().put(RangerHeaderPreAuthFilter.PROP_USERNAME_HEADER_NAME, "x-awc-username");
+        PropertiesUtil.getPropertiesMap().put(RangerHeaderPreAuthFilter.PROP_USERNAME_HEADER_NAME, "X-Forwarded-User");
 
         RangerHeaderPreAuthFilter filter  = new RangerHeaderPreAuthFilter();
         UserMgr                   userMgr = mock(UserMgr.class);
@@ -116,7 +116,7 @@ public class TestRangerHeaderPreAuthFilter {
     @Test
     public void testDoFilter_enabled_withUsername_setsAuthenticationFromRangerDbRoles() throws Exception {
         PropertiesUtil.getPropertiesMap().put(RangerHeaderPreAuthFilter.PROP_HEADER_AUTH_ENABLED, "true");
-        PropertiesUtil.getPropertiesMap().put(RangerHeaderPreAuthFilter.PROP_USERNAME_HEADER_NAME, "x-awc-username");
+        PropertiesUtil.getPropertiesMap().put(RangerHeaderPreAuthFilter.PROP_USERNAME_HEADER_NAME, "X-Forwarded-User");
 
         RangerHeaderPreAuthFilter filter  = new RangerHeaderPreAuthFilter();
         UserMgr                   userMgr = mock(UserMgr.class);
@@ -129,7 +129,7 @@ public class TestRangerHeaderPreAuthFilter {
         HttpServletRequest  request  = mock(HttpServletRequest.class);
         HttpServletResponse response = mock(HttpServletResponse.class);
 
-        when(request.getHeader("x-awc-username")).thenReturn("joeuser");
+        when(request.getHeader("X-Forwarded-User")).thenReturn("joeuser");
 
         FilterChain chain = new FilterChain() {
             @Override
@@ -155,8 +155,8 @@ public class TestRangerHeaderPreAuthFilter {
     @Test
     public void testDoFilter_enabled_withSpiffeHeader_setsServiceAccountAuthentication() throws Exception {
         PropertiesUtil.getPropertiesMap().put(RangerHeaderPreAuthFilter.PROP_HEADER_AUTH_ENABLED, "true");
-        PropertiesUtil.getPropertiesMap().put(RangerHeaderPreAuthFilter.PROP_USERNAME_HEADER_NAME, "x-awc-username");
-        PropertiesUtil.getPropertiesMap().put(RangerHeaderPreAuthFilter.PROP_SPIFFE_HEADER_NAME, "x-awc-source-workload-id");
+        PropertiesUtil.getPropertiesMap().put(RangerHeaderPreAuthFilter.PROP_USERNAME_HEADER_NAME, "X-Forwarded-User");
+        PropertiesUtil.getPropertiesMap().put(RangerHeaderPreAuthFilter.PROP_SPIFFE_HEADER_NAME, "X-Spiffe-Id");
 
         RangerHeaderPreAuthFilter filter  = new RangerHeaderPreAuthFilter();
         UserMgr                   userMgr = mock(UserMgr.class);
@@ -169,9 +169,9 @@ public class TestRangerHeaderPreAuthFilter {
         HttpServletRequest  request  = mock(HttpServletRequest.class);
         HttpServletResponse response = mock(HttpServletResponse.class);
 
-        when(request.getHeader("x-awc-username")).thenReturn(null);
+        when(request.getHeader("X-Forwarded-User")).thenReturn(null);
         // Realistic production SPIFFE ID: DNS-style Kubernetes cluster trust domain + namespace/service-account.
-        when(request.getHeader("x-awc-source-workload-id")).thenReturn("spiffe://prod-cluster.k8s.example.com/ns/ingress-nginx/sa/nginx-ingress");
+        when(request.getHeader("X-Spiffe-Id")).thenReturn("spiffe://prod-cluster.k8s.example.com/ns/ingress-nginx/sa/nginx-ingress");
 
         FilterChain chain = new FilterChain() {
             @Override
@@ -192,8 +192,8 @@ public class TestRangerHeaderPreAuthFilter {
     @Test
     public void testDoFilter_enabled_usernameHeaderTakesPrecedenceOverSpiffe() throws Exception {
         PropertiesUtil.getPropertiesMap().put(RangerHeaderPreAuthFilter.PROP_HEADER_AUTH_ENABLED, "true");
-        PropertiesUtil.getPropertiesMap().put(RangerHeaderPreAuthFilter.PROP_USERNAME_HEADER_NAME, "x-awc-username");
-        PropertiesUtil.getPropertiesMap().put(RangerHeaderPreAuthFilter.PROP_SPIFFE_HEADER_NAME, "x-awc-source-workload-id");
+        PropertiesUtil.getPropertiesMap().put(RangerHeaderPreAuthFilter.PROP_USERNAME_HEADER_NAME, "X-Forwarded-User");
+        PropertiesUtil.getPropertiesMap().put(RangerHeaderPreAuthFilter.PROP_SPIFFE_HEADER_NAME, "X-Spiffe-Id");
 
         RangerHeaderPreAuthFilter filter  = new RangerHeaderPreAuthFilter();
         UserMgr                   userMgr = mock(UserMgr.class);
@@ -206,7 +206,7 @@ public class TestRangerHeaderPreAuthFilter {
         HttpServletRequest  request  = mock(HttpServletRequest.class);
         HttpServletResponse response = mock(HttpServletResponse.class);
 
-        when(request.getHeader("x-awc-username")).thenReturn("joeuser");
+        when(request.getHeader("X-Forwarded-User")).thenReturn("joeuser");
 
         FilterChain chain = new FilterChain() {
             @Override
@@ -226,7 +226,7 @@ public class TestRangerHeaderPreAuthFilter {
     @Test
     public void testDoFilter_enabled_multipleSpiffeHeaders_usesFirstValid() throws Exception {
         PropertiesUtil.getPropertiesMap().put(RangerHeaderPreAuthFilter.PROP_HEADER_AUTH_ENABLED, "true");
-        PropertiesUtil.getPropertiesMap().put(RangerHeaderPreAuthFilter.PROP_SPIFFE_HEADER_NAME, "x-awc-source-workload-id, x-awc-upstream-workload-id");
+        PropertiesUtil.getPropertiesMap().put(RangerHeaderPreAuthFilter.PROP_SPIFFE_HEADER_NAME, "X-Spiffe-Id, X-Workload-Id");
 
         RangerHeaderPreAuthFilter filter  = new RangerHeaderPreAuthFilter();
         UserMgr                   userMgr = mock(UserMgr.class);
@@ -239,8 +239,8 @@ public class TestRangerHeaderPreAuthFilter {
         HttpServletRequest  request  = mock(HttpServletRequest.class);
         HttpServletResponse response = mock(HttpServletResponse.class);
 
-        when(request.getHeader("x-awc-source-workload-id")).thenReturn("not-a-spiffe-id");
-        when(request.getHeader("x-awc-upstream-workload-id")).thenReturn("spiffe://my-cluster/ns/service-namespace/sa/service-sa");
+        when(request.getHeader("X-Spiffe-Id")).thenReturn("not-a-spiffe-id");
+        when(request.getHeader("X-Workload-Id")).thenReturn("spiffe://my-cluster/ns/service-namespace/sa/service-sa");
 
         FilterChain chain = new FilterChain() {
             @Override
@@ -258,7 +258,7 @@ public class TestRangerHeaderPreAuthFilter {
     @Test
     public void testDoFilter_enabled_malformedSpiffeHeader_passesThrough() throws Exception {
         PropertiesUtil.getPropertiesMap().put(RangerHeaderPreAuthFilter.PROP_HEADER_AUTH_ENABLED, "true");
-        PropertiesUtil.getPropertiesMap().put(RangerHeaderPreAuthFilter.PROP_SPIFFE_HEADER_NAME, "x-awc-source-workload-id");
+        PropertiesUtil.getPropertiesMap().put(RangerHeaderPreAuthFilter.PROP_SPIFFE_HEADER_NAME, "X-Spiffe-Id");
 
         RangerHeaderPreAuthFilter filter  = new RangerHeaderPreAuthFilter();
         UserMgr                   userMgr = mock(UserMgr.class);
@@ -270,7 +270,7 @@ public class TestRangerHeaderPreAuthFilter {
         HttpServletResponse response = mock(HttpServletResponse.class);
         FilterChain         chain    = mock(FilterChain.class);
 
-        when(request.getHeader("x-awc-source-workload-id")).thenReturn("not-a-spiffe-id");
+        when(request.getHeader("X-Spiffe-Id")).thenReturn("not-a-spiffe-id");
 
         filter.doFilter(request, response, chain);
 
@@ -282,7 +282,7 @@ public class TestRangerHeaderPreAuthFilter {
     @Test
     public void testDoFilter_enabled_specValidButNonConformingSpiffeHeader_passesThrough() throws Exception {
         PropertiesUtil.getPropertiesMap().put(RangerHeaderPreAuthFilter.PROP_HEADER_AUTH_ENABLED, "true");
-        PropertiesUtil.getPropertiesMap().put(RangerHeaderPreAuthFilter.PROP_SPIFFE_HEADER_NAME, "x-awc-source-workload-id");
+        PropertiesUtil.getPropertiesMap().put(RangerHeaderPreAuthFilter.PROP_SPIFFE_HEADER_NAME, "X-Spiffe-Id");
 
         RangerHeaderPreAuthFilter filter  = new RangerHeaderPreAuthFilter();
         UserMgr                   userMgr = mock(UserMgr.class);
@@ -295,7 +295,7 @@ public class TestRangerHeaderPreAuthFilter {
         FilterChain         chain    = mock(FilterChain.class);
 
         // Valid SPIFFE ID per the SPIFFE spec, but not in the expected /ns/<ns>/sa/<sa> layout.
-        when(request.getHeader("x-awc-source-workload-id")).thenReturn("spiffe://example.org/workload/frontend");
+        when(request.getHeader("X-Spiffe-Id")).thenReturn("spiffe://example.org/workload/frontend");
 
         filter.doFilter(request, response, chain);
 
@@ -307,7 +307,7 @@ public class TestRangerHeaderPreAuthFilter {
     @Test
     public void testDoFilter_enabled_spiffeHeaderWithIllegalChars_passesThrough() throws Exception {
         PropertiesUtil.getPropertiesMap().put(RangerHeaderPreAuthFilter.PROP_HEADER_AUTH_ENABLED, "true");
-        PropertiesUtil.getPropertiesMap().put(RangerHeaderPreAuthFilter.PROP_SPIFFE_HEADER_NAME, "x-awc-source-workload-id");
+        PropertiesUtil.getPropertiesMap().put(RangerHeaderPreAuthFilter.PROP_SPIFFE_HEADER_NAME, "X-Spiffe-Id");
 
         RangerHeaderPreAuthFilter filter  = new RangerHeaderPreAuthFilter();
         UserMgr                   userMgr = mock(UserMgr.class);
@@ -320,7 +320,7 @@ public class TestRangerHeaderPreAuthFilter {
         FilterChain         chain    = mock(FilterChain.class);
 
         // Correct layout but the service-account contains whitespace, which is not an allowed SPIFFE character.
-        when(request.getHeader("x-awc-source-workload-id")).thenReturn("spiffe://my-cluster/ns/prod/sa/service sa");
+        when(request.getHeader("X-Spiffe-Id")).thenReturn("spiffe://my-cluster/ns/prod/sa/service sa");
 
         filter.doFilter(request, response, chain);
 
@@ -332,7 +332,7 @@ public class TestRangerHeaderPreAuthFilter {
     @Test
     public void testDoFilter_enabled_existingAuthenticatedContext_doesNotOverrideAuthentication() throws Exception {
         PropertiesUtil.getPropertiesMap().put(RangerHeaderPreAuthFilter.PROP_HEADER_AUTH_ENABLED, "true");
-        PropertiesUtil.getPropertiesMap().put(RangerHeaderPreAuthFilter.PROP_USERNAME_HEADER_NAME, "x-awc-username");
+        PropertiesUtil.getPropertiesMap().put(RangerHeaderPreAuthFilter.PROP_USERNAME_HEADER_NAME, "X-Forwarded-User");
 
         RangerHeaderPreAuthFilter filter  = new RangerHeaderPreAuthFilter();
         UserMgr                   userMgr = mock(UserMgr.class);

--- a/security-admin/src/test/java/org/apache/ranger/security/web/filter/TestRangerSecurityContextFormationFilter.java
+++ b/security-admin/src/test/java/org/apache/ranger/security/web/filter/TestRangerSecurityContextFormationFilter.java
@@ -184,7 +184,7 @@ public class TestRangerSecurityContextFormationFilter {
 
     @Test
     public void testDoFilter_authenticated_createsSecurityContextAndUserSession() throws Exception {
-        PropertiesUtil.getPropertiesMap().put(RangerHeaderPreAuthFilter.PROP_REQUEST_ID_HEADER_NAME, "x-awc-requestid");
+        PropertiesUtil.getPropertiesMap().put(RangerHeaderPreAuthFilter.PROP_REQUEST_ID_HEADER_NAME, "X-Request-Id");
 
         try {
             RangerSecurityContextFormationFilter filter = new RangerSecurityContextFormationFilter();
@@ -212,7 +212,7 @@ public class TestRangerSecurityContextFormationFilter {
             Mockito.when(req.getSession(false)).thenReturn(session);
             Mockito.when(session.getAttribute(RangerSecurityContextFormationFilter.AKA_SC_SESSION_KEY)).thenReturn(null);
             Mockito.when(req.getHeader(RangerSecurityContextFormationFilter.USER_AGENT)).thenReturn("Mozilla/5.0");
-            Mockito.when(req.getHeader("x-awc-requestid")).thenReturn("awc-request-1");
+            Mockito.when(req.getHeader("X-Request-Id")).thenReturn("request-1");
             Mockito.when(req.getRequestURI()).thenReturn("/secure");
             Mockito.when(httpUtil.getDeviceType(req)).thenReturn(RangerCommonEnums.DEVICE_BROWSER);
 
@@ -229,7 +229,7 @@ public class TestRangerSecurityContextFormationFilter {
 
                     assertNotNull(ctx);
                     assertNotNull(ctx.getRequestContext());
-                    assertEquals("awc-request-1", ctx.getRequestContext().getServerRequestId());
+                    assertEquals("request-1", ctx.getRequestContext().getServerRequestId());
                     assertSame(userSession, ctx.getUserSession());
                 }
             };


### PR DESCRIPTION
## What changes were proposed in this pull request?
- Adds SPIFFE-based service-to-service authentication as a second trusted-header path, alongside the existing username-header (user identity) authentication, in Ranger Admin and the PDP server.
- When the username header is absent, the server reads a configured SPIFFE header and extracts the trailing service-account segment from the SPIFFE ID (spiffe://<trust-domain>/ns/<ns>/sa/<service-account> → <service-account>), authenticating the caller as that service account.
- Adds a shared SpiffeIdUtil helper in common-utils so Admin and PDP share identical parsing semantics.
- New config: 
     - ranger.admin.authn.header.spiffe (Admin)
     - ranger.pdp.authn.header.spiffe (PDP).
- By design the config accepts a comma-separated list of SPIFFE header names while also fully supporting a single header name (a single value is just a list of one).
- Precedence: the username header always wins; among SPIFFE headers, the first one carrying a well-formed SPIFFE ID is used, and malformed values are skipped.
- Backward compatible: the existing *.authn.header.enabled flag continues to gate the entire trusted-header path.

## How was this patch tested?
- Added unit tests for SpiffeIdUtil, the Admin RangerHeaderPreAuthFilter, and the PDP HttpHeaderAuthNHandler.
- Verified end-to-end in the dev-support/ranger-docker stack (Admin + PDP).
- Single-ID scenarios: no header → 401; valid SPIFFE header → authenticated as the service account; malformed SPIFFE ID → 401.
- Multiple-ID scenarios: falls through to a later header when an earlier one is absent; the first well-formed header wins even when a later header would resolve to a different valid identity; a malformed leading header is skipped so resolution continues to the next configured header.
