### PR TITLE
RANGER-5718: Add gson to PDP server lib classpath

### DIFF
--- a/distro/src/main/assembly/pdp.xml
+++ b/distro/src/main/assembly/pdp.xml
@@ -82,6 +82,9 @@
                     <include>org.glassfish.hk2.external:javax.inject</include>
                     <include>org.glassfish:osgi-resource-locator</include>
 
+                    <!-- Gson (policy/role/tag JSON parsing in ranger-plugins-common) -->
+                    <include>com.google.code.gson:gson:jar:${gson.version}</include>
+
                     <!-- Jackson (JSON serialization for authz-api model classes) -->
                     <include>com.fasterxml.jackson.core:jackson-databind:jar:${fasterxml.jackson.databind.version}</include>
                     <include>com.fasterxml.jackson.core:jackson-core:jar:${fasterxml.jackson.version}</include>

--- a/pdp/pom.xml
+++ b/pdp/pom.xml
@@ -50,6 +50,11 @@
             <version>${fasterxml.jackson.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>${gson.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.nimbusds</groupId>
             <artifactId>nimbus-jose-jwt</artifactId>
             <version>${nimbus-jose-jwt.version}</version>


### PR DESCRIPTION
## Summary

Fixes `NoClassDefFoundError: com/google/gson/GsonBuilder` logged by the Ranger PDP server on every plugin initialization when policies/tags are downloaded from Admin.

The PDP assembly descriptor (`distro/src/main/assembly/pdp.xml`) uses a strict `lib/` dependency whitelist but did not include `gson`, unlike other Ranger plugin assemblies (KMS, Kafka, Solr, etc.). As a result, `ranger-2.9.0-pdp.tar.gz` and the `ranger-pdp` docker image ship without `gson-*.jar` on the classpath.

Policy download and authorization still work today because `RangerAdminRESTClient` parses Admin REST responses with Jackson. The error is non-fatal (`AbstractRangerAdminClient.init()` catches it and leaves `gson` null) but is noisy and leaves file-based policy sources (`EmbeddedResourcePolicySource`, `LocalFolderPolicySource`) without Gson support.

## Changes

- **`distro/src/main/assembly/pdp.xml`**: add `com.google.code.gson:gson:jar:${gson.version}` to the binaries whitelist
- **`pdp/pom.xml`**: declare explicit `gson` runtime dependency

## Test plan

- [x] Built PDP modules with the change (`mvn install -pl pdp,... -am`)
- [x] Assembly descriptor resolves gson to `gson-2.9.0`
- [x] Docker smoke test on existing `rangernw` stack (isolated PDP on port 16500):
  - With `gson-2.9.0.jar` in `lib/`: health READY, `POST /authz/v1/authorize` → ALLOW, `PolicyRefresher` downloads policies, **no GsonBuilder ERROR**
  - Without gson (pre-fix): same `NoClassDefFoundError` reproduced
- [ ] CI green
- [ ] After merge: rebuild `ranger-*-pdp.tar.gz` and verify `tar -tzf ... | grep gson`

## Jira

https://issues.apache.org/jira/browse/RANGER-5718

Made with [Cursor](https://cursor.com)