### PR TITLE
RANGER-5710: Default access audit store to Solr

### DIFF
--- a/dev-support/ranger-docker/scripts/admin/ranger-admin-install-postgres.properties
+++ b/dev-support/ranger-docker/scripts/admin/ranger-admin-install-postgres.properties
@@ -46,10 +46,10 @@ keyadmin_password=rangerR0cks!
 ## --- Audit store: enable ONE of the following blocks ---
 
 ## Option 1: Solr (default)
-# audit_store=solr
+audit_store=solr
 # FQDN required for SPNEGO to Solr (HTTP/ranger-solr.rangernw@REALM)
-# audit_solr_urls=http://ranger-solr.rangernw:8983/solr/ranger_audits
-# audit_solr_collection_name=ranger_audits
+audit_solr_urls=http://ranger-solr.rangernw:8983/solr/ranger_audits
+audit_solr_collection_name=ranger_audits
 
 ## Option 2: OpenSearch / Elasticsearch (legacy - uses ES HighLevel REST Client)
 # audit_store=elasticsearch
@@ -62,14 +62,14 @@ keyadmin_password=rangerR0cks!
 # audit_elasticsearch_bootstrap_enabled=true
 
 ## Option 3: OpenSearch (native - uses low-level REST client, works with any OpenSearch version)
-audit_store=opensearch
-audit_opensearch_urls=ranger-opensearch
-audit_opensearch_port=9200
-audit_opensearch_protocol=http
-audit_opensearch_user=admin
-audit_opensearch_password=admin
-audit_opensearch_index=ranger_audits
-audit_opensearch_bootstrap_enabled=true
+# audit_store=opensearch
+# audit_opensearch_urls=ranger-opensearch
+# audit_opensearch_port=9200
+# audit_opensearch_protocol=http
+# audit_opensearch_user=admin
+# audit_opensearch_password=admin
+# audit_opensearch_index=ranger_audits
+# audit_opensearch_bootstrap_enabled=true
 
 policymgr_external_url=http://ranger-admin:6080
 policymgr_http_enabled=true

--- a/security-admin/src/main/java/org/apache/ranger/biz/RangerBizUtil.java
+++ b/security-admin/src/main/java/org/apache/ranger/biz/RangerBizUtil.java
@@ -130,7 +130,7 @@ public class RangerBizUtil {
     Set<Class<?>> groupEditableClasses;
     int           maxDisplayNameLength = 150;
     boolean       enableResourceAccessControl;
-    String        auditDBType = AUDIT_STORE_RDBMS;
+    String        auditDBType = AUDIT_STORE_SOLR;
 
     public RangerBizUtil() {
         RangerAdminConfig config = RangerAdminConfig.getInstance();

--- a/security-admin/src/main/resources/conf.dist/ranger-admin-site.xml
+++ b/security-admin/src/main/resources/conf.dist/ranger-admin-site.xml
@@ -141,7 +141,7 @@
 	</property>
 	<property>
 		<name>ranger.audit.source.type</name>
-		<value>db</value>
+		<value>solr</value>
 		<description></description>
 	</property>
 


### PR DESCRIPTION
## Summary

The `ClassCastException` on multi-value `requestUser` occurred because installs fell through to the deprecated **DB audit path** when `ranger.audit.source.type` was unset or misconfigured:

1. `RangerBizUtil` defaulted to `AUDIT_STORE_RDBMS` when the property was missing
2. Docker Postgres `install.properties` had `audit_store=opensearch` active while Solr URLs were commented out

This PR fixes configuration defaults so fresh installs and docker stacks use **Solr** (or explicitly configured OpenSearch), not the legacy DB path.

## Changes

- **`RangerBizUtil`**: default `auditDBType` → `AUDIT_STORE_SOLR` (was `AUDIT_STORE_RDBMS`)
- **`conf.dist/ranger-admin-site.xml`**: default `ranger.audit.source.type` → `solr` (was `db`)
- **Docker Postgres `install.properties`**: enable `audit_store=solr` with FQDN Solr URLs; comment out OpenSearch block

## Test plan

- [ ] Fresh install: `ranger.audit.source.type=solr` in `ranger-admin-site.xml` after setup
- [ ] Docker Postgres stack: Admin audit UI queries Solr (no DB path in logs)
- [ ] `GET /service/assets/accessAudit?requestUser=admin&requestUser=hive` → HTTP 200 via Solr path
- [ ] Existing installs with explicit `ranger.audit.source.type` unchanged

https://issues.apache.org/jira/browse/RANGER-5710
