### PR TITLE
RANGER-5421: Align authorization and service detail handling for repository search APIs

### DIFF
--- a/security-admin/src/main/java/org/apache/ranger/common/ServiceUtil.java
+++ b/security-admin/src/main/java/org/apache/ranger/common/ServiceUtil.java
@@ -45,7 +45,6 @@ import org.apache.ranger.view.VXPermObj;
 import org.apache.ranger.view.VXPolicy;
 import org.apache.ranger.view.VXPolicyList;
 import org.apache.ranger.view.VXRepository;
-import org.apache.ranger.view.VXRepositoryList;
 import org.apache.ranger.view.VXResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -412,20 +411,6 @@ public class ServiceUtil {
         }
 
         return searchCriteria;
-    }
-
-    public VXRepositoryList rangerServiceListToPublicObjectList(List<RangerService> serviceList) {
-        List<VXRepository> repoList = new ArrayList<>();
-
-        for (RangerService service : serviceList) {
-            VXRepository vXRepo = toVXRepository(service);
-
-            if (vXRepo != null) {
-                repoList.add(vXRepo);
-            }
-        }
-
-        return new VXRepositoryList(repoList);
     }
 
     public VXPolicy toVXPolicy(RangerPolicy policy, RangerService service) {

--- a/security-admin/src/main/java/org/apache/ranger/rest/PublicAPIs.java
+++ b/security-admin/src/main/java/org/apache/ranger/rest/PublicAPIs.java
@@ -32,6 +32,7 @@ import org.apache.ranger.entity.XXService;
 import org.apache.ranger.plugin.model.RangerPolicy;
 import org.apache.ranger.plugin.model.RangerService;
 import org.apache.ranger.plugin.util.SearchFilter;
+import org.apache.ranger.security.context.RangerAPIList;
 import org.apache.ranger.service.RangerPolicyService;
 import org.apache.ranger.service.XAssetService;
 import org.apache.ranger.view.VXAsset;
@@ -62,6 +63,7 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Path("public")
@@ -175,18 +177,31 @@ public class PublicAPIs {
     @GET
     @Path("/api/repository/")
     @Produces("application/json")
+    @PreAuthorize("@rangerPreAuthSecurityHandler.isAPIAccessible(\"" + RangerAPIList.SEARCH_X_ASSETS + "\")")
     public VXRepositoryList searchRepositories(@Context HttpServletRequest request) {
         logger.debug("==> PublicAPIs.searchRepositories()");
 
+        VXRepositoryList ret = new VXRepositoryList();
+
         SearchFilter        filter      = searchUtil.getSearchFilterFromLegacyRequestForRepositorySearch(request, xAssetService.sortFields);
         List<RangerService> serviceList = serviceREST.getServices(filter);
-        VXRepositoryList    ret         = null;
 
         if (serviceList != null) {
-            ret = serviceUtil.rangerServiceListToPublicObjectList(serviceList);
+            List<VXRepository> repositories = new ArrayList<>(serviceList.size());
+            for (RangerService service : serviceList) {
+                VXRepository repository = serviceUtil.toVXRepository(service);
+
+                if (repository != null) {
+                    repositories.add(repository);
+                }
+            }
+
+            ret.setVXRepositories(repositories);
+            ret.setTotalCount(repositories.size());
+            ret.setResultSize(repositories.size());
         }
 
-        logger.debug("<== PublicAPIs.searchRepositories(): count={}", (ret == null ? 0 : ret.getListSize()));
+        logger.debug("<== PublicAPIs.searchRepositories(): count={}", ret.getListSize());
 
         return ret;
     }

--- a/security-admin/src/main/java/org/apache/ranger/rest/ServiceREST.java
+++ b/security-admin/src/main/java/org/apache/ranger/rest/ServiceREST.java
@@ -992,6 +992,19 @@ public class ServiceREST {
             }
 
             ret = svcStore.getServices(filter);
+
+            if (ret != null) {
+                UserSessionBase userSession = ContextUtil.getCurrentUserSession();
+                if (userSession != null && userSession.isSingleRoleUserSession()) {
+                    List<RangerService> updateServiceList = new ArrayList<>(ret.size());
+                    for (RangerService rangerService : ret) {
+                        if (rangerService != null) {
+                            updateServiceList.add(hideCriticalServiceDetailsForRoleUser(rangerService));
+                        }
+                    }
+                    ret = updateServiceList;
+                }
+            }
         } catch (WebApplicationException excp) {
             throw excp;
         } catch (Throwable excp) {

--- a/security-admin/src/test/java/org/apache/ranger/rest/TestPublicAPIs.java
+++ b/security-admin/src/test/java/org/apache/ranger/rest/TestPublicAPIs.java
@@ -180,21 +180,21 @@ public class TestPublicAPIs {
     @Test
     public void test5searchRepositories() {
         HttpServletRequest  request       = Mockito.mock(HttpServletRequest.class);
-        List<RangerService> ret           = new ArrayList<>();
+        List<RangerService> services      = new ArrayList<>();
         RangerService       rangerService = rangerService();
         VXRepository        vXRepository  = vXRepository(rangerService);
-        List<VXRepository>  repoList      = new ArrayList<>();
-        repoList.add(vXRepository);
-        VXRepositoryList vXRepositoryList = new VXRepositoryList(repoList);
-        SearchFilter     filter           = new SearchFilter();
+        services.add(rangerService);
+        SearchFilter filter = new SearchFilter();
         filter.setParam(SearchFilter.POLICY_NAME, "policyName");
         filter.setParam(SearchFilter.SERVICE_NAME, "serviceName");
         Mockito.when(searchUtil.getSearchFilterFromLegacyRequestForRepositorySearch(request, xAssetService.sortFields)).thenReturn(filter);
-        Mockito.when(serviceREST.getServices(filter)).thenReturn(ret);
-        Mockito.when(serviceUtil.rangerServiceListToPublicObjectList(ret)).thenReturn(vXRepositoryList);
+        Mockito.when(serviceREST.getServices(filter)).thenReturn(services);
+        Mockito.when(serviceUtil.toVXRepository(rangerService)).thenReturn(vXRepository);
         VXRepositoryList dbVXRepositoryList = publicAPIs.searchRepositories(request);
         Assertions.assertNotNull(dbVXRepositoryList);
-        Assertions.assertEquals(dbVXRepositoryList.getResultSize(), vXRepositoryList.getResultSize());
+        Assertions.assertEquals(1, dbVXRepositoryList.getResultSize());
+        Assertions.assertEquals(vXRepository, dbVXRepositoryList.getVXRepositories().get(0));
+        Mockito.verify(serviceUtil).toVXRepository(rangerService);
     }
 
     @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

## Summary

Aligns the legacy public repository search API (`PublicAPIs.searchRepositories`) with the internal assets search endpoint (`AssetREST.searchXAssets`) for authorization and service detail handling.

- Adds the standard `@PreAuthorize` API access check (`SEARCH_X_ASSETS`) to `GET /service/public/api/repository/`
- Updates `searchRepositories` to follow the same response-building pattern as `AssetREST.searchXAssets` (always returns a non-null list wrapper, converts services individually, sets list metadata)
- Applies existing service detail redaction in `ServiceREST.getServices(SearchFilter)` so behavior matches the request-based services lookup path

## Changes

- `PublicAPIs.java` — authorization annotation and response handling for `searchRepositories`
- `ServiceREST.java` — service detail redaction in `getServices(SearchFilter)`
- `TestPublicAPIs.java` — updated unit test for the new conversion path

## How was this patch tested?

## Test plan
- [ ] `TestPublicAPIs.test5searchRepositories` passes
- [ ] Authorized admin user: `GET /service/public/api/repository/?pageSize=200` returns `200` with repository list
- [ ] Authorized non-admin user: same endpoint returns `200` with repository list (consistent with `/service/assets/assets`)
- [ ] User without module permissions: receives appropriate access denied response
- [ ] Verify trailing slash URL: `/service/public/api/repository/` (required for this endpoint)
