### PR TITLE
RANGER-5673: Update Apache Ranger website with 2.9.0

### DIFF
--- a/docs/src/site/site.xml
+++ b/docs/src/site/site.xml
@@ -75,6 +75,7 @@ under the License.
 	    <item name="Security Advisories" href="https://cwiki.apache.org/confluence/display/RANGER/Vulnerabilities+found+in+Ranger" target="_blank" />
     </menu>
     <menu name="Releases">
+        <item name="2.9.0" href="https://cwiki.apache.org/confluence/display/RANGER/Apache+Ranger+2.9.0+-+Release+Notes" target="_blank" />
         <item name="2.8.0" href="https://cwiki.apache.org/confluence/display/RANGER/Apache+Ranger+2.8.0+-+Release+Notes" target="_blank" />
         <item name="2.7.0" href="https://cwiki.apache.org/confluence/display/RANGER/Apache+Ranger+2.7.0+-+Release+Notes" target="_blank" />
         <item name="2.6.0" href="https://cwiki.apache.org/confluence/display/RANGER/Apache+Ranger+2.6.0+-+Release+Notes" target="_blank" />

--- a/docs/src/site/xdoc/download.xml
+++ b/docs/src/site/xdoc/download.xml
@@ -29,7 +29,17 @@
 <ul>
 <li>
 <p>
-Current Stable release - Apache Ranger 2.8.0:
+Current Stable release - Apache Ranger 2.9.0:
+</p>
+<p>
+<a href="https://downloads.apache.org/ranger/2.9.0/apache-ranger-2.9.0.tar.gz">apache-ranger-2.9.0.tar.gz</a>
+(<a href="https://downloads.apache.org/ranger/2.9.0/apache-ranger-2.9.0.tar.gz.asc">PGP</a>)
+(<a href="https://downloads.apache.org/ranger/2.9.0/apache-ranger-2.9.0.tar.gz.sha512">Digest</a>)
+</p>
+</li>
+<li>
+<p>
+Apache Ranger 2.8.0:
 </p>
 <p>
 <a href="https://downloads.apache.org/ranger/2.8.0/apache-ranger-2.8.0.tar.gz">apache-ranger-2.8.0.tar.gz</a>
@@ -52,9 +62,9 @@ Apache Ranger 2.7.0:
 Apache Ranger 2.6.0:
 </p>
 <p>
-<a href="https://downloads.apache.org/ranger/2.6.0/apache-ranger-2.6.0.tar.gz">apache-ranger-2.6.0.tar.gz</a>
-(<a href="https://downloads.apache.org/ranger/2.6.0/apache-ranger-2.6.0.tar.gz.asc">PGP</a>)
-(<a href="https://downloads.apache.org/ranger/2.6.0/apache-ranger-2.6.0.tar.gz.sha512">Digest</a>)
+<a href="https://archive.apache.org/dist/ranger/2.6.0/apache-ranger-2.6.0.tar.gz">apache-ranger-2.6.0.tar.gz</a>
+(<a href="https://archive.apache.org/dist/ranger/2.6.0/apache-ranger-2.6.0.tar.gz.asc">PGP</a>)
+(<a href="https://archive.apache.org/dist/ranger/2.6.0/apache-ranger-2.6.0.tar.gz.sha512">Digest</a>)
 </p>
 </li>
 <li>

--- a/docs/src/site/xdoc/download.xml
+++ b/docs/src/site/xdoc/download.xml
@@ -62,9 +62,9 @@ Apache Ranger 2.7.0:
 Apache Ranger 2.6.0:
 </p>
 <p>
-<a href="https://archive.apache.org/dist/ranger/2.6.0/apache-ranger-2.6.0.tar.gz">apache-ranger-2.6.0.tar.gz</a>
-(<a href="https://archive.apache.org/dist/ranger/2.6.0/apache-ranger-2.6.0.tar.gz.asc">PGP</a>)
-(<a href="https://archive.apache.org/dist/ranger/2.6.0/apache-ranger-2.6.0.tar.gz.sha512">Digest</a>)
+<a href="https://downloads.apache.org/ranger/2.6.0/apache-ranger-2.6.0.tar.gz">apache-ranger-2.6.0.tar.gz</a>
+(<a href="https://downloads.apache.org/ranger/2.6.0/apache-ranger-2.6.0.tar.gz.asc">PGP</a>)
+(<a href="https://downloads.apache.org/ranger/2.6.0/apache-ranger-2.6.0.tar.gz.sha512">Digest</a>)
 </p>
 </li>
 <li>


### PR DESCRIPTION
## Summary
- Add Apache Ranger 2.9.0 as the current stable release on the download page.
- Add 2.9.0 release notes link to the site navigation menu.
## Test plan
- [x] Verified 2.9.0 source tarball, PGP, and SHA512 links return HTTP 200 on downloads.apache.org.
- [x] Verified Confluence release notes URL for 2.9.0 is reachable.