### PR TITLE
RANGER-5678: Concurrent policy-engine rebuild on shared serviceDef causes CME/NPE for delegated-admin User

### DIFF
--- a/agents-common/src/main/java/org/apache/ranger/plugin/model/RangerBaseModelObject.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/model/RangerBaseModelObject.java
@@ -57,6 +57,17 @@ public class RangerBaseModelObject implements java.io.Serializable {
         setIsEnabled(null);
     }
 
+    public RangerBaseModelObject(RangerBaseModelObject other) {
+        setId(other.getId());
+        setGuid(other.getGuid());
+        setIsEnabled(other.getIsEnabled());
+        setCreatedBy(other.getCreatedBy());
+        setUpdatedBy(other.getUpdatedBy());
+        setCreateTime(other.getCreateTime());
+        setUpdateTime(other.getUpdateTime());
+        setVersion(other.getVersion());
+    }
+
     public static <T> List<T> nullSafeList(List<T> coll) {
         return nullSafeSupplier.toList(coll);
     }

--- a/agents-common/src/main/java/org/apache/ranger/plugin/model/RangerServiceDef.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/model/RangerServiceDef.java
@@ -32,6 +32,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.UnaryOperator;
 
 @JsonAutoDetect(fieldVisibility = Visibility.ANY)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
@@ -112,6 +113,39 @@ public class RangerServiceDef extends RangerBaseModelObject implements java.io.S
             List<RangerEnumDef> enums) {
         this(name, implClass, label, description, options, configs, modifiedResourceDefs, accessTypes, policyConditions, contextEnrichers, enums);
         this.setDisplayName(displayName);
+    }
+
+    public RangerServiceDef(RangerServiceDef other) {
+        super(other);
+
+        setName(other.getName());
+        setDisplayName(other.getDisplayName());
+        setImplClass(other.getImplClass());
+        setLabel(other.getLabel());
+        setDescription(other.getDescription());
+        setRbKeyLabel(other.getRbKeyLabel());
+        setRbKeyDescription(other.getRbKeyDescription());
+        setOptions(other.getOptions() == null ? null : new HashMap<>(other.getOptions()));
+        setConfigs(copyList(other.getConfigs(), RangerServiceConfigDef::new));
+        setResources(copyList(other.getResources(), RangerResourceDef::new));
+        setAccessTypes(copyList(other.getAccessTypes(), RangerAccessTypeDef::new));
+        setPolicyConditions(copyList(other.getPolicyConditions(), RangerPolicyConditionDef::new));
+        setContextEnrichers(copyList(other.getContextEnrichers(), RangerContextEnricherDef::new));
+        setEnums(copyList(other.getEnums(), RangerEnumDef::new));
+        setDataMaskDef(other.getDataMaskDef() == null ? null : new RangerDataMaskDef(other.getDataMaskDef()));
+        setRowFilterDef(other.getRowFilterDef() == null ? null : new RangerRowFilterDef(other.getRowFilterDef()));
+        setMarkerAccessTypes(copyList(other.getMarkerAccessTypes(), RangerAccessTypeDef::new));
+    }
+
+    private static <T> List<T> copyList(List<T> list, UnaryOperator<T> copier) {
+        List<T> ret = null;
+        if (list != null) {
+            ret = new ArrayList<>(list.size());
+            for (T item : list) {
+                ret.add(item == null ? null : copier.apply(item));
+            }
+        }
+        return ret;
     }
 
     /**
@@ -644,6 +678,24 @@ public class RangerServiceDef extends RangerBaseModelObject implements java.io.S
             setDefaultIndex(defaultIndex);
         }
 
+        public RangerEnumDef(RangerEnumDef other) {
+            setItemId(other.getItemId());
+            setName(other.getName());
+            setElements(copyEnumElementDefs(other.getElements()));
+            setDefaultIndex(other.getDefaultIndex());
+        }
+
+        private static List<RangerEnumElementDef> copyEnumElementDefs(List<RangerEnumElementDef> elementDefs) {
+            List<RangerEnumElementDef> ret = null;
+            if (elementDefs != null) {
+                ret = new ArrayList<>(elementDefs.size());
+                for (RangerEnumElementDef elementDef : elementDefs) {
+                    ret.add(elementDef == null ? null : new RangerEnumElementDef(elementDef));
+                }
+            }
+            return ret;
+        }
+
         /**
          * @return the itemId
          */
