### PR TITLE
RANGER-5736: Fix MariaDB grant failure during Ranger Admin DB setup

### DIFF
--- a/kms/scripts/dba_script.py
+++ b/kms/scripts/dba_script.py
@@ -149,6 +149,23 @@ class MysqlConf(BaseDB):
 		self.javax_net_ssl_keyStorePassword=javax_net_ssl_keyStorePassword
 		self.javax_net_ssl_trustStore=javax_net_ssl_trustStore
 		self.javax_net_ssl_trustStorePassword=javax_net_ssl_trustStorePassword
+		self.is_mariadb = None
+
+	def detect_server_type(self, get_cmd, db_root_password):
+		if self.is_mariadb is not None:
+			return self.is_mariadb
+		if is_unix:
+			query = get_cmd + " -query \"SELECT version();\""
+		elif os_name == "WINDOWS":
+			query = get_cmd + " -query \"SELECT version();\" -c ;"
+		jisql_log(query, db_root_password)
+		output = check_output(query).lower()
+		self.is_mariadb = "mariadb" in output
+		if self.is_mariadb:
+			log("[I] Detected MariaDB server", "info")
+		else:
+			log("[I] Detected MySQL-compatible server (non-MariaDB)", "info")
+		return self.is_mariadb
 
 	def get_jisql_cmd(self, user, password ,db_name):
 		#TODO: User array for forming command
@@ -171,6 +188,14 @@ class MysqlConf(BaseDB):
 			self.JAVA_BIN = self.JAVA_BIN.strip("'")
 			jisql_cmd = "%s %s -cp %s;%s\\jisql\\lib\\* org.apache.util.sql.Jisql -driver mysqlconj -cstring jdbc:mysql://%s/%s%s -u %s -p \"%s\" -noheader -trim" %(self.JAVA_BIN,db_ssl_cert_param,self.SQL_CONNECTOR_JAR, path, self.host, db_name,db_ssl_param, user, password)
 		return jisql_cmd
+
+	def user_hosts(self):
+		if self.host == "localhost":
+			return ["%", "localhost"]
+		if self.is_mariadb is True:
+			# Grant db_host before FLUSH from wildcard/localhost grants (MariaDB docker init issue).
+			return [self.host, "%", "localhost"]
+		return ["%", "localhost", self.host]
 
 	def verify_user(self, root_user, db_root_password, host, db_user, get_cmd,dryMode):
 		if dryMode == False:
@@ -195,8 +220,9 @@ class MysqlConf(BaseDB):
 			query = get_cmd + " -query \"SELECT version();\" -c ;"
 		jisql_log(query, db_password)
 		output = check_output(query)
-		if output.strip('Production  |'):
-			#log("[I] Checking connection passed.", "info")
+		if output.strip('Production  |') or output.strip():
+			if self.is_mariadb is None:
+				self.is_mariadb = "mariadb" in output.lower()
 			return True
 		else:
 			log("[E] Can't establish db connection.. Exiting.." ,"error")
@@ -204,8 +230,7 @@ class MysqlConf(BaseDB):
 
 	def create_rangerdb_user(self, root_user, db_user, db_password, db_root_password,dryMode):
 		if self.check_connection('mysql', root_user, db_root_password):
-			hosts_arr =["%", "localhost"]
-			hosts_arr.append(self.host)
+			hosts_arr = self.user_hosts()
 			for host in hosts_arr:
 				get_cmd = self.get_jisql_cmd(root_user, db_root_password, 'mysql')
 				if self.verify_user(root_user, db_root_password, host, db_user, get_cmd,dryMode):
@@ -303,12 +328,13 @@ class MysqlConf(BaseDB):
 				logFile("create database %s;" %(db_name))
 
 	def grant_xa_db_user(self, root_user, db_name, db_user, db_password, db_root_password, is_revoke,dryMode):
-		hosts_arr =["%", "localhost"]
-		hosts_arr.append(self.host)
+		hosts_arr = self.user_hosts()
+		get_cmd = self.get_jisql_cmd(root_user, db_root_password, 'mysql')
+		if dryMode == False:
+			self.detect_server_type(get_cmd, db_root_password)
 		for host in hosts_arr:
 			if dryMode == False:
 				log("[I] ---------- Granting privileges TO user '"+db_user+"'@'"+host+"' on db '"+db_name+"'----------" , "info")
-				get_cmd = self.get_jisql_cmd(root_user, db_root_password, 'mysql')
 				if is_unix:
 					query = get_cmd + " -query \"grant all privileges on %s.* to '%s'@'%s' with grant option;\"" %(db_name,db_user, host)
 					jisql_log(query, db_root_password)
@@ -317,16 +343,52 @@ class MysqlConf(BaseDB):
 					query = get_cmd + " -query \"grant all privileges on %s.* to '%s'@'%s' with grant option;\" -c ;" %(db_name,db_user, host)
 					jisql_log(query, db_root_password)
 					ret = subprocess.call(query)
