### PR TITLE
RANGER-5729: Unable to import exported GDS policies via Service Manag…

### DIFF
--- a/security-admin/src/main/java/org/apache/ranger/rest/ServiceREST.java
+++ b/security-admin/src/main/java/org/apache/ranger/rest/ServiceREST.java
@@ -3488,6 +3488,12 @@ public class ServiceREST {
                 RangerPolicy policy = entry.getValue();
 
                 if (policy != null) {
+                    if (isGdsPolicy(policy)) {
+                        LOG.warn("Skipping GDS policy '{}' during import - GDS policies must be managed via GDS APIs", policy.getName());
+
+                        continue;
+                    }
+
                     if (!CollectionUtils.isEmpty(serviceNameList)) {
                         for (String service : serviceNameList) {
                             if (StringUtils.isNotEmpty(service.trim()) && StringUtils.isNotEmpty(policy.getService().trim())) {
@@ -3833,7 +3839,7 @@ public class ServiceREST {
 
         if (!CollectionUtils.isEmpty(policyLists)) {
             for (RangerPolicy policy : policyLists) {
-                if (policy != null) {
+                if (policy != null && !isGdsPolicy(policy)) {
                     //set createTime & updateTime Time as null since exported policies dont need this
                     policy.setCreateTime(null);
                     policy.setUpdateTime(null);
@@ -3841,14 +3847,16 @@ public class ServiceREST {
                     orderedPolicies.put(policy.getId(), policy);
                 }
             }
-            if (!orderedPolicies.isEmpty()) {
-                policyLists.clear();
 
-                policyLists.addAll(orderedPolicies.values());
-            }
+            policyLists.clear();
+            policyLists.addAll(orderedPolicies.values());
         }
 
         return policyLists;
+    }
+
+    private boolean isGdsPolicy(RangerPolicy policy) {
+        return EMBEDDED_SERVICEDEF_GDS_NAME.equals(policy.getServiceType());
     }
 
     private void deletePoliciesProvidedInServiceMap(List<String> sourceServices, List<String> destinationServices, String zoneName) throws Exception {

--- a/security-admin/src/test/java/org/apache/ranger/rest/TestServiceREST.java
+++ b/security-admin/src/test/java/org/apache/ranger/rest/TestServiceREST.java
@@ -4672,4 +4672,109 @@ public class TestServiceREST {
                 "serviceDef Id mismatch or service name not provided",
                 true);
     }
+
+    @Test
+    public void testIsGdsPolicy_ByServiceType() throws Exception {
+        Method m = ServiceREST.class.getDeclaredMethod("isGdsPolicy", RangerPolicy.class);
+        m.setAccessible(true);
+        RangerPolicy policy = new RangerPolicy();
+        policy.setServiceType(EmbeddedServiceDefsUtil.EMBEDDED_SERVICEDEF_GDS_NAME);
+
+        Assertions.assertTrue((Boolean) m.invoke(serviceREST, policy));
+    }
+
+    @Test
+    public void testIsGdsPolicy_ByServiceNameOnlyReturnsFalse() throws Exception {
+        Method m = ServiceREST.class.getDeclaredMethod("isGdsPolicy", RangerPolicy.class);
+        m.setAccessible(true);
+        RangerPolicy policy = new RangerPolicy();
+        policy.setService(ServiceDBStore.GDS_SERVICE_NAME);
+
+        Assertions.assertFalse((Boolean) m.invoke(serviceREST, policy));
+    }
+
+    @Test
+    public void testIsGdsPolicy_NonGdsPolicy() throws Exception {
+        Method m = ServiceREST.class.getDeclaredMethod("isGdsPolicy", RangerPolicy.class);
+        m.setAccessible(true);
+        RangerPolicy policy = rangerPolicy();
+        policy.setServiceType("hive");
+        policy.setService("dev_hive");
+
+        Assertions.assertFalse((Boolean) m.invoke(serviceREST, policy));
+    }
+
+    @Test
+    public void testGetAllFilteredPolicyList_ExcludesGdsPolicies() throws Exception {
+        ServiceREST spy = Mockito.spy(serviceREST);
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        SearchFilter filter = new SearchFilter();
+
+        RangerPolicy hivePolicy = new RangerPolicy();
+        hivePolicy.setId(1L);
+        hivePolicy.setService("dev_hive");
+        hivePolicy.setServiceType("hive");
+        hivePolicy.setName("hive-policy");
+
+        RangerPolicy gdsPolicy = new RangerPolicy();
+        gdsPolicy.setId(2L);
+        gdsPolicy.setService(ServiceDBStore.GDS_SERVICE_NAME);
+        gdsPolicy.setServiceType(EmbeddedServiceDefsUtil.EMBEDDED_SERVICEDEF_GDS_NAME);
+        gdsPolicy.setName("DATASET: dataset_test1");
+
+        Mockito.doReturn(new ArrayList<>(Arrays.asList(hivePolicy, gdsPolicy))).when(spy).getPolicies(Mockito.any(SearchFilter.class));
+
+        Method m = ServiceREST.class.getDeclaredMethod("getAllFilteredPolicyList", SearchFilter.class, HttpServletRequest.class, List.class);
+        m.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        List<RangerPolicy> out = (List<RangerPolicy>) m.invoke(spy, filter, request, new ArrayList<>());
+
+        Assertions.assertNotNull(out);
+        Assertions.assertEquals(1, out.size());
+        Assertions.assertEquals(hivePolicy.getId(), out.get(0).getId());
+    }
+
+    @Test
+    public void testGetAllFilteredPolicyList_ExcludesOnlyGdsPoliciesReturnsEmpty() throws Exception {
+        ServiceREST spy = Mockito.spy(serviceREST);
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        SearchFilter filter = new SearchFilter();
+
+        RangerPolicy gdsPolicy = new RangerPolicy();
+        gdsPolicy.setId(2L);
+        gdsPolicy.setService(ServiceDBStore.GDS_SERVICE_NAME);
+        gdsPolicy.setServiceType(EmbeddedServiceDefsUtil.EMBEDDED_SERVICEDEF_GDS_NAME);
+        gdsPolicy.setName("DATASET: dataset_test1");
+
+        Mockito.doReturn(new ArrayList<>(Collections.singletonList(gdsPolicy))).when(spy).getPolicies(Mockito.any(SearchFilter.class));
+
+        Method m = ServiceREST.class.getDeclaredMethod("getAllFilteredPolicyList", SearchFilter.class, HttpServletRequest.class, List.class);
+        m.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        List<RangerPolicy> out = (List<RangerPolicy>) m.invoke(spy, filter, request, new ArrayList<>());
+
+        Assertions.assertNotNull(out);
+        Assertions.assertTrue(out.isEmpty());
+    }
+
+    @Test
+    public void testCreatePolicesBasedOnPolicyMap_SkipsGdsPolicy() throws Exception {
+        ServiceREST spy = Mockito.spy(serviceREST);
+        Method m = ServiceREST.class.getDeclaredMethod("createPolicesBasedOnPolicyMap", HttpServletRequest.class, Map.class, List.class, boolean.class, int.class);
+        m.setAccessible(true);
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+
+        RangerPolicy gdsPolicy = new RangerPolicy();
+        gdsPolicy.setService(ServiceDBStore.GDS_SERVICE_NAME);
+        gdsPolicy.setServiceType(EmbeddedServiceDefsUtil.EMBEDDED_SERVICEDEF_GDS_NAME);
+        gdsPolicy.setName("DATASET: dataset_test1");
+
+        Map<String, RangerPolicy> map = new HashMap<>();
+        map.put("gds", gdsPolicy);
+
+        int ret = (int) m.invoke(spy, request, map, Collections.emptyList(), false, 0);
+
+        Assertions.assertEquals(0, ret);
+        Mockito.verify(spy, Mockito.never()).createPolicy(Mockito.any(RangerPolicy.class), Mockito.eq(request));
+    }
 }


### PR DESCRIPTION
…er due to 403 Error

## What changes were proposed in this pull request?

Governed Data Sharing (GDS) policies are designed to be managed exclusively through GDS APIs. However, they were inadvertently being included when exporting policies from the Report page. When users attempted to import these files back through the Service Manager, it resulted in a 403 error.

This patch resolves the issue by aligning the export and import behaviors:

**Export Updates**: GDS policies are now automatically excluded when exporting policies (JSON, CSV, or Excel).

**Import Updates**: If a user imports a legacy file that still contains GDS policies, the system will now safely skip the GDS policies (logging a helpful warning) rather than failing the entire import. This ensures that non-GDS policies, like Hive, continue to import successfully.


## How was this patch tested?

Created both GDS objects (datashares, datasets, policies) and non-GDS policies (Hive).

Exported policies from the Report page and verified that GDS policies are no longer included in the file.

Imported the newly exported file via Service Manager and confirmed it succeeds without a 403 error.

Imported a legacy export file containing GDS policies to verify that non-GDS policies import correctly while GDS policies are cleanly skipped and logged.