@@ -831,6 +883,13 @@ public class RangerServiceDef extends RangerBaseModelObject implements java.io.S
             setRbKeyLabel(rbKeyLabel);
         }
 
+        public RangerEnumElementDef(RangerEnumElementDef other) {
+            setItemId(other.getItemId());
+            setName(other.getName());
+            setLabel(other.getLabel());
+            setRbKeyLabel(other.getRbKeyLabel());
+        }
+
         /**
          * @return the itemId
          */
@@ -1007,6 +1066,23 @@ public class RangerServiceDef extends RangerBaseModelObject implements java.io.S
             setRbKeyLabel(rbKeyLabel);
             setRbKeyDescription(rbKeyDescription);
             setRbKeyValidationMessage(rbKeyValidationMessage);
+        }
+
+        public RangerServiceConfigDef(RangerServiceConfigDef other) {
+            setItemId(other.getItemId());
+            setName(other.getName());
+            setType(other.getType());
+            setSubType(other.getSubType());
+            setMandatory(other.getMandatory());
+            setDefaultValue(other.getDefaultValue());
+            setValidationRegEx(other.getValidationRegEx());
+            setValidationMessage(other.getValidationMessage());
+            setUiHint(other.getUiHint());
+            setLabel(other.getLabel());
+            setDescription(other.getDescription());
+            setRbKeyLabel(other.getRbKeyLabel());
+            setRbKeyDescription(other.getRbKeyDescription());
+            setRbKeyValidationMessage(other.getRbKeyValidationMessage());
         }
 
         /**
@@ -1436,7 +1512,7 @@ public class RangerServiceDef extends RangerBaseModelObject implements java.io.S
             setRecursiveSupported(other.getRecursiveSupported());
             setExcludesSupported(other.getExcludesSupported());
             setMatcher(other.getMatcher());
-            setMatcherOptions(other.getMatcherOptions());
+            setMatcherOptions(other.getMatcherOptions() == null ? null : new HashMap<>(other.getMatcherOptions()));
             setValidationRegEx(other.getValidationRegEx());
             setValidationMessage(other.getValidationMessage());
             setUiHint(other.getUiHint());
@@ -2304,6 +2380,21 @@ public class RangerServiceDef extends RangerBaseModelObject implements java.io.S
             setRbKeyValidationMessage(rbKeyValidationMessage);
         }
 
+        public RangerPolicyConditionDef(RangerPolicyConditionDef other) {
+            setItemId(other.getItemId());
+            setName(other.getName());
+            setEvaluator(other.getEvaluator());
+            setEvaluatorOptions(other.getEvaluatorOptions() == null ? null : new HashMap<>(other.getEvaluatorOptions()));
+            setValidationRegEx(other.getValidationRegEx());
+            setValidationMessage(other.getValidationMessage());
+            setUiHint(other.getUiHint());
+            setLabel(other.getLabel());
+            setDescription(other.getDescription());
+            setRbKeyLabel(other.getRbKeyLabel());
+            setRbKeyDescription(other.getRbKeyDescription());
+            setRbKeyValidationMessage(other.getRbKeyValidationMessage());
+        }
+
         /**
          * @return the itemId
          */
@@ -2672,6 +2763,13 @@ public class RangerServiceDef extends RangerBaseModelObject implements java.io.S
             setEnricherOptions(enricherOptions);
         }
 
+        public RangerContextEnricherDef(RangerContextEnricherDef other) {
+            setItemId(other.getItemId());
+            setName(other.getName());
+            setEnricher(other.getEnricher());
+            setEnricherOptions(other.getEnricherOptions() == null ? null : new HashMap<>(other.getEnricherOptions()));
+        }
+
         /**
          * @return the itemId
          */