-				if ret == 0:
-					log("[I] ---------- FLUSH PRIVILEGES ----------" , "info")
+				if ret != 0 and self.is_mariadb is True:
+					log("[I] Grant failed for '" + db_user + "'@'" + host + "', recreating user and retrying", "info")
 					if is_unix:
-						query = get_cmd + " -query \"FLUSH PRIVILEGES;\""
-						jisql_log(query, db_root_password)
-						ret = subprocess.call(shlex.split(query))
+						drop_query = get_cmd + " -query \"drop user if exists '%s'@'%s';\"" %(db_user, host)
+						jisql_log(drop_query, db_root_password)
+						subprocess.call(shlex.split(drop_query))
+						if db_password == "":
+							create_query = get_cmd + " -query \"create user '%s'@'%s';\"" %(db_user, host)
+							jisql_log(create_query, db_root_password)
+							ret = subprocess.call(shlex.split(create_query))
+						else:
+							create_query = get_cmd + " -query \"create user '%s'@'%s' identified by '%s';\"" %(db_user, host, db_password)
+							create_query_with_masked_pwd = get_cmd + " -query \"create user '%s'@'%s' identified by '%s';\"" %(db_user, host, masked_pwd_string)
+							jisql_log(create_query_with_masked_pwd, db_root_password)
+							ret = subprocess.call(shlex.split(create_query))
 					elif os_name == "WINDOWS":
-						query = get_cmd + " -query \"FLUSH PRIVILEGES;\" -c ;"
-						jisql_log(query, db_root_password)
-						ret = subprocess.call(query)
+						drop_query = get_cmd + " -query \"drop user if exists '%s'@'%s';\" -c ;" %(db_user, host)
+						jisql_log(drop_query, db_root_password)
+						subprocess.call(drop_query)
+						if db_password == "":
+							create_query = get_cmd + " -query \"create user '%s'@'%s';\" -c ;" %(db_user, host)
+							jisql_log(create_query, db_root_password)
+							ret = subprocess.call(create_query)
+						else:
+							create_query = get_cmd + " -query \"create user '%s'@'%s' identified by '%s';\" -c ;" %(db_user, host, db_password)
+							create_query_with_masked_pwd = get_cmd + " -query \"create user '%s'@'%s' identified by '%s';\" -c ;" %(db_user, host, masked_pwd_string)
+							jisql_log(create_query_with_masked_pwd, db_root_password)
+							ret = subprocess.call(create_query)
+					if ret == 0 and self.verify_user(root_user, db_root_password, host, db_user, get_cmd, dryMode):
+						if is_unix:
+							ret = subprocess.call(shlex.split(query))
+						elif os_name == "WINDOWS":
+							ret = subprocess.call(query)
+					else:
+						ret = 1
+				if ret == 0:
+					if self.is_mariadb is not True:
+						log("[I] ---------- FLUSH PRIVILEGES ----------" , "info")
+						if is_unix:
+							query = get_cmd + " -query \"FLUSH PRIVILEGES;\""
+							jisql_log(query, db_root_password)
+							ret = subprocess.call(shlex.split(query))
+						elif os_name == "WINDOWS":
+							query = get_cmd + " -query \"FLUSH PRIVILEGES;\" -c ;"
+							jisql_log(query, db_root_password)
+							ret = subprocess.call(query)
 					if ret == 0:
 						log("[I] Privileges granted to '" + db_user + "' on '"+db_name+"'", "info")
 					else:
@@ -337,11 +399,23 @@ class MysqlConf(BaseDB):
 					sys.exit(1)
 			else:
 				logFile("grant all privileges on %s.* to '%s'@'%s' with grant option;" %(db_name,db_user, host))
+		if dryMode == False and self.is_mariadb is True:
+			log("[I] ---------- FLUSH PRIVILEGES ----------" , "info")
+			if is_unix:
+				query = get_cmd + " -query \"FLUSH PRIVILEGES;\""
+				jisql_log(query, db_root_password)
+				ret = subprocess.call(shlex.split(query))
+			elif os_name == "WINDOWS":
+				query = get_cmd + " -query \"FLUSH PRIVILEGES;\" -c ;"
+				jisql_log(query, db_root_password)
+				ret = subprocess.call(query)
+			if ret != 0:
+				log("[E] Granting privileges to '" +db_user+"' failed on '"+db_name+"'", "error")
+				sys.exit(1)
 
 	def writeDrymodeCmd(self, xa_db_root_user, xa_db_root_password, db_user, db_password, db_name):
 		logFile("# Login to MySQL Server from a MySQL dba user(i.e 'root') to execute below sql statements.")
-		hosts_arr =["%", "localhost"]
-		if not self.host == "localhost": hosts_arr.append(self.host)
+		hosts_arr = self.user_hosts()
 		for host in hosts_arr:
 			logFile("create user '%s'@'%s' identified by '%s';" %(db_user, host, db_password))
 		logFile("create database %s;"%(db_name))

