### PR TITLE
RANGER-5713: Move ranger-hadoop bulk chown to image build time

### DIFF
--- a/dev-support/ranger-docker/Dockerfile.ranger-hadoop
+++ b/dev-support/ranger-docker/Dockerfile.ranger-hadoop
@@ -44,6 +44,9 @@ RUN tar xvfz /home/ranger/dist/hadoop-${HADOOP_VERSION}.tar.gz --directory=/opt/
     ln -s /opt/ranger/ranger-${YARN_PLUGIN_VERSION}-yarn-plugin /opt/ranger/ranger-yarn-plugin && \
     rm -f /home/ranger/dist/ranger-${YARN_PLUGIN_VERSION}-yarn-plugin.tar.gz && \
     rm -f /opt/ranger/ranger-yarn-plugin/install.properties && \
+    cp /opt/tez/lib/*.jar /opt/hadoop/share/hadoop/yarn/lib/ 2>/dev/null || true && \
+    cp /opt/tez/*.jar /opt/hadoop/share/hadoop/yarn/lib/ 2>/dev/null || true && \
+    chown -R hdfs:hadoop /opt/hadoop && \
     chmod 744 ${RANGER_SCRIPTS}/ranger-hadoop-setup.sh ${RANGER_SCRIPTS}/ranger-hadoop.sh ${RANGER_SCRIPTS}/ranger-hadoop-mkdir.sh && \
     useradd -g hadoop -ms /bin/bash healthcheck && \
     chmod 744 ${RANGER_SCRIPTS}/ranger-hadoop-healthcheck.sh && \

--- a/dev-support/ranger-docker/scripts/hadoop/ranger-hadoop-setup.sh
+++ b/dev-support/ranger-docker/scripts/hadoop/ranger-hadoop-setup.sh
@@ -42,26 +42,17 @@ cp ${RANGER_SCRIPTS}/hdfs-site.xml ${HADOOP_HOME}/etc/hadoop/hdfs-site.xml
 cp ${RANGER_SCRIPTS}/yarn-site.xml ${HADOOP_HOME}/etc/hadoop/yarn-site.xml
 
 mkdir -p /opt/hadoop/logs
-chown -R hdfs:hadoop /opt/hadoop/
 chmod g+w /opt/hadoop/logs
 # user logs directory permissions for NodeManager health
 mkdir -p ${HADOOP_HOME}/logs/userlogs
 chown -R yarn:hadoop ${HADOOP_HOME}/logs/userlogs
 chmod -R 777 ${HADOOP_HOME}/logs/userlogs
 
-# Install Tez JARs for YARN NodeManager
-echo "Installing Tez JARs for YARN NodeManager..."
+# Tez JARs are installed at image build time; ensure conf dir exists at runtime.
 if [ -d "/opt/tez" ]; then
-    echo "Copying Tez JARs to YARN lib directory..."
-    cp /opt/tez/lib/*.jar /opt/hadoop/share/hadoop/yarn/lib/ 2>/dev/null
-    cp /opt/tez/*.jar /opt/hadoop/share/hadoop/yarn/lib/ 2>/dev/null
-
-    # Set up Tez environment
     export TEZ_HOME=/opt/tez
     export TEZ_CONF_DIR=${TEZ_HOME}/conf
     mkdir -p ${TEZ_CONF_DIR}
-
-    echo "Tez JARs installed successfully for YARN NodeManager"
 else
     echo "WARNING: Tez directory not found at /opt/tez"
 fi
@@ -71,3 +62,13 @@ cd ${RANGER_HOME}/ranger-hdfs-plugin
 
 cd ${RANGER_HOME}/ranger-yarn-plugin
 ./enable-yarn-plugin.sh
+
+# Ownership for /opt/hadoop is set at image build time. Only fix paths modified here.
+chown hdfs:hadoop \
+    "${HADOOP_HOME}/etc/hadoop/hadoop-env.sh" \
+    "${HADOOP_HOME}/etc/hadoop/core-site.xml" \
+    "${HADOOP_HOME}/etc/hadoop/hdfs-site.xml" \
+    "${HADOOP_HOME}/etc/hadoop/yarn-site.xml" \
+    /opt/hadoop/logs
+chown -R hdfs:hadoop "${HADOOP_HOME}/etc/hadoop"
+chown -R yarn:hadoop "${HADOOP_HOME}/logs/userlogs"


### PR DESCRIPTION
## Summary

- Move `chown -R hdfs:hadoop /opt/hadoop` and Tez JAR installation to `Dockerfile.ranger-hadoop` at image build time
- Remove the expensive recursive chown from `ranger-hadoop-setup.sh` on every container start
- At runtime, only chown paths modified during setup (config files, logs, plugin changes)

Fixes slow first-boot startup of the `ranger-hadoop` container (30+ minutes on some hosts), which blocks Hive, HBase, and other services waiting on the Hadoop healthcheck.

Jira: https://issues.apache.org/jira/browse/RANGER-5713

## Test plan

- [ ] Rebuild hadoop image: `docker compose -f docker-compose.ranger-hadoop.yml build ranger-hadoop`
- [ ] Recreate container: `docker compose -f docker-compose.ranger-hadoop.yml up -d --force-recreate ranger-hadoop`
- [ ] Confirm `ranger-hadoop` becomes healthy quickly (~30–60s vs 30+ min)
- [ ] Verify HDFS and YARN start cleanly
- [ ] Confirm Hive/HBase no longer timeout waiting on `ranger-hadoop`