@@ -2828,15 +2926,15 @@ public class RangerServiceDef extends RangerBaseModelObject implements java.io.S
         }
 
         public RangerDataMaskDef(List<RangerDataMaskTypeDef> maskTypes, List<RangerAccessTypeDef> accessTypes, List<RangerResourceDef> resources) {
-            setMaskTypes(maskTypes);
-            setAccessTypes(accessTypes);
-            setResources(resources);
+            setMaskTypes(copyList(maskTypes, RangerDataMaskTypeDef::new));
+            setAccessTypes(copyList(accessTypes, RangerAccessTypeDef::new));
+            setResources(copyList(resources, RangerResourceDef::new));
         }
 
         public RangerDataMaskDef(RangerDataMaskDef other) {
-            setMaskTypes(other.getMaskTypes());
-            setAccessTypes(other.getAccessTypes());
-            setResources(other.getResources());
+            setMaskTypes(copyList(other.getMaskTypes(), RangerDataMaskTypeDef::new));
+            setAccessTypes(copyList(other.getAccessTypes(), RangerAccessTypeDef::new));
+            setResources(copyList(other.getResources(), RangerResourceDef::new));
         }
 
         public List<RangerDataMaskTypeDef> getMaskTypes() {
@@ -3301,13 +3399,13 @@ public class RangerServiceDef extends RangerBaseModelObject implements java.io.S
         }
 
         public RangerRowFilterDef(List<RangerAccessTypeDef> accessTypes, List<RangerResourceDef> resources) {
-            setAccessTypes(accessTypes);
-            setResources(resources);
+            setAccessTypes(copyList(accessTypes, RangerAccessTypeDef::new));
+            setResources(copyList(resources, RangerResourceDef::new));
         }
 
         public RangerRowFilterDef(RangerRowFilterDef other) {
-            setAccessTypes(other.getAccessTypes());
-            setResources(other.getResources());
+            setAccessTypes(copyList(other.getAccessTypes(), RangerAccessTypeDef::new));
+            setResources(copyList(other.getResources(), RangerResourceDef::new));
         }
 
         public List<RangerAccessTypeDef> getAccessTypes() {

--- a/agents-common/src/main/java/org/apache/ranger/plugin/model/validation/RangerServiceDefValidator.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/model/validation/RangerServiceDefValidator.java
@@ -61,7 +61,7 @@ public class RangerServiceDefValidator extends RangerValidator {
 
         RangerServiceDef normalizedServiceDef = ServiceDefUtil.normalize(serviceDef);
 
-        LOG.debug("Normalized Service Definition being validated: ({}, {})", serviceDef, action);
+        LOG.debug("Normalized Service Definition being validated: ({}, {})", normalizedServiceDef, action);
 
         List<ValidationFailureDetails> failures = new ArrayList<>();
         boolean                        valid    = isValid(normalizedServiceDef, action, failures);

--- a/agents-common/src/main/java/org/apache/ranger/plugin/policyengine/PolicyEngine.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/policyengine/PolicyEngine.java
@@ -563,12 +563,14 @@ public class PolicyEngine {
         RangerServiceDef serviceDef = servicePolicies.getServiceDef();
 
         if (serviceDef != null) {
-            ServiceDefUtil.normalize(serviceDef);
-
+            serviceDef = ServiceDefUtil.normalize(serviceDef);
+            servicePolicies.setServiceDef(serviceDef);
             RangerServiceDef tagServiceDef = servicePolicies.getTagPolicies() != null ? servicePolicies.getTagPolicies().getServiceDef() : null;
 
             if (tagServiceDef != null) {
-                ServiceDefUtil.normalizeAccessTypeDefs(ServiceDefUtil.normalize(tagServiceDef), serviceDef.getName());
+                tagServiceDef = ServiceDefUtil.normalize(tagServiceDef);
+                ServiceDefUtil.normalizeAccessTypeDefs(tagServiceDef, serviceDef.getName());
+                servicePolicies.getTagPolicies().setServiceDef(tagServiceDef);
             }
         }
     }

--- a/agents-common/src/main/java/org/apache/ranger/plugin/policyengine/RangerPolicyRepository.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/policyengine/RangerPolicyRepository.java
@@ -189,6 +189,7 @@ public class RangerPolicyRepository {
 
         this.serviceName          = servicePolicies.getServiceName();
         this.serviceDef           = ServiceDefUtil.normalize(servicePolicies.getServiceDef());
+        servicePolicies.setServiceDef(this.serviceDef);
         this.componentServiceName = this.serviceName;
         this.componentServiceDef  = this.serviceDef;
         this.zoneName             = zoneName;
@@ -260,6 +261,7 @@ public class RangerPolicyRepository {
         this.componentServiceName = componentServiceName;
         this.zoneName             = null;
         this.serviceDef           = ServiceDefUtil.normalizeAccessTypeDefs(ServiceDefUtil.normalize(tagPolicies.getServiceDef()), componentServiceDef.getName());
+        tagPolicies.setServiceDef(this.serviceDef);
         this.componentServiceDef  = componentServiceDef;
         this.appId                = pluginContext.getConfig().getAppId();
         this.options              = new RangerPolicyEngineOptions(pluginContext.getConfig().getPolicyEngineOptions(), new RangerServiceDefHelper(serviceDef, false));

--- a/agents-common/src/main/java/org/apache/ranger/plugin/util/ServiceDefUtil.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/util/ServiceDefUtil.java
@@ -126,10 +126,11 @@ public class ServiceDefUtil {
     }
 
     public static RangerServiceDef normalize(RangerServiceDef serviceDef) {
-        normalizeDataMaskDef(serviceDef);
-        normalizeRowFilterDef(serviceDef);
+        RangerServiceDef ret = serviceDef == null ? null : new RangerServiceDef(serviceDef);
+        normalizeDataMaskDef(ret);
+        normalizeRowFilterDef(ret);
 
-        return serviceDef;
+        return ret;
     }
 
     public static RangerPolicyConditionDef getConditionDef(RangerServiceDef serviceDef, String conditionName) {

--- a/agents-common/src/test/java/org/apache/ranger/plugin/policyengine/gds/TestGdsPolicyEngine.java
+++ b/agents-common/src/test/java/org/apache/ranger/plugin/policyengine/gds/TestGdsPolicyEngine.java
@@ -126,7 +126,7 @@ public class TestGdsPolicyEngine {
 
         assertTrue(testCase.gdsInfo != null && testCase.tests != null, "invalid input: " + testName);
 
-        ServiceDefUtil.normalize(testCase.serviceDef);
+        testCase.serviceDef = ServiceDefUtil.normalize(testCase.serviceDef);
         testCase.serviceDef.setMarkerAccessTypes(ServiceDefUtil.getMarkerAccessTypes(testCase.serviceDef.getAccessTypes()));
 
         RangerPluginContext       pluginContext = new RangerPluginContext(new RangerPluginConfig(testCase.serviceDef.getName(), null, "hive", "cl1", "on-prem", null));

--- a/agents-common/src/test/java/org/apache/ranger/plugin/policyevaluator/TestInlinePolicyEvaluator.java
+++ b/agents-common/src/test/java/org/apache/ranger/plugin/policyevaluator/TestInlinePolicyEvaluator.java
@@ -90,7 +90,7 @@ public class TestInlinePolicyEvaluator {
         ServicePolicies  servicePolicies = testCase.servicePolicies;
         RangerServiceDef serviceDef      = servicePolicies.getServiceDef();
 
-        ServiceDefUtil.normalize(serviceDef);
+        serviceDef = ServiceDefUtil.normalize(serviceDef);
 
         RangerPolicyEngineOptions   policyEngineOptions = new RangerPolicyEngineOptions();
         RangerPluginContext         pluginContext       = new RangerPluginContext(new RangerPluginConfig(serviceDef.getName(), servicePolicies.getServiceName(), null, "cl1", "on-prem", policyEngineOptions));

--- a/agents-common/src/test/java/org/apache/ranger/plugin/util/ServiceDefUtilTest.java
+++ b/agents-common/src/test/java/org/apache/ranger/plugin/util/ServiceDefUtilTest.java
@@ -57,6 +57,9 @@ import static org.apache.ranger.plugin.util.ServiceDefUtil.ACCESS_TYPE_MARKER_UP
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ServiceDefUtilTest {
@@ -387,6 +390,59 @@ public class ServiceDefUtilTest {
             svcPolicies.getSecurityZones().get("zone1").getPolicyDeltas().add(new RangerPolicyDelta(1L, RangerPolicyDelta.CHANGE_TYPE_POLICY_CREATE, 1L, policy));
             assertTrue(ServiceDefUtil.addUserStoreEnricherIfNeeded(svcPolicies, RangerAdminUserStoreRetriever.class.getCanonicalName(), "60000"), "zone-policy-delta data-mask refers to user/group attribute: " + filterExpr);
         }
+    }
+
+    @Test
+    public void testNormalizeDoesNotMutateOrShareStateWithSource() throws Exception {
+        RangerServiceDef source = EmbeddedServiceDefsUtil.instance().getEmbeddedServiceDef(EmbeddedServiceDefsUtil.EMBEDDED_SERVICEDEF_HIVE_NAME);
+
+        assertNotNull(source, "hive embedded service-def should be available");
+        assertNotNull(source.getDataMaskDef(), "hive service-def should have dataMaskDef");
+        assertNotNull(source.getRowFilterDef(), "hive service-def should have rowFilterDef");
+
+        // snapshot every nested list/map/object reference on the source BEFORE calling normalize(),
+        // so we can prove afterward that normalize() never touched any of them
+        List<RangerAccessTypeDef> srcAccessTypes = source.getAccessTypes();
+        List<RangerServiceDef.RangerResourceDef> srcResources = source.getResources();
+        List<RangerServiceDef.RangerServiceConfigDef> srcConfigs = source.getConfigs();
+        RangerServiceDef.RangerDataMaskDef srcDataMaskDef = source.getDataMaskDef();
+        List<RangerAccessTypeDef> srcDataMaskAccessTypes = srcDataMaskDef.getAccessTypes();
+        List<RangerServiceDef.RangerResourceDef> srcDataMaskResources = srcDataMaskDef.getResources();
+        List<RangerServiceDef.RangerDataMaskTypeDef> srcMaskTypes = srcDataMaskDef.getMaskTypes();
+        RangerServiceDef.RangerRowFilterDef srcRowFilterDef = source.getRowFilterDef();
+        List<RangerAccessTypeDef> srcRowFilterAccessTypes = srcRowFilterDef.getAccessTypes();
+        List<RangerServiceDef.RangerResourceDef> srcRowFilterResources = srcRowFilterDef.getResources();
+
+        int srcAccessTypeCount = srcAccessTypes.size();
+        int srcResourceCount = srcResources.size();
+
+        RangerServiceDef normalized = ServiceDefUtil.normalize(source);
+
+        // --- normalize() must return a DIFFERENT object, not mutate source in place ---
+        assertNotSame(source, normalized, "normalize() must return a copy, not mutate the input in place");
+
+        // --- none of the returned object's nested collections may be the SAME instances as source's ---
+        assertNotSame(srcAccessTypes, normalized.getAccessTypes(), "accessTypes list must not be shared with source");
+        assertNotSame(srcResources, normalized.getResources(), "resources list must not be shared with source");
+        assertNotSame(srcConfigs, normalized.getConfigs(), "configs list must not be shared with source");
+        assertNotSame(srcDataMaskDef, normalized.getDataMaskDef(), "dataMaskDef must not be shared with source");
+        assertNotSame(srcDataMaskAccessTypes, normalized.getDataMaskDef().getAccessTypes(), "dataMaskDef.accessTypes must not be shared with source");
+        assertNotSame(srcDataMaskResources, normalized.getDataMaskDef().getResources(), "dataMaskDef.resources must not be shared with source");
+        assertNotSame(srcMaskTypes, normalized.getDataMaskDef().getMaskTypes(), "dataMaskDef.maskTypes must not be shared with source");
+        assertNotSame(srcRowFilterDef, normalized.getRowFilterDef(), "rowFilterDef must not be shared with source");
+        assertNotSame(srcRowFilterAccessTypes, normalized.getRowFilterDef().getAccessTypes(), "rowFilterDef.accessTypes must not be shared with source");
+        assertNotSame(srcRowFilterResources, normalized.getRowFilterDef().getResources(), "rowFilterDef.resources must not be shared with source");
+
+        // --- source's own fields must be completely untouched - same references, same sizes, as before the call ---
+        assertSame(srcAccessTypes, source.getAccessTypes(), "source.accessTypes reference must be unchanged after normalize()");
+        assertSame(srcResources, source.getResources(), "source.resources reference must be unchanged after normalize()");
+        assertSame(srcDataMaskDef, source.getDataMaskDef(), "source.dataMaskDef reference must be unchanged after normalize()");
+        assertEquals(srcAccessTypeCount, source.getAccessTypes().size(), "source.accessTypes size must be unchanged after normalize()");
+        assertEquals(srcResourceCount, source.getResources().size(), "source.resources size must be unchanged after normalize()");
+
+        // --- sanity: the copy still has real, non-empty data - not just identity-different but empty/broken ---
+        assertFalse(normalized.getAccessTypes().isEmpty(), "normalized accessTypes should not be empty");
+        assertFalse(normalized.getResources().isEmpty(), "normalized resources should not be empty");
     }
 
     private RangerAccessTypeDef getAccessType(List<RangerAccessTypeDef> accessTypeDefs, String accessType) {

--- a/security-admin/src/main/java/org/apache/ranger/service/RangerServiceDefServiceBase.java
+++ b/security-admin/src/main/java/org/apache/ranger/service/RangerServiceDefServiceBase.java
@@ -716,7 +716,7 @@ public abstract class RangerServiceDefServiceBase<T extends XXServiceDefBase, V 
 
         addImplicitConditionExpressionIfNeeded(serviceDef);
 
-        ServiceDefUtil.normalize(serviceDef);
+        serviceDef = (V) ServiceDefUtil.normalize(serviceDef);
 
         return serviceDef;
     }


### PR DESCRIPTION


## What changes were proposed in this pull request?

Under concurrent delegated-admin V2 API load, multiple threads rebuild the policy engine for the same service — or for services that share a tag serviceDef — at the same time. Each rebuild calls ServiceDefUtil.normalize() on the shared, cached RangerServiceDef, which mutates it in place, causing ConcurrentModificationException/NullPointerException under concurrent access.
The fix makes ServiceDefUtil.normalize() return a deep copy of the RangerServiceDef instead of mutating its input.

Initially, I assumed adding copy constructors and changing normalize() to copy-then-mutate would be enough on its own. However, ServiceDefUtil.normalize() was both mutating its input and returning it — which made its original intent ambiguous: was the return value meant to be authoritative, or was it just a convenience alongside the real effect (the in-place mutation)? Rather than guess, I took the conservative approach: treat the return value as authoritative, and update every call site to propagate the returned (now-copied) RangerServiceDef back to wherever the caller had originally expected the mutation to be visible. This keeps the change behavior-preserving — nothing that depended on seeing the normalized state after calling normalize() loses that guarantee — while fully resolving the CME/NPE.

## How was this patch tested?

Existing unit tests updated and passing.
New test testNormalizeDoesNotMutateOrShareStateWithSource verifies identity and content isolation.
Local concurrency exercises (same serviceDef + cross-service shared tag serviceDef) no longer reproduce the CME/NPE