--- a/security-admin/scripts/dba_script.py
+++ b/security-admin/scripts/dba_script.py
@@ -216,86 +216,13 @@ class MysqlConf(BaseDB):
 			jisql_cmd = "%s %s -cp %s;%s\\jisql\\lib\\* org.apache.util.sql.Jisql -driver mysqlconj -cstring jdbc:mysql://%s/%s%s -u %s -p \"%s\" -noheader -trim" %(self.JAVA_BIN, db_ssl_cert_param,self.SQL_CONNECTOR_JAR, path, self.host, db_name,db_ssl_param,user, password)
 		return jisql_cmd
 
-	def mysql_user_hosts(self):
+	def user_hosts(self):
 		if self.host == "localhost":
 			return ["%", "localhost"]
 		if self.is_mariadb is True:
 			# Grant db_host before FLUSH from wildcard/localhost grants (MariaDB docker init issue).
 			return [self.host, "%", "localhost"]
 		return ["%", "localhost", self.host]
-
-	def recreate_mysql_user(self, root_user, db_root_password, db_user, db_password, host, get_cmd, dryMode):
-		if dryMode == False:
-			log("[I] Recreating MySQL user " + db_user + " for host " + host, "info")
-		if is_unix:
-			query = get_cmd + " -query \"drop user if exists '%s'@'%s';\"" %(db_user, host)
-			jisql_log(query, db_root_password)
-			subprocessCallWithRetry(shlex.split(query))
-			if db_password == "":
-				query = get_cmd + " -query \"create user '%s'@'%s';\"" %(db_user, host)
-				jisql_log(query, db_root_password)
-				ret = subprocessCallWithRetry(shlex.split(query))
-			else:
-				query = get_cmd + " -query \"create user '%s'@'%s' identified by '%s';\"" %(db_user, host, db_password)
-				query_with_masked_pwd = get_cmd + " -query \"create user '%s'@'%s' identified by '%s';\"" %(db_user, host, masked_pwd_string)
-				jisql_log(query_with_masked_pwd, db_root_password)
-				ret = subprocessCallWithRetry(shlex.split(query))
-		elif os_name == "WINDOWS":
-			query = get_cmd + " -query \"drop user if exists '%s'@'%s';\" -c ;" %(db_user, host)
-			jisql_log(query, db_root_password)
-			subprocessCallWithRetry(query)
-			if db_password == "":
-				query = get_cmd + " -query \"create user '%s'@'%s';\" -c ;" %(db_user, host)
-				jisql_log(query, db_root_password)
-				ret = subprocessCallWithRetry(query)
-			else:
-				query = get_cmd + " -query \"create user '%s'@'%s' identified by '%s';\" -c ;" %(db_user, host, db_password)
-				query_with_masked_pwd = get_cmd + " -query \"create user '%s'@'%s' identified by '%s';\" -c ;" %(db_user, host, masked_pwd_string)
-				jisql_log(query_with_masked_pwd, db_root_password)
-				ret = subprocessCallWithRetry(query)
-		if ret != 0:
-			return False
-		return self.verify_user(root_user, db_root_password, host, db_user, get_cmd, dryMode)
-
-	def grant_mysql_user_on_db(self, get_cmd, db_root_password, db_name, db_user, db_password, host, root_user, dryMode, retry_on_failure):
-		if dryMode == False:
-			log("[I] ---------- Granting privileges TO user '"+db_user+"'@'"+host+"' on db '"+db_name+"'----------" , "info")
-			if is_unix:
-				query = get_cmd + " -query \"grant all privileges on %s.* to '%s'@'%s' with grant option;\"" %(db_name,db_user, host)
-				jisql_log(query, db_root_password)
-				ret = subprocessCallWithRetry(shlex.split(query))
-			elif os_name == "WINDOWS":
-				query = get_cmd + " -query \"grant all privileges on %s.* to '%s'@'%s' with grant option;\" -c ;" %(db_name,db_user, host)
-				jisql_log(query, db_root_password)
-				ret = subprocessCallWithRetry(query)
-			if ret != 0 and retry_on_failure:
-				log("[I] Grant failed for '" + db_user + "'@'" + host + "', recreating user and retrying", "info")
-				if not self.recreate_mysql_user(root_user, db_root_password, db_user, db_password, host, get_cmd, dryMode):
-					return False
-				if is_unix:
-					ret = subprocessCallWithRetry(shlex.split(query))
-				elif os_name == "WINDOWS":
-					ret = subprocessCallWithRetry(query)
-			if ret != 0:
-				return False
-			log("[I] Privileges granted to '" + db_user + "' on '"+db_name+"'", "info")
-		else:
-			logFile("grant all privileges on %s.* to '%s'@'%s' with grant option;" %(db_name,db_user, host))
-		return True
-
-	def flush_mysql_privileges(self, get_cmd, db_root_password, db_user, db_name):
-		log("[I] ---------- FLUSH PRIVILEGES ----------" , "info")
-		if is_unix:
-			query = get_cmd + " -query \"FLUSH PRIVILEGES;\""
-			jisql_log(query, db_root_password)
-			ret = subprocessCallWithRetry(shlex.split(query))
-		elif os_name == "WINDOWS":
-			query = get_cmd + " -query \"FLUSH PRIVILEGES;\" -c ;"
-			jisql_log(query, db_root_password)
-			ret = subprocessCallWithRetry(query)
-		if ret != 0:
-			log("[E] Granting privileges to '" +db_user+"' failed on '"+db_name+"'", "error")
-			sys.exit(1)
 
 	def verify_user(self, root_user, db_root_password, host, db_user, get_cmd,dryMode):
 		if dryMode == False:
