### PR TITLE
RANGER-5739: Recursive URL resource policy does not match resources e…

### DIFF
--- a/agents-common/src/main/java/org/apache/ranger/plugin/resourcematcher/RangerURLResourceMatcher.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/resourcematcher/RangerURLResourceMatcher.java
@@ -31,7 +31,6 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class RangerURLResourceMatcher extends RangerDefaultResourceMatcher {
@@ -39,6 +38,7 @@ public class RangerURLResourceMatcher extends RangerDefaultResourceMatcher {
 
     public static final String OPTION_PATH_SEPARATOR       = "pathSeparatorChar";
     public static final char   DEFAULT_PATH_SEPARATOR_CHAR = org.apache.hadoop.fs.Path.SEPARATOR_CHAR;
+    private static final Pattern PATH_URL_PATTERN          = Pattern.compile(":/{2,}");
 
     boolean policyIsRecursive;
     char    pathSeparatorChar = DEFAULT_PATH_SEPARATOR_CHAR;
@@ -97,24 +97,32 @@ public class RangerURLResourceMatcher extends RangerDefaultResourceMatcher {
         boolean ret = false;
 
         if (url != null) {
-            Pattern p1 = Pattern.compile(":/{2}");
-            Matcher m1 = p1.matcher(url);
-
-            Pattern p2 = Pattern.compile(":/{3,}");
-            Matcher m2 = p2.matcher(url);
-
-            ret = (m1.find() && !(m2.find()));
+            ret = PATH_URL_PATTERN.matcher(url).find();
         }
 
         return ret;
     }
 
+    private static int getSchemeEndIndex(String url) {
+        int colonIdx = StringUtils.indexOf(url, ":");
+        if (colonIdx < 0) {
+            return -1;
+        }
+        int idx = colonIdx + 1;
+        while (idx < url.length() && url.charAt(idx) == '/') {
+            idx++;
+        }
+        return (idx - (colonIdx + 1)) >= 2 ? idx : -1;
+    }
+
     static String getScheme(String url) {
-        return StringUtils.substring(url, 0, (StringUtils.indexOf(url, ":") + 3));
+        int schemeEnd = getSchemeEndIndex(url);
+        return schemeEnd < 0 ? StringUtils.EMPTY : StringUtils.substring(url, 0, schemeEnd);
     }
 
     static String getPathWithOutScheme(String url) {
-        return StringUtils.substring(url, (StringUtils.indexOf(url, ":") + 2));
+        int schemeEnd = getSchemeEndIndex(url);
+        return schemeEnd < 0 ? url : StringUtils.substring(url, schemeEnd);
     }
 
     @Override

--- a/agents-common/src/test/java/org/apache/ranger/plugin/resourcematcher/RangerURLResourceMatcherTest.java
+++ b/agents-common/src/test/java/org/apache/ranger/plugin/resourcematcher/RangerURLResourceMatcherTest.java
@@ -31,6 +31,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class RangerURLResourceMatcherTest {
     Object[][] data = {
@@ -49,7 +51,12 @@ public class RangerURLResourceMatcherTest {
             {"///app/warehouse/file://data/emp.db",            "hdfs://app/*",                         true,  true,  false, "user"},
             {"hdfs:///app/warehouse/data/emp.db",              "hdfs://app/*",                         true,  true,  false, "user"},
             {"hdfs://///app/warehouse/data/emp.db",            "hdfs://app/*",                         true,  true,  false, "user"},
-            {"://apps/warehouse/data/emp.db",                  "hdfs://app/*",                         true,  true,  false, "user"}
+            {"://apps/warehouse/data/emp.db",                  "hdfs://app/*",                         true,  true,  false, "user"},
+            {"hdfs:///app/warehouse/data/emp.db",              "hdfs:///app/warehouse/*",              true,  true,  true,  "user"},
+            {"file:///etc/ranger/data.txt",                    "file:///etc/ranger/*",                 true,  true,  true,  "user"},
+            {"hdfs:///app/warehouse/data/emp.db",              "hdfs:///other/*",                      true,  true,  false, "user"},
+            {"hdfs:///app/warehouse/data/emp.db",              "hdfs://app/warehouse/*",               true,  true,  false, "user"},
+            {"hdfs://app/warehouse/data/emp.db",               "hdfs:///app/warehouse/*",              true,  true,  false, "user"}
     };
 
     Object[][] dataForSelfOrPrefixScope = {
@@ -147,6 +154,78 @@ public class RangerURLResourceMatcherTest {
 
     String getMessage(Object[] row) {
         return String.format("Resource=%s, Policy=%s, optWildcard=%s, recursive=%s, result=%s", row[0], row[1], row[2], row[3], row[4]);
+    }
+
+    @Test
+    public void testIsPathURLType_DefaultFS_HDFS() {
+        // hdfs:///path - the canonical default-FS form; was incorrectly false
+        assertTrue(RangerURLResourceMatcher.isPathURLType("hdfs:///app/warehouse"));
+        assertTrue(RangerURLResourceMatcher.isPathURLType("hdfs:///app/warehouse/data"));
+        assertTrue(RangerURLResourceMatcher.isPathURLType("hdfs:///"));
+    }
+
+    @Test
+    public void testIsPathURLType_DefaultFS_LocalFile() {
+        assertTrue(RangerURLResourceMatcher.isPathURLType("file:///tmp"));
+        assertTrue(RangerURLResourceMatcher.isPathURLType("file:///var/log/app"));
+    }
+
+    @Test
+    public void testIsPathURLType_ExplicitAuthority() {
+        // Explicit authority - was already correct; must remain true
+        assertTrue(RangerURLResourceMatcher.isPathURLType("hdfs://nn1:8020/app/warehouse"));
+        assertTrue(RangerURLResourceMatcher.isPathURLType("hdfs://namenode/path"));
+    }
+
+    @Test
+    public void testIsPathURLType_NonPathURLs() {
+        assertFalse(RangerURLResourceMatcher.isPathURLType(null));
+        assertFalse(RangerURLResourceMatcher.isPathURLType(""));
+        assertFalse(RangerURLResourceMatcher.isPathURLType("mailto:user@example.com"));
+        assertFalse(RangerURLResourceMatcher.isPathURLType("hdfs:/path")); // single slash
+        assertFalse(RangerURLResourceMatcher.isPathURLType("just-a-string"));
+    }
+
+    @Test
+    public void testRecursiveMatch_DefaultFS_Enabled() {
+        // The core regression: recursive=true on hdfs:///.../* must match
+        Map<String, Object> evalContext = new HashMap<>();
+        RangerAccessRequestUtil.setCurrentUserInContext(evalContext, "user");
+        MatcherWrapper matcher = new MatcherWrapper("hdfs:///app/warehouse/*", true, true);
+        assertTrue(matcher.isMatch("hdfs:///app/warehouse/data", ResourceElementMatchingScope.SELF, evalContext), "direct child");
+        assertTrue(matcher.isMatch("hdfs:///app/warehouse/data/x", ResourceElementMatchingScope.SELF, evalContext), "nested child");
+        assertFalse(matcher.isMatch("hdfs:///app/other/data", ResourceElementMatchingScope.SELF, evalContext), "non-matching sibling");
+    }
+
+    @Test
+    public void testRecursiveMatch_ExplicitAuthority_StillWorks() {
+        // Negative control: explicit-authority form was never broken
+        Map<String, Object> evalContext = new HashMap<>();
+        RangerAccessRequestUtil.setCurrentUserInContext(evalContext, "user");
+        MatcherWrapper matcher = new MatcherWrapper("hdfs://nn1:8020/app/warehouse/*", true, true);
+        assertTrue(matcher.isMatch("hdfs://nn1:8020/app/warehouse/data", ResourceElementMatchingScope.SELF, evalContext));
+        assertFalse(matcher.isMatch("hdfs://nn1:8020/app/other/data", ResourceElementMatchingScope.SELF, evalContext));
+    }
+
+    @Test
+    public void testRecursiveMatch_DefaultFS_DoesNotCrossMatchExplicitAuthority() {
+        // Must not cross-match: default-FS resource vs. a policy scoped to an
+        // explicit authority literally named "app", and vice versa.
+        Map<String, Object> evalContext = new HashMap<>();
+        RangerAccessRequestUtil.setCurrentUserInContext(evalContext, "user");
+        MatcherWrapper defaultFsPolicy    = new MatcherWrapper("hdfs:///app/warehouse/*", true, true);
+        MatcherWrapper explicitHostPolicy = new MatcherWrapper("hdfs://app/warehouse/*", true, true);
+        assertFalse(defaultFsPolicy.isMatch("hdfs://app/warehouse/data", ResourceElementMatchingScope.SELF, evalContext));
+        assertFalse(explicitHostPolicy.isMatch("hdfs:///app/warehouse/data", ResourceElementMatchingScope.SELF, evalContext));
+    }
+
+    @Test
+    public void testNonRecursiveMatch_DefaultFS_StillWorks() {
+        // Non-recursive was never broken; verify no regression
+        Map<String, Object> evalContext = new HashMap<>();
+        RangerAccessRequestUtil.setCurrentUserInContext(evalContext, "user");
+        MatcherWrapper matcher = new MatcherWrapper("hdfs:///app/warehouse/*", true, false);
+        assertTrue(matcher.isMatch("hdfs:///app/warehouse/data", ResourceElementMatchingScope.SELF, evalContext));
     }
 
     static class MatcherWrapper extends RangerURLResourceMatcher {


### PR DESCRIPTION


## What changes were proposed in this pull request?

RangerURLResourceMatcher did not match a recursive URL policy against a resource when both were expressed in the scheme:///path form (three slashes after the colon) — the standard way to reference the Hadoop default FileSystem, i.e. a URL with no explicit host/authority.

RangerURLResourceMatcher.isPathURLType() rejected any URL whose scheme was followed by 3 or more slashes, mis-classifying the default-FS form as "not a URL." isRecursiveWildCardMatch() short-circuits to false whenever isPathURLType() is false, so path-element comparison never ran for these URLs

isPathURLType(): a path-URL is now any scheme: followed by 2 or more slashes, not exactly 2.
getScheme() / getPathWithOutScheme(): rather than hard-coding "2 slashes" into the scheme boundary, these now capture all of the slashes immediately following the colon. This is needed for correctness, not just to lift the isPathURLType gate — without it, path-element reconstruction in isRecursiveWildCardMatch collapses the extra slash and a default-FS resource (hdfs:///app/...) could wrongly match a policy scoped to an explicit authority literally named app (hdfs://app/...), or vice versa. Preserving the exact slash count keeps those two forms distinct while letting like-for-like default-FS policy/resource pairs match as expected.

The regex used by isPathURLType() is now compiled once into a static final Pattern field rather than per call, matching the existing convention elsewhere in this package (RangerIpMatcher, RangerTimeOfDayMatcher).

## How was this patch tested?

Added new tests