### PR TITLE
RANGER-5714 : Ranger server returns an incorrect error message when when an admin tries to revoke a non-existing role from a user

### DIFF
--- a/security-admin/src/main/java/org/apache/ranger/biz/RoleDBStore.java
+++ b/security-admin/src/main/java/org/apache/ranger/biz/RoleDBStore.java
@@ -214,7 +214,7 @@ public class RoleDBStore implements RoleStore {
         XXRole xxRole = daoMgr.getXXRole().findByRoleName(name);
 
         if (xxRole == null) {
-            throw restErrorUtil.createRESTException("Role with name: " + name + " does not exist");
+            throw restErrorUtil.createRESTException("Role with name: " + name + " does not exist.");
         }
 
         return roleService.read(xxRole.getId());

--- a/security-admin/src/main/java/org/apache/ranger/rest/RoleREST.java
+++ b/security-admin/src/main/java/org/apache/ranger/rest/RoleREST.java
@@ -1283,6 +1283,8 @@ public class RoleREST {
             } else {
                 existingRole = roleStore.getRole(roleName);
             }
+        } catch (WebApplicationException ex) {
+            throw ex;
         } catch (Exception ex) {
             LOG.error(ex.getMessage());
 

--- a/security-admin/src/test/java/org/apache/ranger/rest/TestRoleREST.java
+++ b/security-admin/src/test/java/org/apache/ranger/rest/TestRoleREST.java
@@ -1728,4 +1728,24 @@ public class TestRoleREST {
             roleRest.getSecureRangerRolesIfUpdated(serviceName, -1L, 0L, pluginId, clusterName, pluginCapabilities, Mockito.mock(HttpServletRequest.class));
         });
     }
+
+    @Test
+    public void test35GrantRoleNonExistentRole() throws Exception {
+        String                 serviceName            = "serviceName";
+        GrantRevokeRoleRequest grantRevokeRoleRequest = createGrantRevokeRoleRequest();
+        String                 roleName               = "role_100";
+        WebApplicationException roleNotFoundException   = new WebApplicationException("Role with name: " + roleName + " does not exist");
+
+        grantRevokeRoleRequest.setTargetRoles(new HashSet<>(Collections.singletonList(roleName)));
+
+        Mockito.when(bizUtil.isUserRangerAdmin(Mockito.anyString())).thenReturn(true);
+        Mockito.when(roleStore.getRole(roleName)).thenThrow(roleNotFoundException);
+
+        WebApplicationException exception = Assertions.assertThrows(WebApplicationException.class, () -> {
+            roleRest.grantRole(serviceName, grantRevokeRoleRequest, Mockito.mock(HttpServletRequest.class));
+        });
+
+        Assertions.assertNotNull(exception);
+        Mockito.verify(roleStore, Mockito.times(1)).getRole(roleName);
+    }
 }


### PR DESCRIPTION
Ranger server returns an incorrect error message when when an admin tries to revoke a non-existing role from a user

## What changes were proposed in this pull request?
We found the Ranger server would return an incorrect error message when an admin tries to revoke a non-existing role from a user. In what follows I provide the steps to reproduce the issue in a beeline instance connected to Hive Server2.
correct message should be - "Role with name: " + name + " does not exist."

corresponding JIRA issue number. (https://issues.apache.org/jira/projects/RANGER/issues/RANGER-5714)


## How was this patch tested?
tested first in deployment with Docker.
then cluster was created and tested with HS2 beeline.