@@ -330,7 +257,7 @@ class MysqlConf(BaseDB):
 
 	def create_rangerdb_user(self, root_user, db_user, db_password, db_root_password,dryMode):
 		if self.check_connection('mysql', root_user, db_root_password):
-			hosts_arr = self.mysql_user_hosts()
+			hosts_arr = self.user_hosts()
 			for host in hosts_arr:
 				get_cmd = self.get_jisql_cmd(root_user, db_root_password, 'mysql')
 				if self.verify_user(root_user, db_root_password, host, db_user, get_cmd,dryMode):
@@ -427,19 +354,90 @@ class MysqlConf(BaseDB):
 
 
 	def grant_xa_db_user(self, root_user, db_name, db_user, db_password, db_root_password, is_revoke,dryMode):
+		hosts_arr = self.user_hosts()
 		get_cmd = self.get_jisql_cmd(root_user, db_root_password, 'mysql')
 		if dryMode == False:
 			self.detect_server_type(get_cmd, db_root_password)
-		hosts_arr = self.mysql_user_hosts()
-		retry_on_failure = self.is_mariadb is True
 		for host in hosts_arr:
-			if not self.grant_mysql_user_on_db(get_cmd, db_root_password, db_name, db_user, db_password, host, root_user, dryMode, retry_on_failure):
+			if dryMode == False:
+				log("[I] ---------- Granting privileges TO user '"+db_user+"'@'"+host+"' on db '"+db_name+"'----------" , "info")
+				if is_unix:
+					query = get_cmd + " -query \"grant all privileges on %s.* to '%s'@'%s' with grant option;\"" %(db_name,db_user, host)
+					jisql_log(query, db_root_password)
+					ret = subprocessCallWithRetry(shlex.split(query))
+				elif os_name == "WINDOWS":
+					query = get_cmd + " -query \"grant all privileges on %s.* to '%s'@'%s' with grant option;\" -c ;" %(db_name,db_user, host)
+					jisql_log(query, db_root_password)
+					ret = subprocessCallWithRetry(query)
+				if ret != 0 and self.is_mariadb is True:
+					log("[I] Grant failed for '" + db_user + "'@'" + host + "', recreating user and retrying", "info")
+					if is_unix:
+						drop_query = get_cmd + " -query \"drop user if exists '%s'@'%s';\"" %(db_user, host)
+						jisql_log(drop_query, db_root_password)
+						subprocessCallWithRetry(shlex.split(drop_query))
+						if db_password == "":
+							create_query = get_cmd + " -query \"create user '%s'@'%s';\"" %(db_user, host)
+							jisql_log(create_query, db_root_password)
+							ret = subprocessCallWithRetry(shlex.split(create_query))
+						else:
+							create_query = get_cmd + " -query \"create user '%s'@'%s' identified by '%s';\"" %(db_user, host, db_password)
+							create_query_with_masked_pwd = get_cmd + " -query \"create user '%s'@'%s' identified by '%s';\"" %(db_user, host, masked_pwd_string)
+							jisql_log(create_query_with_masked_pwd, db_root_password)
+							ret = subprocessCallWithRetry(shlex.split(create_query))
+					elif os_name == "WINDOWS":
+						drop_query = get_cmd + " -query \"drop user if exists '%s'@'%s';\" -c ;" %(db_user, host)
+						jisql_log(drop_query, db_root_password)
+						subprocessCallWithRetry(drop_query)
+						if db_password == "":
+							create_query = get_cmd + " -query \"create user '%s'@'%s';\" -c ;" %(db_user, host)
+							jisql_log(create_query, db_root_password)
+							ret = subprocessCallWithRetry(create_query)
+						else:
+							create_query = get_cmd + " -query \"create user '%s'@'%s' identified by '%s';\" -c ;" %(db_user, host, db_password)
+							create_query_with_masked_pwd = get_cmd + " -query \"create user '%s'@'%s' identified by '%s';\" -c ;" %(db_user, host, masked_pwd_string)
+							jisql_log(create_query_with_masked_pwd, db_root_password)
+							ret = subprocessCallWithRetry(create_query)
+					if ret == 0 and self.verify_user(root_user, db_root_password, host, db_user, get_cmd, dryMode):
+						if is_unix:
+							ret = subprocessCallWithRetry(shlex.split(query))
+						elif os_name == "WINDOWS":
+							ret = subprocessCallWithRetry(query)
+					else:
+						ret = 1
+				if ret == 0:
+					if self.is_mariadb is not True:
+						log("[I] ---------- FLUSH PRIVILEGES ----------" , "info")
+						if is_unix:
+							query = get_cmd + " -query \"FLUSH PRIVILEGES;\""
+							jisql_log(query, db_root_password)
+							ret = subprocessCallWithRetry(shlex.split(query))
+						elif os_name == "WINDOWS":
+							query = get_cmd + " -query \"FLUSH PRIVILEGES;\" -c ;"
+							jisql_log(query, db_root_password)
+							ret = subprocessCallWithRetry(query)
+					if ret == 0:
+						log("[I] Privileges granted to '" + db_user + "' on '"+db_name+"'", "info")
+					else:
+						log("[E] Granting privileges to '" +db_user+"' failed on '"+db_name+"'", "error")
+						sys.exit(1)
+				else:
+					log("[E] Granting privileges to '" +db_user+"' failed on '"+db_name+"'", "error")
+					sys.exit(1)
+			else:
+				logFile("grant all privileges on %s.* to '%s'@'%s' with grant option;" %(db_name,db_user, host))
+		if dryMode == False and self.is_mariadb is True:
+			log("[I] ---------- FLUSH PRIVILEGES ----------" , "info")
+			if is_unix:
+				query = get_cmd + " -query \"FLUSH PRIVILEGES;\""
+				jisql_log(query, db_root_password)
+				ret = subprocessCallWithRetry(shlex.split(query))
+			elif os_name == "WINDOWS":
+				query = get_cmd + " -query \"FLUSH PRIVILEGES;\" -c ;"
+				jisql_log(query, db_root_password)
+				ret = subprocessCallWithRetry(query)
+			if ret != 0:
 				log("[E] Granting privileges to '" +db_user+"' failed on '"+db_name+"'", "error")
 				sys.exit(1)
