### PR TITLE
RANGER-5735: Improve authorization consistency across RoleREST endpoints

### DIFF
--- a/security-admin/src/main/java/org/apache/ranger/rest/RoleREST.java
+++ b/security-admin/src/main/java/org/apache/ranger/rest/RoleREST.java
@@ -349,7 +349,17 @@ public class RoleREST {
         RangerRole ret;
 
         try {
+            UserSessionBase usb = ContextUtil.getCurrentUserSession();
+            String loggedInUser = usb != null ? usb.getLoginId() : null;
             ret = roleStore.getRole(id);
+            if (ret != null && !bizUtil.isUserRangerAdmin(loggedInUser)) {
+                try {
+                    ensureRoleAccess(loggedInUser, userMgr.getGroupsForUser(loggedInUser), ret);
+                } catch (Exception accessExcp) {
+                    LOG.error("User {} does not have permission to get details for role(id={})", loggedInUser, id);
+                    throw restErrorUtil.createRESTException("User doesn't have permissions to get details for role(id=" + id + ")");
+                }
+            }
         } catch (WebApplicationException excp) {
             throw excp;
         } catch (Throwable excp) {
@@ -864,6 +874,8 @@ public class RoleREST {
         RESTResponse ret = new RESTResponse();
 
         try {
+            bizUtil.blockAuditorRoleUser();
+
             validateUsersGroupsAndRoles(grantRoleRequest);
 
             String userName = grantRoleRequest.getGrantor();
@@ -879,8 +891,7 @@ public class RoleREST {
                  * else deny the operation
                  * This logic is implemented as part of getRoleIfAccessible(roleName, serviceName, userName, userGroups)
                  */
-                Set<String> userGroups   = CollectionUtils.isNotEmpty(grantRoleRequest.getGrantorGroups()) ? grantRoleRequest.getGrantorGroups() : userMgr.getGroupsForUser(userName);
-                RangerRole  existingRole = getRoleIfAccessible(roleName, serviceName, userName, userGroups);
+                RangerRole existingRole = getRoleIfAccessible(roleName, serviceName, userName, grantRoleRequest.getGrantorGroups());
 
                 if (existingRole == null) {
                     throw restErrorUtil.createRESTException("User doesn't have permissions to grant role " + roleName);
@@ -922,6 +933,8 @@ public class RoleREST {
         RESTResponse ret = new RESTResponse();
 
         try {
+            bizUtil.blockAuditorRoleUser();
+
             validateUsersGroupsAndRoles(revokeRoleRequest);
 
             String userName = revokeRoleRequest.getGrantor();
@@ -937,8 +950,7 @@ public class RoleREST {
                  * else deny the operation
                  * This logic is implemented as part of getRoleIfAccessible(roleName, serviceName, userName, userGroups)
                  */
-                Set<String> userGroups   = CollectionUtils.isNotEmpty(revokeRoleRequest.getGrantorGroups()) ? revokeRoleRequest.getGrantorGroups() : userMgr.getGroupsForUser(userName);
-                RangerRole  existingRole = getRoleIfAccessible(roleName, serviceName, userName, userGroups);
+                RangerRole existingRole = getRoleIfAccessible(roleName, serviceName, userName, revokeRoleRequest.getGrantorGroups());
 
                 if (existingRole == null) {
                     throw restErrorUtil.createRESTException("User doesn't have permissions to revoke role " + roleName);
@@ -982,6 +994,13 @@ public class RoleREST {
         LOG.debug("==> getUserRoles()");
 
         try {
+            UserSessionBase usb = ContextUtil.getCurrentUserSession();
+            String loggedInUser = usb != null ? usb.getLoginId() : null;
+            if (!StringUtil.equals(userName, loggedInUser) && !bizUtil.isUserRangerAdmin(loggedInUser)) {
+                LOG.error("User {} does not have permission to get roles for user {}", loggedInUser, userName);
+                throw restErrorUtil.createRESTException(HttpServletResponse.SC_FORBIDDEN, "User does not have permission for this operation", true);
+            }
+
             if (xUserService.getXUserByUserName(userName) == null) {
                 throw restErrorUtil.createRESTException(HttpServletResponse.SC_NOT_FOUND, "User:" + userName + " not found", false);
             }
@@ -1249,7 +1268,7 @@ public class RoleREST {
         }
     }
 
-    private RangerRole getRoleIfAccessible(String roleName, String serviceName, String userName, Set<String> userGroups) {
+    private RangerRole getRoleIfAccessible(String roleName, String serviceName, String userName, Set<String> callerAssertedGroups) {
         /* If userName (execUser) is not same as logged in user then check
          * If logged-in user is not ranger admin/service admin/service user, then deny the operation
          * effective User is execUser
@@ -1260,6 +1279,7 @@ public class RoleREST {
          */
         RangerRole      existingRole;
         String          effectiveUser;
+        Set<String>     userGroups;
         UserSessionBase usb          = ContextUtil.getCurrentUserSession();
         String          loggedInUser = usb != null ? usb.getLoginId() : null;
 
@@ -1271,8 +1291,19 @@ public class RoleREST {
             }
 
             effectiveUser = userName != null ? userName : loggedInUser;
+
+            /* effectiveUser differs from the logged-in caller only because the caller has already
+             * been confirmed above to be a trusted principal (ranger admin/service admin/service user)
+             * acting on behalf of effectiveUser, so it is safe to fall back to a caller-supplied group
+             * set for effectiveUser when Ranger has no synced group info for them yet. */
+            userGroups = CollectionUtils.isNotEmpty(callerAssertedGroups) ? callerAssertedGroups : userMgr.getGroupsForUser(effectiveUser);
         } else {
             effectiveUser = loggedInUser;
+
+            /* self-service case: an unprivileged, authenticated caller must never be able to assert
+             * their own group membership via request input for an authorization decision -- always
+             * resolve it server-side. */
+            userGroups = userMgr.getGroupsForUser(loggedInUser);
         }
 
         try {

--- a/security-admin/src/test/java/org/apache/ranger/rest/TestRoleREST.java
+++ b/security-admin/src/test/java/org/apache/ranger/rest/TestRoleREST.java
@@ -780,6 +780,60 @@ public class TestRoleREST {
     }
 
     @Test
+    public void test13eGrantRoleRealGroupMembershipAllowed() {
+        String serviceName = "serviceName";
+        boolean isRefTableCleanupRequired = true;
+        RangerRole.RoleMember groupMember = new RangerRole.RoleMember("real-admin-group", true);
+        RangerRole rangerRole = new RangerRole("target-role", "target-role", null, new ArrayList<>(), new ArrayList<>(Collections.singletonList(groupMember)));
+        GrantRevokeRoleRequest grantRevokeRoleRequest = createGrantRevokeRoleRequest();
+        rangerRole.setCreatedByUser("target-role");
+        rangerRole.setId(roleId);
+        grantRevokeRoleRequest.setGrantor(adminLoginID);
+        Mockito.when(bizUtil.isUserRangerAdmin(Mockito.anyString())).thenReturn(false);
+        Mockito.when(userMgr.getGroupsForUser(adminLoginID)).thenReturn(new HashSet<>(Collections.singletonList("real-admin-group")));
+        try {
+            Mockito.when(roleStore.getRole(Mockito.anyString())).thenReturn(rangerRole);
+            Mockito.when(roleStore.updateRole(Mockito.any(RangerRole.class), Mockito.anyBoolean(), eq(isRefTableCleanupRequired))).then(AdditionalAnswers.returnsFirstArg());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        RESTResponse resp = roleRest.grantRole(serviceName, grantRevokeRoleRequest, Mockito.mock(HttpServletRequest.class));
+        Assertions.assertNotNull(resp);
+        Assertions.assertEquals(resp.getStatusCode(), RESTResponse.STATUS_SUCCESS);
+    }
+
+    @Test
+    public void test13fGrantRoleRealGroupMembershipMismatchRejected() {
+        String serviceName = "serviceName";
+        RangerRole.RoleMember groupMember = new RangerRole.RoleMember("real-admin-group", true);
+        RangerRole rangerRole = new RangerRole("target-role", "target-role", null, new ArrayList<>(), new ArrayList<>(Collections.singletonList(groupMember)));
+        GrantRevokeRoleRequest grantRevokeRoleRequest = createGrantRevokeRoleRequest();
+        rangerRole.setCreatedByUser("target-role");
+        rangerRole.setId(roleId);
+        grantRevokeRoleRequest.setGrantor(adminLoginID);
+        Mockito.when(bizUtil.isUserRangerAdmin(Mockito.anyString())).thenReturn(false);
+        Mockito.when(userMgr.getGroupsForUser(adminLoginID)).thenReturn(new HashSet<>(Arrays.asList("users", "developers")));
+        try {
+            Mockito.when(roleStore.getRole(Mockito.anyString())).thenReturn(rangerRole);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        boolean denied = false;
+        try {
+            roleRest.grantRole(serviceName, grantRevokeRoleRequest, Mockito.mock(HttpServletRequest.class));
+        } catch (Throwable expected) {
+            denied = true;
+        }
+        Assertions.assertTrue(denied, "expected grantRole to deny access for mismatched real groups");
+        Mockito.verify(userMgr, Mockito.atLeastOnce()).getGroupsForUser(adminLoginID);
+        try {
+            Mockito.verify(roleStore, Mockito.never()).updateRole(Mockito.any(RangerRole.class), Mockito.anyBoolean(), Mockito.anyBoolean());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
     public void test13dGrantRoleBlockedForAuditor() {
         Assertions.assertThrows(WebApplicationException.class, () -> {
             String serviceName = "serviceName";
@@ -846,6 +900,62 @@ public class TestRoleREST {
             roleRest.revokeRole(serviceName, grantRevokeRoleRequest, Mockito.mock(HttpServletRequest.class));
             Mockito.verify(restErrorUtil, Mockito.times(1)).createRESTException(Mockito.anyString());
         });
+    }
+
+    @Test
+    public void test14fRevokeRoleRealGroupMembershipAllowed() {
+        String serviceName = "serviceName";
+        boolean isRefTableCleanupRequired = true;
+        RangerRole.RoleMember groupMember = new RangerRole.RoleMember("real-admin-group", true);
+        RangerRole rangerRole = new RangerRole("target-role", "target-role", null, new ArrayList<>(), new ArrayList<>(Collections.singletonList(groupMember)));
+        GrantRevokeRoleRequest grantRevokeRoleRequest = createGrantRevokeRoleRequest();
+        rangerRole.setCreatedByUser("target-role");
+        rangerRole.setId(roleId);
+        grantRevokeRoleRequest.setGrantor(adminLoginID);
+        grantRevokeRoleRequest.setGrantOption(Boolean.TRUE);
+        Mockito.when(bizUtil.isUserRangerAdmin(Mockito.anyString())).thenReturn(false);
+        Mockito.when(userMgr.getGroupsForUser(adminLoginID)).thenReturn(new HashSet<>(Collections.singletonList("real-admin-group")));
+        try {
+            Mockito.when(roleStore.getRole(Mockito.anyString())).thenReturn(rangerRole);
+            Mockito.when(roleStore.updateRole(Mockito.any(RangerRole.class), Mockito.anyBoolean(), eq(isRefTableCleanupRequired))).then(AdditionalAnswers.returnsFirstArg());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        RESTResponse resp = roleRest.revokeRole(serviceName, grantRevokeRoleRequest, Mockito.mock(HttpServletRequest.class));
+        Assertions.assertNotNull(resp);
+        Assertions.assertEquals(resp.getStatusCode(), RESTResponse.STATUS_SUCCESS);
+    }
+
+    @Test
+    public void test14gRevokeRoleRealGroupMembershipMismatchRejected() {
+        String serviceName = "serviceName";
+        RangerRole.RoleMember groupMember = new RangerRole.RoleMember("real-admin-group", true);
+        RangerRole rangerRole = new RangerRole("target-role", "target-role", null, new ArrayList<>(), new ArrayList<>(Collections.singletonList(groupMember)));
+        GrantRevokeRoleRequest grantRevokeRoleRequest = createGrantRevokeRoleRequest();
+        rangerRole.setCreatedByUser("target-role");
+        rangerRole.setId(roleId);
+        grantRevokeRoleRequest.setGrantor(adminLoginID);
+        grantRevokeRoleRequest.setGrantOption(Boolean.TRUE);
+        Mockito.when(bizUtil.isUserRangerAdmin(Mockito.anyString())).thenReturn(false);
+        Mockito.when(userMgr.getGroupsForUser(adminLoginID)).thenReturn(new HashSet<>(Arrays.asList("users", "developers")));
+        try {
+            Mockito.when(roleStore.getRole(Mockito.anyString())).thenReturn(rangerRole);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        boolean denied = false;
+        try {
+            roleRest.revokeRole(serviceName, grantRevokeRoleRequest, Mockito.mock(HttpServletRequest.class));
+        } catch (Throwable expected) {
+            denied = true;
+        }
+        Assertions.assertTrue(denied, "expected revokeRole to deny access for mismatched real groups");
+        Mockito.verify(userMgr, Mockito.atLeastOnce()).getGroupsForUser(adminLoginID);
+        try {
+            Mockito.verify(roleStore, Mockito.never()).updateRole(Mockito.any(RangerRole.class), Mockito.anyBoolean(), Mockito.anyBoolean());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Test

--- a/security-admin/src/test/java/org/apache/ranger/rest/TestRoleREST.java
+++ b/security-admin/src/test/java/org/apache/ranger/rest/TestRoleREST.java
@@ -615,6 +615,37 @@ public class TestRoleREST {
     }
 
     @Test
+    public void test6cGetRoleByIdUnauthorized() {
+        Assertions.assertThrows(Throwable.class, () -> {
+            RangerRole rangerRole = createRangerRole("someOtherUser", false);
+            Mockito.when(bizUtil.isUserRangerAdmin(Mockito.anyString())).thenReturn(false);
+            Mockito.when(userMgr.getGroupsForUser(Mockito.anyString())).thenReturn(new HashSet<>());
+            try {
+                Mockito.when(roleStore.getRole(Mockito.anyLong())).thenReturn(rangerRole);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+            roleRest.getRole(rangerRole.getId());
+            Mockito.verify(restErrorUtil, Mockito.times(1)).createRESTException(Mockito.anyString());
+        });
+    }
+
+    @Test
+    public void test6dGetRoleByIdAllowedForRoleAdminOptionMember() {
+        RangerRole rangerRole = createRole(); // "admin" is an admin-option user member of this role
+        Mockito.when(bizUtil.isUserRangerAdmin(Mockito.anyString())).thenReturn(false);
+        Mockito.when(userMgr.getGroupsForUser(Mockito.anyString())).thenReturn(new HashSet<>());
+        try {
+            Mockito.when(roleStore.getRole(Mockito.anyLong())).thenReturn(rangerRole);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        RangerRole returnedRole = roleRest.getRole(rangerRole.getId());
+        Assertions.assertNotNull(returnedRole);
+        Assertions.assertEquals(returnedRole.getId(), rangerRole.getId());
+    }
+
+    @Test
     public void test7bGetAllRoles() {
         Assertions.assertThrows(Throwable.class, () -> {
             SearchFilter searchFilter = new SearchFilter();
@@ -726,6 +757,39 @@ public class TestRoleREST {
     }
 
     @Test
+    public void test13cGrantRoleForgedGrantorGroupsRejected() {
+        Assertions.assertThrows(Throwable.class, () -> {
+            String serviceName = "serviceName";
+            RangerRole.RoleMember groupMember = new RangerRole.RoleMember("forged-admin-group", true);
+            RangerRole rangerRole = new RangerRole("target-role", "target-role", null, new ArrayList<>(), new ArrayList<>(Collections.singletonList(groupMember)));
+            GrantRevokeRoleRequest grantRevokeRoleRequest = createGrantRevokeRoleRequest();
+            rangerRole.setCreatedByUser("target-role");
+            rangerRole.setId(roleId);
+            grantRevokeRoleRequest.setGrantor(adminLoginID);
+            grantRevokeRoleRequest.setGrantorGroups(new HashSet<>(Collections.singletonList("forged-admin-group")));
+            Mockito.when(bizUtil.isUserRangerAdmin(Mockito.anyString())).thenReturn(false);
+            Mockito.when(userMgr.getGroupsForUser(Mockito.anyString())).thenReturn(new HashSet<>());
+            try {
+                Mockito.when(roleStore.getRole(Mockito.anyString())).thenReturn(rangerRole);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+            roleRest.grantRole(serviceName, grantRevokeRoleRequest, Mockito.mock(HttpServletRequest.class));
+            Mockito.verify(restErrorUtil, Mockito.times(1)).createRESTException(Mockito.anyString());
+        });
+    }
+
+    @Test
+    public void test13dGrantRoleBlockedForAuditor() {
+        Assertions.assertThrows(WebApplicationException.class, () -> {
+            String serviceName = "serviceName";
+            GrantRevokeRoleRequest grantRevokeRoleRequest = createGrantRevokeRoleRequest();
+            Mockito.doThrow(new WebApplicationException()).when(bizUtil).blockAuditorRoleUser();
+            roleRest.grantRole(serviceName, grantRevokeRoleRequest, Mockito.mock(HttpServletRequest.class));
+        });
+    }
+
+    @Test
     public void test14bRevokeRole() {
         RangerRole             rangerRole             = createRole();
         String                 serviceName            = "serviceName";
@@ -761,6 +825,40 @@ public class TestRoleREST {
     }
 
     @Test
+    public void test14dRevokeRoleForgedGrantorGroupsRejected() {
+        Assertions.assertThrows(Throwable.class, () -> {
+            String serviceName = "serviceName";
+            RangerRole.RoleMember groupMember = new RangerRole.RoleMember("forged-admin-group", true);
+            RangerRole rangerRole = new RangerRole("target-role", "target-role", null, new ArrayList<>(), new ArrayList<>(Collections.singletonList(groupMember)));
+            GrantRevokeRoleRequest grantRevokeRoleRequest = createGrantRevokeRoleRequest();
+            rangerRole.setCreatedByUser("target-role");
+            rangerRole.setId(roleId);
+            grantRevokeRoleRequest.setGrantor(adminLoginID);
+            grantRevokeRoleRequest.setGrantOption(Boolean.TRUE);
+            grantRevokeRoleRequest.setGrantorGroups(new HashSet<>(Collections.singletonList("forged-admin-group")));
+            Mockito.when(bizUtil.isUserRangerAdmin(Mockito.anyString())).thenReturn(false);
+            Mockito.when(userMgr.getGroupsForUser(Mockito.anyString())).thenReturn(new HashSet<>());
+            try {
+                Mockito.when(roleStore.getRole(Mockito.anyString())).thenReturn(rangerRole);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+            roleRest.revokeRole(serviceName, grantRevokeRoleRequest, Mockito.mock(HttpServletRequest.class));
+            Mockito.verify(restErrorUtil, Mockito.times(1)).createRESTException(Mockito.anyString());
+        });
+    }
+
+    @Test
+    public void test14eRevokeRoleBlockedForAuditor() {
+        Assertions.assertThrows(WebApplicationException.class, () -> {
+            String serviceName = "serviceName";
+            GrantRevokeRoleRequest grantRevokeRoleRequest = createGrantRevokeRoleRequest();
+            Mockito.doThrow(new WebApplicationException()).when(bizUtil).blockAuditorRoleUser();
+            roleRest.revokeRole(serviceName, grantRevokeRoleRequest, Mockito.mock(HttpServletRequest.class));
+        });
+    }
+
+    @Test
     public void test15bGetUserRoles() {
         Assertions.assertThrows(Throwable.class, () -> {
             Set<RangerRole> rangerRoles = new HashSet<>();
@@ -772,6 +870,84 @@ public class TestRoleREST {
             Mockito.when(roleRefUpdater.getRangerDaoManager().getXXRoleRefUser().findByUserName(adminLoginID)).thenReturn(xxRoleRefRoleList);
             Mockito.when(roleRefUpdater.getRangerDaoManager().getXXRoleRefGroup().findByGroupName(adminLoginID)).thenReturn(xxRoleRefGroupList);
             roleRest.getUserRoles(adminLoginID, Mockito.mock(HttpServletRequest.class));
+        });
+    }
+
+    @Test
+    public void test15cGetUserRolesUnauthorized() {
+        Assertions.assertThrows(Throwable.class, () -> {
+            Mockito.when(bizUtil.isUserRangerAdmin(Mockito.anyString())).thenReturn(false);
+            roleRest.getUserRoles("someOtherUser", Mockito.mock(HttpServletRequest.class));
+            Mockito.verify(restErrorUtil, Mockito.times(1)).createRESTException(Mockito.anyString());
+        });
+    }
+
+    @Test
+    public void test15dGetUserRolesSelfLookupAllowedWithoutAdmin() {
+        Set<RangerRole> rangerRoles = new HashSet<>();
+        RangerRole rangerRole = createRole();
+        rangerRoles.add(rangerRole);
+        Set<String> groups = new HashSet<>();
+        Mockito.when(xUserService.getXUserByUserName(Mockito.anyString())).thenReturn(createVXUser());
+        Mockito.when(userMgr.getGroupsForUser(Mockito.anyString())).thenReturn(groups);
+        try {
+            Mockito.when(roleStore.getRoleNames(Mockito.anyString(), eq(groups))).thenReturn(rangerRoles);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        List<String> returnedRoles = roleRest.getUserRoles(adminLoginID, Mockito.mock(HttpServletRequest.class));
+        Assertions.assertNotNull(returnedRoles);
+        Assertions.assertEquals(returnedRoles.size(), rangerRoles.size());
+    }
+
+    @Test
+    public void test13gGrantRoleImpersonationByPrivilegedCallerHonorsCallerAssertedGroups() {
+        String serviceName = "serviceName";
+        String impersonatedGrantor = "proxy-service-admin";
+        boolean isRefTableCleanupRequired = true;
+        RangerRole.RoleMember groupMember = new RangerRole.RoleMember("asserted-group", true);
+        RangerRole rangerRole = new RangerRole("target-role", "target-role", null, new ArrayList<>(), new ArrayList<>(Collections.singletonList(groupMember)));
+        GrantRevokeRoleRequest grantRevokeRoleRequest = createGrantRevokeRoleRequest();
+
+        rangerRole.setCreatedByUser("target-role");
+        rangerRole.setId(roleId);
+
+        // grantor != the real logged-in user ("admin", per @BeforeEach) -- this is the impersonation branch.
+        grantRevokeRoleRequest.setGrantor(impersonatedGrantor);
+        grantRevokeRoleRequest.setGrantorGroups(new HashSet<>(Collections.singletonList("asserted-group")));
+
+        // the REAL caller (loggedInUser="admin") is a proven ranger admin -- only then is entering the
+        // impersonation branch, and trusting its group assertion for the impersonated user, safe.
+        Mockito.when(bizUtil.isUserRangerAdmin(adminLoginID)).thenReturn(true);
+        Mockito.when(bizUtil.isUserRangerAdmin(Mockito.argThat(u -> !adminLoginID.equals(u)))).thenReturn(false);
+        try {
+            Mockito.when(roleStore.getRole(Mockito.anyString())).thenReturn(rangerRole);
+            Mockito.when(roleStore.updateRole(Mockito.any(RangerRole.class), Mockito.anyBoolean(), eq(isRefTableCleanupRequired))).then(AdditionalAnswers.returnsFirstArg());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        RESTResponse resp = roleRest.grantRole(serviceName, grantRevokeRoleRequest, Mockito.mock(HttpServletRequest.class));
+        Assertions.assertNotNull(resp);
+        Assertions.assertEquals(RESTResponse.STATUS_SUCCESS, resp.getStatusCode());
+        // the impersonated user's groups came from the request, not a directory lookup
+        Mockito.verify(userMgr, Mockito.never()).getGroupsForUser(impersonatedGrantor);
+    }
+
+    @Test
+    public void test13hGrantRoleImpersonationByUnprivilegedCallerRejectedRegardlessOfAssertedGroups() {
+        Assertions.assertThrows(Throwable.class, () -> {
+            String                 serviceName            = "serviceName";
+            String                 impersonatedGrantor    = "proxy-service-admin";
+            GrantRevokeRoleRequest grantRevokeRoleRequest = createGrantRevokeRoleRequest();
+            grantRevokeRoleRequest.setGrantor(impersonatedGrantor);
+            grantRevokeRoleRequest.setGrantorGroups(new HashSet<>(Collections.singletonList("asserted-group")));
+            // the REAL caller ("admin") is NOT a ranger admin and NOT a service admin/service user for
+            // this service -- the impersonation gate rejects before the target role is even looked up
+            // (roleStore.getRole() is never reached on this path), so callerAssertedGroups is never read.
+            Mockito.when(bizUtil.isUserRangerAdmin(Mockito.anyString())).thenReturn(false);
+            Mockito.when(svcStore.isServiceAdminUser(Mockito.anyString(), Mockito.anyString())).thenReturn(false);
+            roleRest.grantRole(serviceName, grantRevokeRoleRequest, Mockito.mock(HttpServletRequest.class));
+            Mockito.verify(restErrorUtil, Mockito.times(1)).createRESTException(Mockito.anyString());
         });
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Hardens authorization handling in RoleREST for role read and role grant/revoke operations:

getRole(id) and getUserRoles(user) now verify the caller is authorized to view the requested role/user's role membership, instead of returning it unconditionally.
grantRole/revokeRole now always resolve the caller's group membership server-side; group membership supplied in the request is no longer trusted for authorization decisions, except when the caller has already been independently verified as a Ranger admin/service admin/service user acting on behalf of another user.
grantRole/revokeRole now also block sessions with the read-only Auditor role from performing role mutations, consistent with existing behavior in ServiceREST.


## How was this patch tested?
Added/updated unit tests in TestRoleREST covering authorized and unauthorized access for getRole, getUserRoles, grantRole, and revokeRole, including group-membership-based authorization and the Auditor-block behavior. Verified manually against a running instance.
