### PR TITLE
RANGER-5709: Fix KMS secure download for roles, tags, and userstore

### DIFF
--- a/security-admin/src/main/java/org/apache/ranger/rest/RoleREST.java
+++ b/security-admin/src/main/java/org/apache/ranger/rest/RoleREST.java
@@ -1085,7 +1085,7 @@ public class RoleREST {
         boolean     isKeyAdmin        = bizUtil.isKeyAdmin();
         Long        downloadedVersion = null;
         boolean     isValid           = false;
-        boolean     isAllowed;
+        boolean     isAllowed         = false;
 
         request.setAttribute("downloadPolicy", "secure");
 
@@ -1110,18 +1110,22 @@ public class RoleREST {
                 }
 
                 XXServiceDef  xServiceDef   = daoManager.getXXServiceDef().getById(xService.getType());
-                RangerService rangerService = svcStore.getServiceByName(serviceName);
+                RangerService rangerService;
 
                 if (StringUtils.equals(xServiceDef.getImplclassname(), EmbeddedServiceDefsUtil.KMS_IMPL_CLASS_NAME)) {
+                    rangerService = svcStore.getServiceByNameForDP(serviceName);
+
                     if (isKeyAdmin) {
                         isAllowed = true;
-                    } else {
+                    } else if (rangerService != null) {
                         isAllowed = bizUtil.isUserAllowed(rangerService, POLICY_DOWNLOAD_USERS);
                     }
                 } else {
+                    rangerService = svcStore.getServiceByName(serviceName);
+
                     if (isAdmin) {
                         isAllowed = true;
-                    } else {
+                    } else if (rangerService != null) {
                         isAllowed = bizUtil.isUserAllowed(rangerService, POLICY_DOWNLOAD_USERS);
                     }
                 }

--- a/security-admin/src/main/java/org/apache/ranger/rest/TagREST.java
+++ b/security-admin/src/main/java/org/apache/ranger/rest/TagREST.java
@@ -1316,7 +1316,7 @@ public class TagREST {
         Long        downloadedVersion = null;
         String      clusterName       = null;
         String      logMsg;
-        boolean     isAllowed;
+        boolean     isAllowed         = false;
 
         if (request != null) {
             clusterName = !StringUtils.isEmpty(request.getParameter(SearchFilter.CLUSTER_NAME)) ? request.getParameter(SearchFilter.CLUSTER_NAME) : "";
@@ -1332,18 +1332,22 @@ public class TagREST {
             }
 
             XXServiceDef  xServiceDef   = daoManager.getXXServiceDef().getById(xService.getType());
-            RangerService rangerService = svcStore.getServiceByName(serviceName);
+            RangerService rangerService;
 
             if (StringUtils.equals(xServiceDef.getImplclassname(), EmbeddedServiceDefsUtil.KMS_IMPL_CLASS_NAME)) {
+                rangerService = svcStore.getServiceByNameForDP(serviceName);
+
                 if (isKeyAdmin) {
                     isAllowed = true;
-                } else {
+                } else if (rangerService != null) {
                     isAllowed = bizUtil.isUserAllowed(rangerService, Allowed_User_List_For_Tag_Download);
                 }
             } else {
+                rangerService = svcStore.getServiceByName(serviceName);
+
                 if (isAdmin) {
                     isAllowed = true;
-                } else {
+                } else if (rangerService != null) {
                     isAllowed = bizUtil.isUserAllowed(rangerService, Allowed_User_List_For_Tag_Download);
                 }
             }

--- a/security-admin/src/main/java/org/apache/ranger/rest/XUserREST.java
+++ b/security-admin/src/main/java/org/apache/ranger/rest/XUserREST.java
@@ -1444,7 +1444,7 @@ public class XUserREST {
         boolean         isKeyAdmin        = bizUtil.isKeyAdmin();
         Long            downloadedVersion = null;
         boolean         isValid           = false;
-        boolean         isAllowed;
+        boolean         isAllowed         = false;
 
         try {
             isValid = serviceUtil.isValidService(serviceName, request);
@@ -1465,18 +1465,22 @@ public class XUserREST {
 
             if (isValid && xService != null) {
                 XXServiceDef  xServiceDef   = rangerDaoManager.getXXServiceDef().getById(xService.getType());
-                RangerService rangerService = svcStore.getServiceByName(serviceName);
+                RangerService rangerService;
 
                 if (StringUtils.equals(xServiceDef.getImplclassname(), EmbeddedServiceDefsUtil.KMS_IMPL_CLASS_NAME)) {
+                    rangerService = svcStore.getServiceByNameForDP(serviceName);
+
                     if (isKeyAdmin) {
                         isAllowed = true;
-                    } else {
+                    } else if (rangerService != null) {
                         isAllowed = bizUtil.isUserAllowed(rangerService, USERSTORE_DOWNLOAD_USERS);
                     }
                 } else {
+                    rangerService = svcStore.getServiceByName(serviceName);
+
                     if (isAdmin) {
                         isAllowed = true;
-                    } else {
+                    } else if (rangerService != null) {
                         isAllowed = bizUtil.isUserAllowed(rangerService, USERSTORE_DOWNLOAD_USERS);
                     }
                 }

--- a/security-admin/src/test/java/org/apache/ranger/rest/TestRoleREST.java
+++ b/security-admin/src/test/java/org/apache/ranger/rest/TestRoleREST.java
@@ -35,14 +35,17 @@ import org.apache.ranger.db.XXRoleDao;
 import org.apache.ranger.db.XXRoleRefGroupDao;
 import org.apache.ranger.db.XXRoleRefRoleDao;
 import org.apache.ranger.db.XXRoleRefUserDao;
+import org.apache.ranger.db.XXServiceDefDao;
 import org.apache.ranger.entity.XXPortalUser;
 import org.apache.ranger.entity.XXRoleRefGroup;
 import org.apache.ranger.entity.XXRoleRefUser;
 import org.apache.ranger.entity.XXService;
+import org.apache.ranger.entity.XXServiceDef;
 import org.apache.ranger.plugin.model.RangerPolicy;
 import org.apache.ranger.plugin.model.RangerPolicy.RangerPolicyItem;
 import org.apache.ranger.plugin.model.RangerPolicy.RangerPolicyResource;
 import org.apache.ranger.plugin.model.RangerRole;
+import org.apache.ranger.plugin.model.RangerService;
 import org.apache.ranger.plugin.model.validation.RangerRoleValidator;
 import org.apache.ranger.plugin.util.GrantRevokeRoleRequest;
 import org.apache.ranger.plugin.util.RangerRoles;
@@ -877,6 +880,47 @@ public class TestRoleREST {
                 throw new RuntimeException(e);
             }
         });
+    }
+
+    @Test
+    public void test17eGetSecureRangerRolesIfUpdatedKmsUsesServiceByNameForDP() throws Exception {
+        RangerRoles rangerRoles        = createRangerRoles();
+        String      serviceName        = "dev_kms";
+        String      pluginId           = "kms-plugin";
+        String      clusterName        = "";
+        String      pluginCapabilities = "";
+
+        XXService xService = createXXService();
+        xService.setName(serviceName);
+        xService.setType(Id);
+
+        XXServiceDef xServiceDef = new XXServiceDef();
+        xServiceDef.setId(Id);
+        xServiceDef.setImplclassname("org.apache.ranger.services.kms.RangerServiceKMS");
+
+        RangerService rangerService = new RangerService();
+        rangerService.setId(Id);
+        rangerService.setName(serviceName);
+
+        XXServiceDefDao xServiceDefDao = Mockito.mock(XXServiceDefDao.class);
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+
+        Mockito.when(serviceUtil.isValidService(serviceName, request)).thenReturn(true);
+        Mockito.when(daoMgr.getXXService().findByName(serviceName)).thenReturn(xService);
+        Mockito.when(daoMgr.getXXServiceDef()).thenReturn(xServiceDefDao);
+        Mockito.when(xServiceDefDao.getById(xService.getType())).thenReturn(xServiceDef);
+        Mockito.when(bizUtil.isAdmin()).thenReturn(false);
+        Mockito.when(bizUtil.isKeyAdmin()).thenReturn(false);
+        Mockito.when(svcStore.getServiceByNameForDP(serviceName)).thenReturn(rangerService);
+        Mockito.when(bizUtil.isUserAllowed(rangerService, RoleREST.POLICY_DOWNLOAD_USERS)).thenReturn(true);
+        Mockito.when(roleStore.getRoles(serviceName, -1L)).thenReturn(rangerRoles);
+
+        RangerRoles result = roleRest.getSecureRangerRolesIfUpdated(serviceName, -1L, 0L, pluginId, clusterName, pluginCapabilities, request);
+
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(rangerRoles.getRangerRoles().size(), result.getRangerRoles().size());
+        Mockito.verify(svcStore).getServiceByNameForDP(serviceName);
+        Mockito.verify(bizUtil).isUserAllowed(rangerService, RoleREST.POLICY_DOWNLOAD_USERS);
     }
 
     // empty request roles (requestParamRoles = 0, dbRoles = 5, return = all dbRoles)

--- a/security-admin/src/test/java/org/apache/ranger/rest/TestTagREST.java
+++ b/security-admin/src/test/java/org/apache/ranger/rest/TestTagREST.java
@@ -1604,7 +1604,7 @@ public class TestTagREST {
         Mockito.when(daoManager.getXXServiceDef()).thenReturn(xXServiceDefDao);
         Mockito.when(xXServiceDefDao.getById(xService.getType())).thenReturn(xServiceDef);
         try {
-            Mockito.when(svcStore.getServiceByName(serviceName)).thenReturn(rangerService);
+            Mockito.when(svcStore.getServiceByNameForDP(serviceName)).thenReturn(rangerService);
         } catch (Exception e) {
         }
 
@@ -1625,7 +1625,7 @@ public class TestTagREST {
         Mockito.verify(daoManager).getXXServiceDef();
         Mockito.verify(xXServiceDefDao).getById(xService.getType());
         try {
-            Mockito.verify(svcStore).getServiceByName(serviceName);
+            Mockito.verify(svcStore).getServiceByNameForDP(serviceName);
         } catch (Exception e) {
         }
         try {
@@ -1730,7 +1730,7 @@ public class TestTagREST {
         Mockito.when(daoManager.getXXServiceDef()).thenReturn(xXServiceDefDao);
         Mockito.when(xXServiceDefDao.getById(xService.getType())).thenReturn(xServiceDef);
         try {
-            Mockito.when(svcStore.getServiceByName(serviceName)).thenReturn(rangerService);
+            Mockito.when(svcStore.getServiceByNameForDP(serviceName)).thenReturn(rangerService);
         } catch (Exception e) {
         }
 
@@ -1752,7 +1752,7 @@ public class TestTagREST {
         Mockito.verify(daoManager).getXXServiceDef();
         Mockito.verify(xXServiceDefDao).getById(xService.getType());
         try {
-            Mockito.verify(svcStore).getServiceByName(serviceName);
+            Mockito.verify(svcStore).getServiceByNameForDP(serviceName);
         } catch (Exception e) {
         }
         Mockito.verify(bizUtil).isUserAllowed(rangerService, Allowed_User_List_For_Tag_Download);


### PR DESCRIPTION
## Summary

KMS plugin users (e.g. `rangerkms`) were getting HTTP 400 on secure **roles**, **tags**, and **userstore** download. Those endpoints called `getServiceByName()`, which requires keyadmin to read a KMS service—before the download allowlist is checked.

Policy download already uses `getServiceByNameForDP()` for KMS. This PR applies the same pattern to:

| Endpoint | Allowlist config |
|----------|------------------|
| `RoleREST.getSecureRangerRolesIfUpdated()` | `policy.download.auth.users` |
| `TagREST.getSecureServiceTagsIfUpdated()` | `tag.download.auth.users` |
| `XUserREST.getSecureRangerUserStoreIfUpdated()` | `userstore.download.auth.users` |

## Test changes

- **TestTagREST** — updated KMS mocks (`test52`, `test54`) to expect `getServiceByNameForDP()`
- **TestRoleREST** — added `test17eGetSecureRangerRolesIfUpdatedKmsUsesServiceByNameForDP`
- **TestXUserREST** — no code changes (existing tests still pass)

## Test plan

- [x] `TestTagREST` KMS secure download tests
- [x] `TestRoleREST#test17e` KMS secure roles download
- [x] `TestRoleREST#test17*` regression
- [x] `TestXUserREST#test142` regression
- [x] PMD on `security-admin`

https://issues.apache.org/jira/browse/RANGER-5709