-			if dryMode == False and self.is_mariadb is not True:
-				self.flush_mysql_privileges(get_cmd, db_root_password, db_user, db_name)
-		if dryMode == False and self.is_mariadb is True:
-			self.flush_mysql_privileges(get_cmd, db_root_password, db_user, db_name)
 
 	def create_auditdb_user(self, xa_db_host, audit_db_host, db_name, audit_db_name, xa_db_root_user, audit_db_root_user, db_user, audit_db_user, xa_db_root_password, audit_db_root_password, db_password, audit_db_password, DBA_MODE,dryMode):
 		is_revoke=False
@@ -452,7 +450,7 @@ class MysqlConf(BaseDB):
 
 	def writeDrymodeCmd(self, xa_db_host, audit_db_host, xa_db_root_user, xa_db_root_password, db_user, db_password, db_name, audit_db_root_user, audit_db_root_password, audit_db_user, audit_db_password, audit_db_name):
 		logFile("# Login to MySQL Server from a MySQL dba user(i.e 'root') to execute below sql statements.")
-		hosts_arr = self.mysql_user_hosts()
+		hosts_arr = self.user_hosts()
 		for host in hosts_arr:
 			logFile("create user '%s'@'%s' identified by '%s';" %(db_user, host, db_password))
 		logFile("create database %s;"%(db_name))

--- a/security-admin/scripts/dba_script.py
+++ b/security-admin/scripts/dba_script.py
@@ -176,6 +176,23 @@ class MysqlConf(BaseDB):
 		self.javax_net_ssl_keyStorePassword=javax_net_ssl_keyStorePassword
 		self.javax_net_ssl_trustStore=javax_net_ssl_trustStore
 		self.javax_net_ssl_trustStorePassword=javax_net_ssl_trustStorePassword
+		self.is_mariadb = None
+
+	def detect_server_type(self, get_cmd, db_root_password):
+		if self.is_mariadb is not None:
+			return self.is_mariadb
+		if is_unix:
+			query = get_cmd + " -query \"SELECT version();\""
+		elif os_name == "WINDOWS":
+			query = get_cmd + " -query \"SELECT version();\" -c ;"
+		jisql_log(query, db_root_password)
+		output = check_output(query).lower()
+		self.is_mariadb = "mariadb" in output
+		if self.is_mariadb:
+			log("[I] Detected MariaDB server", "info")
+		else:
+			log("[I] Detected MySQL-compatible server (non-MariaDB)", "info")
+		return self.is_mariadb
 
 	def get_jisql_cmd(self, user, password ,db_name):
 		#TODO: User array for forming command
@@ -198,6 +215,87 @@ class MysqlConf(BaseDB):
 			self.JAVA_BIN = self.JAVA_BIN.strip("'")
 			jisql_cmd = "%s %s -cp %s;%s\\jisql\\lib\\* org.apache.util.sql.Jisql -driver mysqlconj -cstring jdbc:mysql://%s/%s%s -u %s -p \"%s\" -noheader -trim" %(self.JAVA_BIN, db_ssl_cert_param,self.SQL_CONNECTOR_JAR, path, self.host, db_name,db_ssl_param,user, password)
 		return jisql_cmd
+
+	def mysql_user_hosts(self):
+		if self.host == "localhost":
+			return ["%", "localhost"]
+		if self.is_mariadb is True:
+			# Grant db_host before FLUSH from wildcard/localhost grants (MariaDB docker init issue).
+			return [self.host, "%", "localhost"]
+		return ["%", "localhost", self.host]
+
+	def recreate_mysql_user(self, root_user, db_root_password, db_user, db_password, host, get_cmd, dryMode):
+		if dryMode == False:
+			log("[I] Recreating MySQL user " + db_user + " for host " + host, "info")
+		if is_unix:
+			query = get_cmd + " -query \"drop user if exists '%s'@'%s';\"" %(db_user, host)
+			jisql_log(query, db_root_password)
+			subprocessCallWithRetry(shlex.split(query))
+			if db_password == "":
+				query = get_cmd + " -query \"create user '%s'@'%s';\"" %(db_user, host)
+				jisql_log(query, db_root_password)
+				ret = subprocessCallWithRetry(shlex.split(query))
+			else:
+				query = get_cmd + " -query \"create user '%s'@'%s' identified by '%s';\"" %(db_user, host, db_password)
+				query_with_masked_pwd = get_cmd + " -query \"create user '%s'@'%s' identified by '%s';\"" %(db_user, host, masked_pwd_string)
+				jisql_log(query_with_masked_pwd, db_root_password)
+				ret = subprocessCallWithRetry(shlex.split(query))
+		elif os_name == "WINDOWS":
+			query = get_cmd + " -query \"drop user if exists '%s'@'%s';\" -c ;" %(db_user, host)
+			jisql_log(query, db_root_password)
+			subprocessCallWithRetry(query)
+			if db_password == "":
+				query = get_cmd + " -query \"create user '%s'@'%s';\" -c ;" %(db_user, host)
+				jisql_log(query, db_root_password)
+				ret = subprocessCallWithRetry(query)
+			else:
+				query = get_cmd + " -query \"create user '%s'@'%s' identified by '%s';\" -c ;" %(db_user, host, db_password)
+				query_with_masked_pwd = get_cmd + " -query \"create user '%s'@'%s' identified by '%s';\" -c ;" %(db_user, host, masked_pwd_string)
+				jisql_log(query_with_masked_pwd, db_root_password)
+				ret = subprocessCallWithRetry(query)
+		if ret != 0:
+			return False
+		return self.verify_user(root_user, db_root_password, host, db_user, get_cmd, dryMode)
+
+	def grant_mysql_user_on_db(self, get_cmd, db_root_password, db_name, db_user, db_password, host, root_user, dryMode, retry_on_failure):
+		if dryMode == False:
+			log("[I] ---------- Granting privileges TO user '"+db_user+"'@'"+host+"' on db '"+db_name+"'----------" , "info")
+			if is_unix:
+				query = get_cmd + " -query \"grant all privileges on %s.* to '%s'@'%s' with grant option;\"" %(db_name,db_user, host)
+				jisql_log(query, db_root_password)
+				ret = subprocessCallWithRetry(shlex.split(query))
+			elif os_name == "WINDOWS":
+				query = get_cmd + " -query \"grant all privileges on %s.* to '%s'@'%s' with grant option;\" -c ;" %(db_name,db_user, host)
+				jisql_log(query, db_root_password)
+				ret = subprocessCallWithRetry(query)
+			if ret != 0 and retry_on_failure:
+				log("[I] Grant failed for '" + db_user + "'@'" + host + "', recreating user and retrying", "info")
+				if not self.recreate_mysql_user(root_user, db_root_password, db_user, db_password, host, get_cmd, dryMode):
+					return False
+				if is_unix:
+					ret = subprocessCallWithRetry(shlex.split(query))
+				elif os_name == "WINDOWS":
+					ret = subprocessCallWithRetry(query)
+			if ret != 0:
+				return False
+			log("[I] Privileges granted to '" + db_user + "' on '"+db_name+"'", "info")
+		else:
+			logFile("grant all privileges on %s.* to '%s'@'%s' with grant option;" %(db_name,db_user, host))
+		return True
+
+	def flush_mysql_privileges(self, get_cmd, db_root_password, db_user, db_name):
+		log("[I] ---------- FLUSH PRIVILEGES ----------" , "info")
+		if is_unix:
+			query = get_cmd + " -query \"FLUSH PRIVILEGES;\""
+			jisql_log(query, db_root_password)
+			ret = subprocessCallWithRetry(shlex.split(query))
+		elif os_name == "WINDOWS":
+			query = get_cmd + " -query \"FLUSH PRIVILEGES;\" -c ;"
+			jisql_log(query, db_root_password)
+			ret = subprocessCallWithRetry(query)
+		if ret != 0:
+			log("[E] Granting privileges to '" +db_user+"' failed on '"+db_name+"'", "error")
+			sys.exit(1)
 
 	def verify_user(self, root_user, db_root_password, host, db_user, get_cmd,dryMode):
 		if dryMode == False:
@@ -222,8 +320,9 @@ class MysqlConf(BaseDB):
 			query = get_cmd + " -query \"SELECT version();\" -c ;"
 		jisql_log(query, db_password)
 		output = check_output(query)
-		if output.strip('Production  |'):
-			#log("[I] Checking connection passed.", "info")
+		if output.strip('Production  |') or output.strip():
+			if self.is_mariadb is None:
+				self.is_mariadb = "mariadb" in output.lower()
 			return True
 		else:
 			log("[E] Can't establish db connection.. Exiting.." ,"error")
@@ -231,8 +330,7 @@ class MysqlConf(BaseDB):
 
 	def create_rangerdb_user(self, root_user, db_user, db_password, db_root_password,dryMode):
 		if self.check_connection('mysql', root_user, db_root_password):
-			hosts_arr =["%", "localhost"]
-			if not self.host == "localhost": hosts_arr.append(self.host)
+			hosts_arr = self.mysql_user_hosts()
 			for host in hosts_arr:
 				get_cmd = self.get_jisql_cmd(root_user, db_root_password, 'mysql')
 				if self.verify_user(root_user, db_root_password, host, db_user, get_cmd,dryMode):
@@ -329,40 +427,19 @@ class MysqlConf(BaseDB):
 
 
 	def grant_xa_db_user(self, root_user, db_name, db_user, db_password, db_root_password, is_revoke,dryMode):
-		hosts_arr =["%", "localhost"]
-		if not self.host == "localhost": hosts_arr.append(self.host)
+		get_cmd = self.get_jisql_cmd(root_user, db_root_password, 'mysql')
+		if dryMode == False:
+			self.detect_server_type(get_cmd, db_root_password)
+		hosts_arr = self.mysql_user_hosts()
+		retry_on_failure = self.is_mariadb is True
 		for host in hosts_arr:
-			if dryMode == False:
-				log("[I] ---------- Granting privileges TO user '"+db_user+"'@'"+host+"' on db '"+db_name+"'----------" , "info")
-				get_cmd = self.get_jisql_cmd(root_user, db_root_password, 'mysql')
-				if is_unix:
-					query = get_cmd + " -query \"grant all privileges on %s.* to '%s'@'%s' with grant option;\"" %(db_name,db_user, host)
-					jisql_log(query, db_root_password)
-					ret = subprocessCallWithRetry(shlex.split(query))
-				elif os_name == "WINDOWS":
-					query = get_cmd + " -query \"grant all privileges on %s.* to '%s'@'%s' with grant option;\" -c ;" %(db_name,db_user, host)
-					jisql_log(query, db_root_password)
-					ret = subprocessCallWithRetry(query)
-				if ret == 0:
-					log("[I] ---------- FLUSH PRIVILEGES ----------" , "info")
-					if is_unix:
-						query = get_cmd + " -query \"FLUSH PRIVILEGES;\""
-						jisql_log(query, db_root_password)
-						ret = subprocessCallWithRetry(shlex.split(query))
-					elif os_name == "WINDOWS":
-						query = get_cmd + " -query \"FLUSH PRIVILEGES;\" -c ;"
-						jisql_log(query, db_root_password)
-						ret = subprocessCallWithRetry(query)
-					if ret == 0:
-						log("[I] Privileges granted to '" + db_user + "' on '"+db_name+"'", "info")
-					else:
-						log("[E] Granting privileges to '" +db_user+"' failed on '"+db_name+"'", "error")
-						sys.exit(1)
-				else:
-					log("[E] Granting privileges to '" +db_user+"' failed on '"+db_name+"'", "error")
-					sys.exit(1)
-			else:
-				logFile("grant all privileges on %s.* to '%s'@'%s' with grant option;" %(db_name,db_user, host))
+			if not self.grant_mysql_user_on_db(get_cmd, db_root_password, db_name, db_user, db_password, host, root_user, dryMode, retry_on_failure):
+				log("[E] Granting privileges to '" +db_user+"' failed on '"+db_name+"'", "error")
+				sys.exit(1)
+			if dryMode == False and self.is_mariadb is not True:
+				self.flush_mysql_privileges(get_cmd, db_root_password, db_user, db_name)
+		if dryMode == False and self.is_mariadb is True:
+			self.flush_mysql_privileges(get_cmd, db_root_password, db_user, db_name)
 
 	def create_auditdb_user(self, xa_db_host, audit_db_host, db_name, audit_db_name, xa_db_root_user, audit_db_root_user, db_user, audit_db_user, xa_db_root_password, audit_db_root_password, db_password, audit_db_password, DBA_MODE,dryMode):
 		is_revoke=False
@@ -375,8 +452,7 @@ class MysqlConf(BaseDB):
 
 	def writeDrymodeCmd(self, xa_db_host, audit_db_host, xa_db_root_user, xa_db_root_password, db_user, db_password, db_name, audit_db_root_user, audit_db_root_password, audit_db_user, audit_db_password, audit_db_name):
 		logFile("# Login to MySQL Server from a MySQL dba user(i.e 'root') to execute below sql statements.")
-		hosts_arr =["%", "localhost"]
-		if not self.host == "localhost": hosts_arr.append(self.host)
+		hosts_arr = self.mysql_user_hosts()
 		for host in hosts_arr:
 			logFile("create user '%s'@'%s' identified by '%s';" %(db_user, host, db_password))
 		logFile("create database %s;"%(db_name))


### PR DESCRIPTION
## Summary

Fixes Ranger Admin and KMS database setup failure on MariaDB when `dba_script.py` grants privileges to a host-specific admin user (e.g. `'rangeradmin'@'ranger-db'` or `'rangerkms'@'ranger-db.rangernw'`). MariaDB returns MySQL error **1133** (*Can't find any matching row in the user table*) after wildcard/localhost grants when `FLUSH PRIVILEGES` runs between grants.

Ranger Docker's `DB_FLAVOR=MYSQL` path uses MariaDB (`Dockerfile.ranger-mysql`), not Oracle MySQL Server. This change detects MariaDB at runtime via `SELECT VERSION()` and applies MariaDB-specific grant order, flush timing, and a one-time user recreate/retry on failure. Oracle MySQL and all other DB flavor classes (`PostgresConf`, `OracleConf`, `SqlServerConf`, `SqlAnywhereConf`) are unchanged.

Jira: https://issues.apache.org/jira/browse/RANGER-5736

## Changes

- Detect MariaDB in `MysqlConf` using `SELECT VERSION()` in both `security-admin/scripts/dba_script.py` and `kms/scripts/dba_script.py`
- **MariaDB only:** grant `@db_host` before `@'%'` / `@'localhost'`, run `FLUSH PRIVILEGES` once at the end, drop/recreate user and retry grant once on failure
- **Non-MariaDB MySQL:** preserve original grant order and flush-after-each-grant behavior
- Add `detect_server_type()` and `user_hosts()` helpers; keep grant/flush logic inline in `grant_xa_db_user()`
- No changes to `init_mysql.sql` or other DB flavor setup paths

## Manual testing — Ranger Admin

Ran `security-admin/scripts/dba_script.py -q` (JDK 17) against Docker-backed databases using the corresponding Ranger Admin install properties (`db_host=ranger-db` where applicable):

| DB flavor | Server | Result | Notes |
|-----------|--------|--------|-------|
| MYSQL (MariaDB path) | MariaDB 10.7.3 + `init_mysql.sql` | **PASS** | Host-specific grant first; single FLUSH; recreate/retry if needed |
| MYSQL (non-MariaDB path) | Oracle MySQL 8.0.36 + `init_mysql.sql` | **PASS** | Original grant/flush sequence preserved |
| POSTGRES | PostgreSQL 13.16 | **PASS** | No MariaDB logic involved |
| MSSQL | SQL Server 2022 | **PASS** | No MariaDB logic involved |
| ORACLE | Oracle Free 23 | **PASS** | No MariaDB logic involved |
| SQLA (SQL Anywhere) | — | **Not tested** | No SQL Anywhere image in `ranger-docker` |

Verified the original failure is reproducible on MariaDB 10.7.3 and 10.11 with the pre-fix grant+flush sequence, and that the patched script completes successfully on MariaDB without modifying `init_mysql.sql`.

## Manual testing — Ranger KMS

Mirrored the same `MysqlConf` fix in `kms/scripts/dba_script.py` (KMS Docker hits the same 1133 grant failure). Ran `kms/scripts/dba_script.py -q` (JDK 17) using KMS Docker install properties (`db_host=ranger-db.rangernw`, `db_user=rangerkms`, `db_name=rangerkms`):

| DB flavor | Server | Result | Notes |
|-----------|--------|--------|-------|
| MYSQL (MariaDB path) | MariaDB 10.7.3 | **PASS** | Grants `'rangerkms'@'ranger-db.rangernw'` first; single FLUSH at end |
| MYSQL (non-MariaDB path) | Oracle MySQL 8.0.36 | **PASS** | Non-MariaDB path; per-grant FLUSH preserved |
| POSTGRES | PostgreSQL 13.16 | **PASS** | No MariaDB logic involved |
| MSSQL | SQL Server 2022 | **PASS** | Requires `rangerkms` DB + login/user (same as Docker `init_mssql.sh`) |
| ORACLE | Oracle Free 23.6 | **PASS** | No MariaDB logic involved |
| SQLA (SQL Anywhere) | — | **Not tested** | No SQL Anywhere image in `ranger-docker` |
