### PR TITLE
RANGER-5742: Inconsistent handling of service config fields by name v…

### DIFF
--- a/security-admin/src/main/java/org/apache/ranger/biz/ServiceDBStore.java
+++ b/security-admin/src/main/java/org/apache/ranger/biz/ServiceDBStore.java
@@ -233,6 +233,7 @@ public class ServiceDBStore extends AbstractServiceStore {
     public static final     String                        RANGER_PLUGINS_CONFIG_CONF_PREFIX = "ranger.plugins.conf.";
     public static final     String                        HIDDEN_PASSWORD_STR               = "*****";
     public static final     String                        CONFIG_KEY_PASSWORD               = "password";
+    public static final     String                        CONFIG_TYPE_PASSWORD              = "password";
     public static final     String                        ACCESS_TYPE_DECRYPT_EEK           = "decrypteek";
     public static final     String                        ACCESS_TYPE_GENERATE_EEK          = "generateeek";
     public static final     String                        ACCESS_TYPE_GET_METADATA          = "getmetadata";
@@ -983,6 +984,7 @@ public class ServiceDBStore extends AbstractServiceStore {
 
         XXService             xCreatedService = daoMgr.getXXService().getById(service.getId());
         XXServiceConfigMapDao xConfMapDao     = daoMgr.getXXServiceConfigMap();
+        Set<String> passwordConfigKeys = getPasswordConfigKeys(service.getType());
 
         for (Entry<String, String> configMap : validConfigs.entrySet()) {
             String configKey   = configMap.getKey();
@@ -1005,7 +1007,7 @@ public class ServiceDBStore extends AbstractServiceStore {
                 }
             }
 
-            if (StringUtils.equalsIgnoreCase(configKey, CONFIG_KEY_PASSWORD)) {
+            if (isPasswordConfigKey(passwordConfigKeys, configKey)) {
                 Joiner joiner             = Joiner.on(",").skipNulls();
                 String iv                 = PasswordUtils.generateIvIfNeeded(CRYPT_ALGO);
                 String cryptConfigString  = joiner.join(CRYPT_ALGO, ENCRYPT_KEY, SALT, ITERATION_COUNT, iv, configValue);
@@ -1160,11 +1162,12 @@ public class ServiceDBStore extends AbstractServiceStore {
         }
 
         XXService xUpdService = daoMgr.getXXService().getById(service.getId());
-        String    oldPassword = null;
+        Set<String>  passwordConfigKeys = getPasswordConfigKeys(service.getType());
+        Map<String, String> oldPasswordsByKey = new HashMap<>();
 
         for (XXServiceConfigMap dbConfigMap : dbConfigMaps) {
-            if (StringUtils.equalsIgnoreCase(dbConfigMap.getConfigkey(), CONFIG_KEY_PASSWORD)) {
-                oldPassword = dbConfigMap.getConfigvalue();
+            if (isPasswordConfigKey(passwordConfigKeys, dbConfigMap.getConfigkey())) {
+                oldPasswordsByKey.put(StringUtils.lowerCase(dbConfigMap.getConfigkey()), dbConfigMap.getConfigvalue());
             }
 
             daoMgr.getXXServiceConfigMap().remove(dbConfigMap);
@@ -1193,7 +1196,9 @@ public class ServiceDBStore extends AbstractServiceStore {
                 }
             }
 
-            if (StringUtils.equalsIgnoreCase(configKey, CONFIG_KEY_PASSWORD)) {
+            if (isPasswordConfigKey(passwordConfigKeys, configKey)) {
+                String oldPassword = oldPasswordsByKey.get(StringUtils.lowerCase(configKey));
+
                 if (StringUtils.equalsIgnoreCase(configValue, HIDDEN_PASSWORD_STR)) {
                     if (oldPassword != null && oldPassword.contains(",")) {
                         PasswordUtils util = PasswordUtils.build(oldPassword);
@@ -4243,6 +4248,28 @@ public class ServiceDBStore extends AbstractServiceStore {
         }
 
         return ret;
+    }
+
+    private Set<String> getPasswordConfigKeys(String serviceType) {
+        List<XXServiceConfigDef> svcConfDefList = serviceType != null ? daoMgr.getXXServiceConfigDef().findByServiceDefName(serviceType) : null;
+        return getPasswordConfigKeys(svcConfDefList);
+    }
+
+    public static Set<String> getPasswordConfigKeys(List<XXServiceConfigDef> svcConfDefList) {
+        Set<String> passwordConfigKeys = new HashSet<>();
+        passwordConfigKeys.add(StringUtils.lowerCase(CONFIG_KEY_PASSWORD));
+        if (svcConfDefList != null) {
+            for (XXServiceConfigDef svcConfDef : svcConfDefList) {
+                if (StringUtils.equalsIgnoreCase(svcConfDef.getType(), CONFIG_TYPE_PASSWORD) && svcConfDef.getName() != null) {
+                    passwordConfigKeys.add(StringUtils.lowerCase(svcConfDef.getName()));
+                }
+            }
+        }
+        return passwordConfigKeys;
+    }
+
+    public static boolean isPasswordConfigKey(Set<String> passwordConfigKeys, String configKey) {
+        return configKey != null && passwordConfigKeys.contains(StringUtils.lowerCase(configKey));
     }
 
     private Map<String, String> validateRequiredConfigParams(RangerService service, Map<String, String> configs) {

--- a/security-admin/src/main/java/org/apache/ranger/biz/ServiceDBStore.java
+++ b/security-admin/src/main/java/org/apache/ranger/biz/ServiceDBStore.java
@@ -4251,17 +4251,17 @@ public class ServiceDBStore extends AbstractServiceStore {
     }
 
     private Set<String> getPasswordConfigKeys(String serviceType) {
-        List<XXServiceConfigDef> svcConfDefList = serviceType != null ? daoMgr.getXXServiceConfigDef().findByServiceDefName(serviceType) : null;
-        return getPasswordConfigKeys(svcConfDefList);
+        List<String> passwordConfigNames = serviceType != null ? daoMgr.getXXServiceConfigDef().findConfigNamesByServiceDefNameAndType(serviceType, CONFIG_TYPE_PASSWORD) : null;
+        return getPasswordConfigKeys(passwordConfigNames);
     }
 
-    public static Set<String> getPasswordConfigKeys(List<XXServiceConfigDef> svcConfDefList) {
+    public static Set<String> getPasswordConfigKeys(List<String> passwordConfigNames) {
         Set<String> passwordConfigKeys = new HashSet<>();
         passwordConfigKeys.add(StringUtils.lowerCase(CONFIG_KEY_PASSWORD));
-        if (svcConfDefList != null) {
-            for (XXServiceConfigDef svcConfDef : svcConfDefList) {
-                if (StringUtils.equalsIgnoreCase(svcConfDef.getType(), CONFIG_TYPE_PASSWORD) && svcConfDef.getName() != null) {
-                    passwordConfigKeys.add(StringUtils.lowerCase(svcConfDef.getName()));
+        if (passwordConfigNames != null) {
+            for (String passwordConfigName : passwordConfigNames) {
+                if (passwordConfigName != null) {
+                    passwordConfigKeys.add(StringUtils.lowerCase(passwordConfigName));
                 }
             }
         }

--- a/security-admin/src/main/java/org/apache/ranger/db/XXServiceConfigDefDao.java
+++ b/security-admin/src/main/java/org/apache/ranger/db/XXServiceConfigDefDao.java
@@ -59,4 +59,32 @@ public class XXServiceConfigDefDao extends BaseDao<XXServiceConfigDef> {
             return new ArrayList<>();
         }
     }
+
+    public List<String> findConfigNamesByServiceDefIdAndType(Long serviceDefId, String configType) {
+        if (serviceDefId == null) {
+            return new ArrayList<>();
+        }
+        try {
+            return getEntityManager()
+                    .createNamedQuery("XXServiceConfigDef.findConfigNamesByServiceDefIdAndType", String.class)
+                    .setParameter("serviceDefId", serviceDefId)
+                    .setParameter("configType", configType).getResultList();
+        } catch (NoResultException e) {
+            return new ArrayList<>();
+        }
+    }
+
+    public List<String> findConfigNamesByServiceDefNameAndType(String serviceDef, String configType) {
+        if (serviceDef == null) {
+            return new ArrayList<>();
+        }
+        try {
+            return getEntityManager()
+                    .createNamedQuery("XXServiceConfigDef.findConfigNamesByServiceDefNameAndType", String.class)
+                    .setParameter("serviceDef", serviceDef)
+                    .setParameter("configType", configType).getResultList();
+        } catch (NoResultException e) {
+            return new ArrayList<>();
+        }
+    }
 }

--- a/security-admin/src/main/java/org/apache/ranger/service/RangerServiceService.java
+++ b/security-admin/src/main/java/org/apache/ranger/service/RangerServiceService.java
@@ -38,6 +38,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 @Service
 @Scope("singleton")
@@ -77,30 +78,49 @@ public class RangerServiceService extends RangerServiceServiceBase<XXService, Ra
     public Map<String, String> getConfigsWithDecryptedPassword(RangerService service) throws Exception {
         Map<String, String> configs = service.getConfigs();
 
-        String pwd = configs.get(ServiceDBStore.CONFIG_KEY_PASSWORD);
-        if (!stringUtil.isEmpty(pwd) && ServiceDBStore.HIDDEN_PASSWORD_STR.equalsIgnoreCase(pwd)) {
-            XXServiceConfigMap pwdConfig = daoMgr.getXXServiceConfigMap().findByServiceAndConfigKey(service.getId(), ServiceDBStore.CONFIG_KEY_PASSWORD);
+        if (configs == null) {
+            return configs;
+        }
 
-            if (pwdConfig != null) {
-                String encryptedPwd = pwdConfig.getConfigvalue();
-                if (encryptedPwd.contains(",")) {
-                    PasswordUtils util                     = PasswordUtils.build(encryptedPwd);
-                    String        freeTextPasswordMetaData = Joiner.on(",").skipNulls().join(util.getCryptAlgo(), new String(util.getEncryptKey()), new String(util.getSalt()), util.getIterationCount(), PasswordUtils.needsIv(util.getCryptAlgo()) ? util.getIvAsString() : null);
-                    String        decryptedPwd             = PasswordUtils.decryptPassword(encryptedPwd);
-                    if (StringUtils.equalsIgnoreCase(freeTextPasswordMetaData + "," + PasswordUtils.encryptPassword(freeTextPasswordMetaData + "," + decryptedPwd), encryptedPwd)) {
-                        configs.put(ServiceDBStore.CONFIG_KEY_PASSWORD, encryptedPwd);
-                        // XXX: method name is getConfigsWithDecryptedPassword, then why do we store the encryptedPwd?
-                    }
-                } else {
-                    String decryptedPwd = PasswordUtils.decryptPassword(encryptedPwd);
-                    if (StringUtils.equalsIgnoreCase(PasswordUtils.encryptPassword(decryptedPwd), encryptedPwd)) {
-                        configs.put(ServiceDBStore.CONFIG_KEY_PASSWORD, encryptedPwd);
-                        // XXX: method name is getConfigsWithDecryptedPassword, then why do we store the encryptedPwd?
+        Set<String> passwordConfigKeys = getPasswordConfigKeysByServiceDefName(service.getType());
+        for (String configKey : new ArrayList<>(configs.keySet())) {
+            if (!ServiceDBStore.isPasswordConfigKey(passwordConfigKeys, configKey)) {
+                continue;
+            }
+
+            String pwd = configs.get(configKey);
+            if (!stringUtil.isEmpty(pwd) && ServiceDBStore.HIDDEN_PASSWORD_STR.equalsIgnoreCase(pwd)) {
+                XXServiceConfigMap pwdConfig = daoMgr.getXXServiceConfigMap().findByServiceAndConfigKey(service.getId(), configKey);
+
+                if (pwdConfig != null) {
+                    String encryptedPwd = pwdConfig.getConfigvalue();
+                    if (encryptedPwd.contains(",")) {
+                        PasswordUtils util                     = PasswordUtils.build(encryptedPwd);
+                        String        freeTextPasswordMetaData = Joiner.on(",").skipNulls().join(util.getCryptAlgo(), new String(util.getEncryptKey()), new String(util.getSalt()), util.getIterationCount(), PasswordUtils.needsIv(util.getCryptAlgo()) ? util.getIvAsString() : null);
+                        String        decryptedPwd             = PasswordUtils.decryptPassword(encryptedPwd);
+                        if (StringUtils.equalsIgnoreCase(freeTextPasswordMetaData + "," + PasswordUtils.encryptPassword(freeTextPasswordMetaData + "," + decryptedPwd), encryptedPwd)) {
+                            configs.put(configKey, encryptedPwd);
+                            // XXX: method name is getConfigsWithDecryptedPassword, then why do we store the encryptedPwd?
+                        }
+                    } else {
+                        String decryptedPwd = PasswordUtils.decryptPassword(encryptedPwd);
+                        if (StringUtils.equalsIgnoreCase(PasswordUtils.encryptPassword(decryptedPwd), encryptedPwd)) {
+                            configs.put(configKey, encryptedPwd);
+                            // XXX: method name is getConfigsWithDecryptedPassword, then why do we store the encryptedPwd?
+                        }
                     }
                 }
             }
         }
         return configs;
+    }
+
+    private Set<String> getPasswordConfigKeysByServiceDefId(Long serviceDefId) {
+        return ServiceDBStore.getPasswordConfigKeys(serviceDefId != null ? daoMgr.getXXServiceConfigDef().findByServiceDefId(serviceDefId) : null);
+    }
+
+    private Set<String> getPasswordConfigKeysByServiceDefName(String serviceDefName) {
+        return ServiceDBStore.getPasswordConfigKeys(serviceDefName != null ? daoMgr.getXXServiceConfigDef().findByServiceDefName(serviceDefName) : null);
     }
 
     @Override
@@ -131,11 +151,12 @@ public class RangerServiceService extends RangerServiceServiceBase<XXService, Ra
         RangerService            vService         = super.populateViewBean(xService);
         HashMap<String, String>  configs          = new HashMap<>();
         List<XXServiceConfigMap> svcConfigMapList = daoMgr.getXXServiceConfigMap().findByServiceId(xService.getId());
+        Set<String> passwordConfigKeys = getPasswordConfigKeysByServiceDefId(xService.getType());
 
         for (XXServiceConfigMap svcConfMap : svcConfigMapList) {
             String configValue = svcConfMap.getConfigvalue();
 
-            if (StringUtils.equalsIgnoreCase(svcConfMap.getConfigkey(), ServiceDBStore.CONFIG_KEY_PASSWORD)) {
+            if (ServiceDBStore.isPasswordConfigKey(passwordConfigKeys, svcConfMap.getConfigkey())) {
                 configValue = ServiceDBStore.HIDDEN_PASSWORD_STR;
             }
 

--- a/security-admin/src/main/java/org/apache/ranger/service/RangerServiceService.java
+++ b/security-admin/src/main/java/org/apache/ranger/service/RangerServiceService.java
@@ -116,11 +116,11 @@ public class RangerServiceService extends RangerServiceServiceBase<XXService, Ra
     }
 
     private Set<String> getPasswordConfigKeysByServiceDefId(Long serviceDefId) {
-        return ServiceDBStore.getPasswordConfigKeys(serviceDefId != null ? daoMgr.getXXServiceConfigDef().findByServiceDefId(serviceDefId) : null);
+        return ServiceDBStore.getPasswordConfigKeys(serviceDefId != null ? daoMgr.getXXServiceConfigDef().findConfigNamesByServiceDefIdAndType(serviceDefId, ServiceDBStore.CONFIG_TYPE_PASSWORD) : null);
     }
 
     private Set<String> getPasswordConfigKeysByServiceDefName(String serviceDefName) {
-        return ServiceDBStore.getPasswordConfigKeys(serviceDefName != null ? daoMgr.getXXServiceConfigDef().findByServiceDefName(serviceDefName) : null);
+        return ServiceDBStore.getPasswordConfigKeys(serviceDefName != null ? daoMgr.getXXServiceConfigDef().findConfigNamesByServiceDefNameAndType(serviceDefName, ServiceDBStore.CONFIG_TYPE_PASSWORD) : null);
     }
 
     @Override

--- a/security-admin/src/main/resources/META-INF/jpa_named_queries.xml
+++ b/security-admin/src/main/resources/META-INF/jpa_named_queries.xml
@@ -646,6 +646,15 @@
 				where obj.defId = svcDef.id and svcDef.name = :serviceDef order by obj.order</query>
 	</named-query>
 
+	<named-query name="XXServiceConfigDef.findConfigNamesByServiceDefIdAndType">
+		<query>select obj.name from XXServiceConfigDef obj
+				where obj.defId = :serviceDefId and obj.type = :configType order by obj.order</query>
+	</named-query>
+
+	<named-query name="XXServiceConfigDef.findConfigNamesByServiceDefNameAndType">
+		<query>select obj.name from XXServiceConfigDef obj, XXServiceDef svcDef
+				where obj.defId = svcDef.id and svcDef.name = :serviceDef and obj.type = :configType order by obj.order</query>
+	</named-query>
 
 	<!-- XXAccessTypeDef -->
 	<named-query name="XXAccessTypeDef.findByServiceDefId">

--- a/security-admin/src/test/java/org/apache/ranger/biz/TestServiceDBStore.java
+++ b/security-admin/src/test/java/org/apache/ranger/biz/TestServiceDBStore.java
@@ -18,6 +18,7 @@
 package org.apache.ranger.biz;
 
 import org.apache.commons.collections.ListUtils;
+import org.apache.hadoop.thirdparty.com.google.common.base.Joiner;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
@@ -124,6 +125,7 @@ import org.apache.ranger.plugin.policyresourcematcher.RangerPolicyResourceMatche
 import org.apache.ranger.plugin.service.RangerBaseService;
 import org.apache.ranger.plugin.store.PList;
 import org.apache.ranger.plugin.store.ServicePredicateUtil;
+import org.apache.ranger.plugin.util.PasswordUtils;
 import org.apache.ranger.plugin.util.RangerPolicyDeltaUtil;
 import org.apache.ranger.plugin.util.RangerPurgeResult;
 import org.apache.ranger.plugin.util.SearchFilter;
@@ -156,6 +158,7 @@ import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
@@ -980,6 +983,293 @@ public class TestServiceDBStore {
         Assertions.assertEquals(dbRangerService.getType(), rangerService.getType());
         Assertions.assertEquals(dbRangerService.getVersion(), rangerService.getVersion());
         Mockito.verify(daoMgr).getXXUser();
+    }
+
+    @Test
+    public void test20aCreateServiceEncryptsAllServiceDefTypePasswordConfigs() throws Exception {
+        final String keyKeystorePwd = "nifi.ssl.keystorePassword";
+        final String keyTruststorePwd = "nifi.ssl.truststorePassword";
+        final String keyUrl = "nifi.url";
+        final String plainKeystorePwd = "s3cr3t-keystore";
+        final String plainTruststorePwd = "s3cr3t-truststore";
+        final String plainUrl = "https://nifi.example.com:8443/nifi-api";
+
+        XXServiceDao xServiceDao = Mockito.mock(XXServiceDao.class);
+        XXServiceConfigMapDao xServiceConfigMapDao = Mockito.mock(XXServiceConfigMapDao.class);
+        XXUserDao xUserDao = Mockito.mock(XXUserDao.class);
+        XXServiceConfigDefDao xServiceConfigDefDao = Mockito.mock(XXServiceConfigDefDao.class);
+        XXService xService = Mockito.mock(XXService.class);
+
+        Map<String, String> configs = new HashMap<>();
+        configs.put(keyKeystorePwd, plainKeystorePwd);
+        configs.put(keyTruststorePwd, plainTruststorePwd);
+        configs.put(keyUrl, plainUrl);
+
+        RangerService rangerService = new RangerService();
+        rangerService.setId(Id);
+        rangerService.setName("nifi-svc");
+        rangerService.setType("nifi");
+        rangerService.setConfigs(configs);
+        rangerService.setIsEnabled(true);
+
+        List<XXServiceConfigDef> nifiPasswordDefs = Arrays.asList(
+                serviceConfigDef(keyKeystorePwd, "password"),
+                serviceConfigDef(keyTruststorePwd, "password"),
+                serviceConfigDef(keyUrl, "string"));
+
+        Mockito.when(daoMgr.getXXServiceConfigDef()).thenReturn(xServiceConfigDefDao);
+        Mockito.when(xServiceConfigDefDao.findByServiceDefName("nifi")).thenReturn(nifiPasswordDefs);
+
+        Mockito.when(svcService.create(rangerService)).thenReturn(rangerService);
+        Mockito.when(daoMgr.getXXService()).thenReturn(xServiceDao);
+        Mockito.when(xServiceDao.getById(rangerService.getId())).thenReturn(xService);
+        Mockito.when(daoMgr.getXXServiceConfigMap()).thenReturn(xServiceConfigMapDao);
+        Mockito.when(daoMgr.getXXUser()).thenReturn(xUserDao);
+
+        Mockito.when(svcService.getPopulatedViewObject(xService)).thenReturn(rangerService);
+        Mockito.when(rangerAuditFields.populateAuditFields(Mockito.any(XXServiceConfigMap.class), Mockito.any(XXService.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        ServiceDBStore spy = Mockito.spy(serviceDBStore);
+        Mockito.doNothing().when(spy).createDefaultPolicies(rangerService);
+
+        spy.createService(rangerService);
+
+        ArgumentCaptor<XXServiceConfigMap> captor = ArgumentCaptor.forClass(XXServiceConfigMap.class);
+        Mockito.verify(xServiceConfigMapDao, Mockito.times(3)).create(captor.capture());
+
+        Map<String, String> persisted = new HashMap<>();
+        for (XXServiceConfigMap m : captor.getAllValues()) {
+            persisted.put(m.getConfigkey(), m.getConfigvalue());
+        }
+
+        Assertions.assertNotEquals(plainKeystorePwd, persisted.get(keyKeystorePwd), "keystore password must be encrypted, not stored in cleartext");
+        Assertions.assertNotEquals(plainTruststorePwd, persisted.get(keyTruststorePwd), "truststore password must be encrypted, not stored in cleartext");
+        Assertions.assertTrue(persisted.get(keyKeystorePwd).contains(","), "encrypted value should carry the padded crypt-param prefix");
+        Assertions.assertTrue(persisted.get(keyTruststorePwd).contains(","), "encrypted value should carry the padded crypt-param prefix");
+        Assertions.assertEquals(plainUrl, persisted.get(keyUrl), "non-secret config must be stored verbatim");
+    }
+
+    @Test
+    public void test20aLiteralPasswordKeyStillEncryptedOnCreate() throws Exception {
+        final String keyPassword = "password";
+        final String keyUrl = "jdbc.url";
+        final String plainPassword = "s3cr3t";
+        final String plainUrl = "jdbc:hive2://localhost:10000";
+
+        XXServiceDao xServiceDao = Mockito.mock(XXServiceDao.class);
+        XXServiceConfigMapDao xServiceConfigMapDao = Mockito.mock(XXServiceConfigMapDao.class);
+        XXUserDao xUserDao = Mockito.mock(XXUserDao.class);
+        XXServiceConfigDefDao xServiceConfigDefDao = Mockito.mock(XXServiceConfigDefDao.class);
+        XXService xService = Mockito.mock(XXService.class);
+
+        Map<String, String> configs = new HashMap<>();
+        configs.put(keyPassword, plainPassword);
+        configs.put(keyUrl, plainUrl);
+
+        RangerService rangerService = new RangerService();
+        rangerService.setId(Id);
+        rangerService.setName("hive-svc");
+        rangerService.setType("hive");
+        rangerService.setConfigs(configs);
+        rangerService.setIsEnabled(true);
+
+        // no type="password" declarations at all for this service-def - only the literal key
+        // "password" should still get encrypted.
+        Mockito.when(daoMgr.getXXServiceConfigDef()).thenReturn(xServiceConfigDefDao);
+        Mockito.when(xServiceConfigDefDao.findByServiceDefName("hive")).thenReturn(Collections.emptyList());
+
+        Mockito.when(svcService.create(rangerService)).thenReturn(rangerService);
+        Mockito.when(daoMgr.getXXService()).thenReturn(xServiceDao);
+        Mockito.when(xServiceDao.getById(rangerService.getId())).thenReturn(xService);
+        Mockito.when(daoMgr.getXXServiceConfigMap()).thenReturn(xServiceConfigMapDao);
+        Mockito.when(daoMgr.getXXUser()).thenReturn(xUserDao);
+
+        Mockito.when(svcService.getPopulatedViewObject(xService)).thenReturn(rangerService);
+        Mockito.when(rangerAuditFields.populateAuditFields(Mockito.any(XXServiceConfigMap.class), Mockito.any(XXService.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        ServiceDBStore spy = Mockito.spy(serviceDBStore);
+        Mockito.doNothing().when(spy).createDefaultPolicies(rangerService);
+
+        spy.createService(rangerService);
+
+        ArgumentCaptor<XXServiceConfigMap> captor = ArgumentCaptor.forClass(XXServiceConfigMap.class);
+        Mockito.verify(xServiceConfigMapDao, Mockito.times(2)).create(captor.capture());
+
+        Map<String, String> persisted = new HashMap<>();
+        for (XXServiceConfigMap m : captor.getAllValues()) {
+            persisted.put(m.getConfigkey(), m.getConfigvalue());
+        }
+
+        Assertions.assertNotEquals(plainPassword, persisted.get(keyPassword), "the legacy literal 'password' key must still be encrypted, not stored in cleartext");
+        Assertions.assertTrue(persisted.get(keyPassword).contains(","), "encrypted value should carry the padded crypt-param prefix");
+        Assertions.assertEquals(plainUrl, persisted.get(keyUrl), "non-secret config must be stored verbatim");
+    }
+
+    @Test
+    public void test20bUpdateServicePreservesPerKeyEncryptedValueOnHiddenSentinel() throws Exception {
+        final String keyKeystorePwd = "nifi.ssl.keystorePassword";
+        final String keyTruststorePwd = "nifi.ssl.truststorePassword";
+
+        String oldKeystoreEncrypted = encryptForStorage("old-keystore-secret");
+        String oldTruststoreEncrypted = encryptForStorage("old-truststore-secret");
+        Assertions.assertNotEquals(oldKeystoreEncrypted, oldTruststoreEncrypted, "test fixture sanity check");
+
+        XXServiceDao xServiceDao = Mockito.mock(XXServiceDao.class);
+        XXService xService = Mockito.mock(XXService.class);
+        XXServiceConfigMapDao xServiceConfigMapDao = Mockito.mock(XXServiceConfigMapDao.class);
+        XXServiceConfigDefDao xServiceConfigDefDao = Mockito.mock(XXServiceConfigDefDao.class);
+        XXUserDao xUserDao = Mockito.mock(XXUserDao.class);
+
+        Map<String, String> configs = new HashMap<>();
+        configs.put(keyKeystorePwd, ServiceDBStore.HIDDEN_PASSWORD_STR);
+        configs.put(keyTruststorePwd, ServiceDBStore.HIDDEN_PASSWORD_STR);
+
+        RangerService rangerService = new RangerService();
+        rangerService.setId(Id);
+        rangerService.setName("nifi-svc");
+        rangerService.setType("nifi");
+        rangerService.setConfigs(configs);
+        rangerService.setIsEnabled(true);
+
+        RangerService existing = new RangerService();
+        existing.setId(Id);
+        existing.setName("nifi-svc");
+        existing.setType("nifi");
+        existing.setIsEnabled(true);
+
+        List<XXServiceConfigDef> nifiPasswordDefs = Arrays.asList(
+                serviceConfigDef(keyKeystorePwd, "password"),
+                serviceConfigDef(keyTruststorePwd, "password"));
+
+        Mockito.when(daoMgr.getXXServiceConfigDef()).thenReturn(xServiceConfigDefDao);
+        Mockito.when(xServiceConfigDefDao.findByServiceDefName("nifi")).thenReturn(nifiPasswordDefs);
+
+        Mockito.when(daoMgr.getXXService()).thenReturn(xServiceDao);
+        Mockito.when(xServiceDao.getById(Id)).thenReturn(xService);
+        Mockito.when(svcService.getPopulatedViewObject(xService)).thenReturn(existing).thenReturn(rangerService);
+
+        List<XXServiceConfigMap> dbConfigMaps = Arrays.asList(
+                storedConfigMap(keyKeystorePwd, oldKeystoreEncrypted),
+                storedConfigMap(keyTruststorePwd, oldTruststoreEncrypted));
+
+        Mockito.when(daoMgr.getXXServiceConfigMap()).thenReturn(xServiceConfigMapDao);
+        Mockito.when(xServiceConfigMapDao.findByServiceId(Id)).thenReturn(dbConfigMaps);
+        Mockito.when(daoMgr.getXXUser()).thenReturn(xUserDao);
+
+        Mockito.when(svcService.update(rangerService)).thenReturn(rangerService);
+        Mockito.when(rangerAuditFields.populateAuditFields(Mockito.any(XXServiceConfigMap.class), Mockito.any(XXService.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        RangerService result = serviceDBStore.updateService(rangerService, null);
+        Assertions.assertNotNull(result);
+
+        ArgumentCaptor<XXServiceConfigMap> captor = ArgumentCaptor.forClass(XXServiceConfigMap.class);
+        Mockito.verify(xServiceConfigMapDao, Mockito.times(2)).create(captor.capture());
+
+        Map<String, String> persisted = new HashMap<>();
+        for (XXServiceConfigMap m : captor.getAllValues()) {
+            persisted.put(m.getConfigkey(), m.getConfigvalue());
+        }
+
+        Assertions.assertEquals(oldKeystoreEncrypted, persisted.get(keyKeystorePwd), "old keystore password must be preserved when the client sends the hidden sentinel");
+        Assertions.assertEquals(oldTruststoreEncrypted, persisted.get(keyTruststorePwd), "old truststore password must be preserved when the client sends the hidden sentinel");
+        Assertions.assertNotEquals(oldTruststoreEncrypted, persisted.get(keyKeystorePwd), "keystore's old value must not be swapped with truststore's");
+        Assertions.assertNotEquals(oldKeystoreEncrypted, persisted.get(keyTruststorePwd), "truststore's old value must not be swapped with keystore's");
+    }
+
+    @Test
+    public void test20cUpdateServiceReEncryptsChangedKeyAndPreservesOtherOnHiddenSentinel() throws Exception {
+        final String keyKeystorePwd = "nifi.ssl.keystorePassword";
+        final String keyTruststorePwd = "nifi.ssl.truststorePassword";
+        final String newKeystorePwd = "brand-new-keystore-secret";
+
+        String oldKeystoreEncrypted = encryptForStorage("old-keystore-secret");
+        String oldTruststoreEncrypted = encryptForStorage("old-truststore-secret");
+
+        XXServiceDao xServiceDao = Mockito.mock(XXServiceDao.class);
+        XXService xService = Mockito.mock(XXService.class);
+        XXServiceConfigMapDao xServiceConfigMapDao = Mockito.mock(XXServiceConfigMapDao.class);
+        XXServiceConfigDefDao xServiceConfigDefDao = Mockito.mock(XXServiceConfigDefDao.class);
+        XXUserDao xUserDao = Mockito.mock(XXUserDao.class);
+
+        Map<String, String> configs = new HashMap<>();
+        configs.put(keyKeystorePwd, newKeystorePwd);                       // changed
+        configs.put(keyTruststorePwd, ServiceDBStore.HIDDEN_PASSWORD_STR); // untouched
+
+        RangerService rangerService = new RangerService();
+        rangerService.setId(Id);
+        rangerService.setName("nifi-svc");
+        rangerService.setType("nifi");
+        rangerService.setConfigs(configs);
+        rangerService.setIsEnabled(true);
+
+        RangerService existing = new RangerService();
+        existing.setId(Id);
+        existing.setName("nifi-svc");
+        existing.setType("nifi");
+        existing.setIsEnabled(true);
+
+        List<XXServiceConfigDef> nifiPasswordDefs = Arrays.asList(
+                serviceConfigDef(keyKeystorePwd, "password"),
+                serviceConfigDef(keyTruststorePwd, "password"));
+
+        Mockito.when(daoMgr.getXXServiceConfigDef()).thenReturn(xServiceConfigDefDao);
+        Mockito.when(xServiceConfigDefDao.findByServiceDefName("nifi")).thenReturn(nifiPasswordDefs);
+
+        Mockito.when(daoMgr.getXXService()).thenReturn(xServiceDao);
+        Mockito.when(xServiceDao.getById(Id)).thenReturn(xService);
+        Mockito.when(svcService.getPopulatedViewObject(xService)).thenReturn(existing).thenReturn(rangerService);
+
+        List<XXServiceConfigMap> dbConfigMaps = Arrays.asList(
+                storedConfigMap(keyKeystorePwd, oldKeystoreEncrypted),
+                storedConfigMap(keyTruststorePwd, oldTruststoreEncrypted));
+
+        Mockito.when(daoMgr.getXXServiceConfigMap()).thenReturn(xServiceConfigMapDao);
+        Mockito.when(xServiceConfigMapDao.findByServiceId(Id)).thenReturn(dbConfigMaps);
+        Mockito.when(daoMgr.getXXUser()).thenReturn(xUserDao);
+
+        Mockito.when(svcService.update(rangerService)).thenReturn(rangerService);
+        Mockito.when(rangerAuditFields.populateAuditFields(Mockito.any(XXServiceConfigMap.class), Mockito.any(XXService.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        RangerService result = serviceDBStore.updateService(rangerService, null);
+        Assertions.assertNotNull(result);
+
+        ArgumentCaptor<XXServiceConfigMap> captor = ArgumentCaptor.forClass(XXServiceConfigMap.class);
+        Mockito.verify(xServiceConfigMapDao, Mockito.times(2)).create(captor.capture());
+
+        Map<String, String> persisted = new HashMap<>();
+        for (XXServiceConfigMap m : captor.getAllValues()) {
+            persisted.put(m.getConfigkey(), m.getConfigvalue());
+        }
+
+        Assertions.assertNotEquals(oldKeystoreEncrypted, persisted.get(keyKeystorePwd), "changed keystore password must be freshly re-encrypted, not left as the old value");
+        Assertions.assertNotEquals(newKeystorePwd, persisted.get(keyKeystorePwd), "keystore password must be encrypted, not stored in cleartext");
+        Assertions.assertEquals(oldTruststoreEncrypted, persisted.get(keyTruststorePwd), "untouched truststore password must keep its old encrypted value");
+    }
+
+    private XXServiceConfigDef serviceConfigDef(String name, String type) {
+        XXServiceConfigDef def = new XXServiceConfigDef();
+        def.setName(name);
+        def.setType(type);
+        return def;
+    }
+
+    private XXServiceConfigMap storedConfigMap(String key, String value) {
+        XXServiceConfigMap m = new XXServiceConfigMap();
+        m.setConfigkey(key);
+        m.setConfigvalue(value);
+        return m;
+    }
+
+    private String encryptForStorage(String plainValue) throws Exception {
+        String iv                = PasswordUtils.generateIvIfNeeded(ServiceDBStore.CRYPT_ALGO);
+        Joiner joiner            = Joiner.on(",").skipNulls();
+        String cryptConfigString = joiner.join(ServiceDBStore.CRYPT_ALGO, ServiceDBStore.ENCRYPT_KEY, ServiceDBStore.SALT, ServiceDBStore.ITERATION_COUNT, iv, plainValue);
+        String encryptedPwd      = PasswordUtils.encryptPassword(cryptConfigString);
+        return joiner.join(ServiceDBStore.CRYPT_ALGO, ServiceDBStore.ENCRYPT_KEY, ServiceDBStore.SALT, ServiceDBStore.ITERATION_COUNT, iv, encryptedPwd);
     }
 
     @Test

--- a/security-admin/src/test/java/org/apache/ranger/biz/TestServiceDBStore.java
+++ b/security-admin/src/test/java/org/apache/ranger/biz/TestServiceDBStore.java
@@ -1019,6 +1019,7 @@ public class TestServiceDBStore {
 
         Mockito.when(daoMgr.getXXServiceConfigDef()).thenReturn(xServiceConfigDefDao);
         Mockito.when(xServiceConfigDefDao.findByServiceDefName("nifi")).thenReturn(nifiPasswordDefs);
+        Mockito.when(xServiceConfigDefDao.findConfigNamesByServiceDefNameAndType("nifi", ServiceDBStore.CONFIG_TYPE_PASSWORD)).thenReturn(Arrays.asList(keyKeystorePwd, keyTruststorePwd));
 
         Mockito.when(svcService.create(rangerService)).thenReturn(rangerService);
         Mockito.when(daoMgr.getXXService()).thenReturn(xServiceDao);
@@ -1145,6 +1146,7 @@ public class TestServiceDBStore {
 
         Mockito.when(daoMgr.getXXServiceConfigDef()).thenReturn(xServiceConfigDefDao);
         Mockito.when(xServiceConfigDefDao.findByServiceDefName("nifi")).thenReturn(nifiPasswordDefs);
+        Mockito.when(xServiceConfigDefDao.findConfigNamesByServiceDefNameAndType("nifi", ServiceDBStore.CONFIG_TYPE_PASSWORD)).thenReturn(Arrays.asList(keyKeystorePwd, keyTruststorePwd));
 
         Mockito.when(daoMgr.getXXService()).thenReturn(xServiceDao);
         Mockito.when(xServiceDao.getById(Id)).thenReturn(xService);
@@ -1217,6 +1219,7 @@ public class TestServiceDBStore {
 
         Mockito.when(daoMgr.getXXServiceConfigDef()).thenReturn(xServiceConfigDefDao);
         Mockito.when(xServiceConfigDefDao.findByServiceDefName("nifi")).thenReturn(nifiPasswordDefs);
+        Mockito.when(xServiceConfigDefDao.findConfigNamesByServiceDefNameAndType("nifi", ServiceDBStore.CONFIG_TYPE_PASSWORD)).thenReturn(Arrays.asList(keyKeystorePwd, keyTruststorePwd));
 
         Mockito.when(daoMgr.getXXService()).thenReturn(xServiceDao);
         Mockito.when(xServiceDao.getById(Id)).thenReturn(xService);

--- a/security-admin/src/test/java/org/apache/ranger/service/TestRangerServiceService.java
+++ b/security-admin/src/test/java/org/apache/ranger/service/TestRangerServiceService.java
@@ -16,23 +16,28 @@
  */
 package org.apache.ranger.service;
 
+import org.apache.hadoop.thirdparty.com.google.common.base.Joiner;
 import org.apache.ranger.biz.RangerBizUtil;
+import org.apache.ranger.biz.ServiceDBStore;
 import org.apache.ranger.common.ContextUtil;
 import org.apache.ranger.common.JSONUtil;
 import org.apache.ranger.common.StringUtil;
 import org.apache.ranger.common.UserSessionBase;
 import org.apache.ranger.db.RangerDaoManager;
 import org.apache.ranger.db.XXPortalUserDao;
+import org.apache.ranger.db.XXServiceConfigDefDao;
 import org.apache.ranger.db.XXServiceConfigMapDao;
 import org.apache.ranger.db.XXServiceDao;
 import org.apache.ranger.db.XXServiceDefDao;
 import org.apache.ranger.db.XXServiceVersionInfoDao;
 import org.apache.ranger.entity.XXPortalUser;
 import org.apache.ranger.entity.XXService;
+import org.apache.ranger.entity.XXServiceConfigDef;
 import org.apache.ranger.entity.XXServiceConfigMap;
 import org.apache.ranger.entity.XXServiceDef;
 import org.apache.ranger.entity.XXServiceVersionInfo;
 import org.apache.ranger.plugin.model.RangerService;
+import org.apache.ranger.plugin.util.PasswordUtils;
 import org.apache.ranger.security.context.RangerContextHolder;
 import org.apache.ranger.security.context.RangerSecurityContext;
 import org.junit.jupiter.api.Assertions;
@@ -46,6 +51,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -111,6 +117,7 @@ public class TestRangerServiceService {
         XXServiceDefDao xServiceDefDao = Mockito.mock(XXServiceDefDao.class);
         XXService       xService       = xService();
         String          name           = "fdfdfds";
+        XXServiceConfigDefDao xServiceConfigDefDao = Mockito.mock(XXServiceConfigDefDao.class);
 
         List<XXServiceConfigMap> svcConfigMapList = new ArrayList<>();
         XXServiceConfigMap       xConfMap         = new XXServiceConfigMap();
@@ -160,6 +167,9 @@ public class TestRangerServiceService {
         Mockito.when(daoManager.getXXServiceConfigMap()).thenReturn(xServiceConfigMapDao);
         Mockito.when(xServiceConfigMapDao.findByServiceId(xService.getId())).thenReturn(svcConfigMapList);
 
+        Mockito.when(daoManager.getXXServiceConfigDef()).thenReturn(xServiceConfigDefDao);
+        Mockito.when(xServiceConfigDefDao.findByServiceDefId(xService.getType())).thenReturn(new ArrayList<>());
+
         RangerService dbService = serviceService.populateViewBean(xService);
 
         Assertions.assertNotNull(dbService);
@@ -182,6 +192,7 @@ public class TestRangerServiceService {
         XXServiceConfigMapDao xServiceConfigMapDao = Mockito.mock(XXServiceConfigMapDao.class);
         XXPortalUserDao       xPortalUserDao       = Mockito.mock(XXPortalUserDao.class);
         XXServiceDefDao       xServiceDefDao       = Mockito.mock(XXServiceDefDao.class);
+        XXServiceConfigDefDao xServiceConfigDefDao = Mockito.mock(XXServiceConfigDefDao.class);
         XXService             xService             = xService();
         String                name                 = "fdfdfds";
 
@@ -232,6 +243,9 @@ public class TestRangerServiceService {
         Mockito.when(daoManager.getXXServiceConfigMap()).thenReturn(xServiceConfigMapDao);
         Mockito.when(xServiceConfigMapDao.findByServiceId(xService.getId())).thenReturn(svcConfigMapList);
 
+        Mockito.when(daoManager.getXXServiceConfigDef()).thenReturn(xServiceConfigDefDao);
+        Mockito.when(xServiceConfigDefDao.findByServiceDefId(xService.getType())).thenReturn(new ArrayList<>());
+
         RangerService dbService = serviceService.getPopulatedViewObject(xService);
 
         Assertions.assertNotNull(dbService);
@@ -250,11 +264,140 @@ public class TestRangerServiceService {
     }
 
     @Test
+    public void test4aPopulateViewBeanMasksAllServiceDefTypePasswordConfigs() {
+        XXServiceConfigMapDao xServiceConfigMapDao = Mockito.mock(XXServiceConfigMapDao.class);
+        XXPortalUserDao       xPortalUserDao       = Mockito.mock(XXPortalUserDao.class);
+        XXServiceDefDao       xServiceDefDao       = Mockito.mock(XXServiceDefDao.class);
+        XXServiceConfigDefDao xServiceConfigDefDao = Mockito.mock(XXServiceConfigDefDao.class);
+        XXService             xService             = xService();
+
+        final String keyGenericPassword    = "password";
+        final String keyKeystorePassword   = "nifi.ssl.keystorePassword";
+        final String keyTruststorePassword = "nifi.ssl.truststorePassword";
+        final String keyUrl                = "nifi.url";
+
+        List<XXServiceConfigMap> svcConfigMapList = new ArrayList<>();
+        svcConfigMapList.add(configMap(keyGenericPassword, "s3cr3t-admin"));
+        svcConfigMapList.add(configMap(keyKeystorePassword, "s3cr3t-keystore"));
+        svcConfigMapList.add(configMap(keyTruststorePassword, "s3cr3t-truststore"));
+        svcConfigMapList.add(configMap(keyUrl, "https://nifi.example.com:8443/nifi-api"));
+
+        XXPortalUser tUser = new XXPortalUser();
+        tUser.setAddedByUserId(userId);
+        tUser.setCreateTime(new Date());
+        tUser.setEmailAddress("test@gmail.com");
+        tUser.setFirstName("nifi-prod");
+        tUser.setId(userId);
+        tUser.setLastName("nifi-prod");
+
+        XXServiceDef xServiceDef = new XXServiceDef();
+        xServiceDef.setAddedByUserId(userId);
+        xServiceDef.setCreateTime(new Date());
+        xServiceDef.setDescription("test");
+        xServiceDef.setGuid("1427365526516_835_0");
+        xServiceDef.setId(userId);
+
+        XXServiceVersionInfoDao xServiceVersionInfoDao = Mockito.mock(XXServiceVersionInfoDao.class);
+        XXServiceVersionInfo    serviceVersionInfo     = new XXServiceVersionInfo();
+        serviceVersionInfo.setServiceId(xService.getId());
+        serviceVersionInfo.setPolicyVersion(xService.getPolicyVersion());
+        serviceVersionInfo.setPolicyUpdateTime(xService.getPolicyUpdateTime());
+        serviceVersionInfo.setTagVersion(xService.getTagVersion());
+        serviceVersionInfo.setTagUpdateTime(xService.getTagUpdateTime());
+
+        Mockito.when(daoManager.getXXServiceVersionInfo()).thenReturn(xServiceVersionInfoDao);
+        Mockito.when(xServiceVersionInfoDao.findByServiceId(xService.getId())).thenReturn(serviceVersionInfo);
+
+        Mockito.when(daoManager.getXXPortalUser()).thenReturn(xPortalUserDao);
+        Mockito.when(xPortalUserDao.getById(userId)).thenReturn(tUser);
+
+        Mockito.when(daoManager.getXXServiceDef()).thenReturn(xServiceDefDao);
+        Mockito.when(xServiceDefDao.getById(xService.getType())).thenReturn(xServiceDef);
+
+        Mockito.when(daoManager.getXXServiceConfigMap()).thenReturn(xServiceConfigMapDao);
+        Mockito.when(xServiceConfigMapDao.findByServiceId(xService.getId())).thenReturn(svcConfigMapList);
+
+        /* the config item names the NiFi service-def declares with "type":"password" */
+        List<XXServiceConfigDef> nifiPasswordTypedDefs = new ArrayList<>();
+        nifiPasswordTypedDefs.add(configDef(keyKeystorePassword, "password"));
+        nifiPasswordTypedDefs.add(configDef(keyTruststorePassword, "password"));
+        nifiPasswordTypedDefs.add(configDef(keyUrl, "string"));
+
+        Mockito.when(daoManager.getXXServiceConfigDef()).thenReturn(xServiceConfigDefDao);
+        Mockito.when(xServiceConfigDefDao.findByServiceDefId(xService.getType())).thenReturn(nifiPasswordTypedDefs);
+
+        RangerService        dbService = serviceService.getPopulatedViewObject(xService);
+        Map<String, String>  configs   = dbService.getConfigs();
+
+        Assertions.assertEquals("*****", configs.get(keyGenericPassword), "literal 'password' key must still be masked");
+        Assertions.assertEquals("*****", configs.get(keyKeystorePassword), "type=password key nifi.ssl.keystorePassword must now be masked");
+        Assertions.assertEquals("*****", configs.get(keyTruststorePassword), "type=password key nifi.ssl.truststorePassword must now be masked");
+        Assertions.assertEquals("https://nifi.example.com:8443/nifi-api", configs.get(keyUrl), "non-secret config must be returned verbatim");
+    }
+
+    @Test
+    public void test4bGetConfigsWithDecryptedPasswordResolvesMixedCaseKeys() throws Exception {
+        final String  configKey  = "nifi.ssl.keystorePassword"; // mixed case, as NiFi's service-def declares it
+        final String  plainValue = "s3cr3t-keystore";
+
+        String iv                = PasswordUtils.generateIvIfNeeded(ServiceDBStore.CRYPT_ALGO);
+        Joiner joiner            = Joiner.on(",").skipNulls();
+        String cryptConfigString = joiner.join(ServiceDBStore.CRYPT_ALGO, ServiceDBStore.ENCRYPT_KEY, ServiceDBStore.SALT, ServiceDBStore.ITERATION_COUNT, iv, plainValue);
+        String encryptedPwd      = PasswordUtils.encryptPassword(cryptConfigString);
+        String storedValue       = joiner.join(ServiceDBStore.CRYPT_ALGO, ServiceDBStore.ENCRYPT_KEY, ServiceDBStore.SALT, ServiceDBStore.ITERATION_COUNT, iv, encryptedPwd);
+
+        XXServiceConfigMapDao xServiceConfigMapDao = Mockito.mock(XXServiceConfigMapDao.class);
+        XXServiceConfigDefDao xServiceConfigDefDao = Mockito.mock(XXServiceConfigDefDao.class);
+
+        Map<String, String> configs = new HashMap<>();
+        configs.put(configKey, ServiceDBStore.HIDDEN_PASSWORD_STR); // UI didn't change this field -> sentinel value
+
+        RangerService service = new RangerService();
+        service.setId(userId);
+        service.setType("nifi");
+        service.setConfigs(configs);
+
+        XXServiceConfigMap storedConfigMap = new XXServiceConfigMap();
+        storedConfigMap.setConfigkey(configKey);
+        storedConfigMap.setConfigvalue(storedValue);
+
+        Mockito.when(daoManager.getXXServiceConfigDef()).thenReturn(xServiceConfigDefDao);
+        Mockito.when(xServiceConfigDefDao.findByServiceDefName("nifi")).thenReturn(Collections.singletonList(configDef(configKey, "password")));
+
+        Mockito.when(daoManager.getXXServiceConfigMap()).thenReturn(xServiceConfigMapDao);
+        Mockito.when(xServiceConfigMapDao.findByServiceAndConfigKey(userId, configKey)).thenReturn(storedConfigMap);
+
+        Mockito.when(stringUtil.isEmpty(Mockito.anyString())).thenReturn(false);
+
+        Map<String, String> result = serviceService.getConfigsWithDecryptedPassword(service);
+
+        Assertions.assertEquals(storedValue, result.get(configKey),
+                "mixed-case password-typed key must be resolved via case-insensitive lookup, not silently skipped");
+    }
+
+    private XXServiceConfigMap configMap(String key, String value) {
+        XXServiceConfigMap xConfMap = new XXServiceConfigMap();
+        xConfMap.setConfigkey(key);
+        xConfMap.setConfigvalue(value);
+        xConfMap.setCreateTime(new Date());
+        xConfMap.setUpdateTime(new Date());
+        return xConfMap;
+    }
+
+    private XXServiceConfigDef configDef(String name, String type) {
+        XXServiceConfigDef def = new XXServiceConfigDef();
+        def.setName(name);
+        def.setType(type);
+        return def;
+    }
+
+    @Test
     public void test5GetAllServices() {
         XXServiceDao          xServiceDao          = Mockito.mock(XXServiceDao.class);
         XXPortalUserDao       xPortalUserDao       = Mockito.mock(XXPortalUserDao.class);
         XXServiceConfigMapDao xServiceConfigMapDao = Mockito.mock(XXServiceConfigMapDao.class);
         XXServiceDefDao       xServiceDefDao       = Mockito.mock(XXServiceDefDao.class);
+        XXServiceConfigDefDao xServiceConfigDefDao = Mockito.mock(XXServiceConfigDefDao.class);
 
         String name = "fdfdfds";
 
@@ -311,6 +454,9 @@ public class TestRangerServiceService {
 
         Mockito.when(daoManager.getXXServiceConfigMap()).thenReturn(xServiceConfigMapDao);
         Mockito.when(xServiceConfigMapDao.findByServiceId(xService.getId())).thenReturn(svcConfigMapList);
+
+        Mockito.when(daoManager.getXXServiceConfigDef()).thenReturn(xServiceConfigDefDao);
+        Mockito.when(xServiceConfigDefDao.findByServiceDefId(xService.getType())).thenReturn(new ArrayList<>());
 
         List<RangerService> dbServiceList = serviceService.getAllServices();
         Assertions.assertNotNull(dbServiceList);

--- a/security-admin/src/test/java/org/apache/ranger/service/TestRangerServiceService.java
+++ b/security-admin/src/test/java/org/apache/ranger/service/TestRangerServiceService.java
@@ -32,7 +32,6 @@ import org.apache.ranger.db.XXServiceDefDao;
 import org.apache.ranger.db.XXServiceVersionInfoDao;
 import org.apache.ranger.entity.XXPortalUser;
 import org.apache.ranger.entity.XXService;
-import org.apache.ranger.entity.XXServiceConfigDef;
 import org.apache.ranger.entity.XXServiceConfigMap;
 import org.apache.ranger.entity.XXServiceDef;
 import org.apache.ranger.entity.XXServiceVersionInfo;
@@ -51,6 +50,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -168,7 +168,7 @@ public class TestRangerServiceService {
         Mockito.when(xServiceConfigMapDao.findByServiceId(xService.getId())).thenReturn(svcConfigMapList);
 
         Mockito.when(daoManager.getXXServiceConfigDef()).thenReturn(xServiceConfigDefDao);
-        Mockito.when(xServiceConfigDefDao.findByServiceDefId(xService.getType())).thenReturn(new ArrayList<>());
+        Mockito.when(xServiceConfigDefDao.findConfigNamesByServiceDefIdAndType(xService.getType(), ServiceDBStore.CONFIG_TYPE_PASSWORD)).thenReturn(new ArrayList<>());
 
         RangerService dbService = serviceService.populateViewBean(xService);
 
@@ -244,7 +244,7 @@ public class TestRangerServiceService {
         Mockito.when(xServiceConfigMapDao.findByServiceId(xService.getId())).thenReturn(svcConfigMapList);
 
         Mockito.when(daoManager.getXXServiceConfigDef()).thenReturn(xServiceConfigDefDao);
-        Mockito.when(xServiceConfigDefDao.findByServiceDefId(xService.getType())).thenReturn(new ArrayList<>());
+        Mockito.when(xServiceConfigDefDao.findConfigNamesByServiceDefIdAndType(xService.getType(), ServiceDBStore.CONFIG_TYPE_PASSWORD)).thenReturn(new ArrayList<>());
 
         RangerService dbService = serviceService.getPopulatedViewObject(xService);
 
@@ -317,14 +317,12 @@ public class TestRangerServiceService {
         Mockito.when(daoManager.getXXServiceConfigMap()).thenReturn(xServiceConfigMapDao);
         Mockito.when(xServiceConfigMapDao.findByServiceId(xService.getId())).thenReturn(svcConfigMapList);
 
-        /* the config item names the NiFi service-def declares with "type":"password" */
-        List<XXServiceConfigDef> nifiPasswordTypedDefs = new ArrayList<>();
-        nifiPasswordTypedDefs.add(configDef(keyKeystorePassword, "password"));
-        nifiPasswordTypedDefs.add(configDef(keyTruststorePassword, "password"));
-        nifiPasswordTypedDefs.add(configDef(keyUrl, "string"));
+        /* the config item names the NiFi service-def declares with "type":"password" -
+         * already filtered by type at the DB layer, so only those two names come back */
+        List<String> nifiPasswordTypedNames = Arrays.asList(keyKeystorePassword, keyTruststorePassword);
 
         Mockito.when(daoManager.getXXServiceConfigDef()).thenReturn(xServiceConfigDefDao);
-        Mockito.when(xServiceConfigDefDao.findByServiceDefId(xService.getType())).thenReturn(nifiPasswordTypedDefs);
+        Mockito.when(xServiceConfigDefDao.findConfigNamesByServiceDefIdAndType(xService.getType(), ServiceDBStore.CONFIG_TYPE_PASSWORD)).thenReturn(nifiPasswordTypedNames);
 
         RangerService        dbService = serviceService.getPopulatedViewObject(xService);
         Map<String, String>  configs   = dbService.getConfigs();
@@ -362,8 +360,7 @@ public class TestRangerServiceService {
         storedConfigMap.setConfigvalue(storedValue);
 
         Mockito.when(daoManager.getXXServiceConfigDef()).thenReturn(xServiceConfigDefDao);
-        Mockito.when(xServiceConfigDefDao.findByServiceDefName("nifi")).thenReturn(Collections.singletonList(configDef(configKey, "password")));
-
+        Mockito.when(xServiceConfigDefDao.findConfigNamesByServiceDefNameAndType("nifi", ServiceDBStore.CONFIG_TYPE_PASSWORD)).thenReturn(Collections.singletonList(configKey));
         Mockito.when(daoManager.getXXServiceConfigMap()).thenReturn(xServiceConfigMapDao);
         Mockito.when(xServiceConfigMapDao.findByServiceAndConfigKey(userId, configKey)).thenReturn(storedConfigMap);
 
@@ -382,13 +379,6 @@ public class TestRangerServiceService {
         xConfMap.setCreateTime(new Date());
         xConfMap.setUpdateTime(new Date());
         return xConfMap;
-    }
-
-    private XXServiceConfigDef configDef(String name, String type) {
-        XXServiceConfigDef def = new XXServiceConfigDef();
-        def.setName(name);
-        def.setType(type);
-        return def;
     }
 
     @Test
@@ -456,7 +446,7 @@ public class TestRangerServiceService {
         Mockito.when(xServiceConfigMapDao.findByServiceId(xService.getId())).thenReturn(svcConfigMapList);
 
         Mockito.when(daoManager.getXXServiceConfigDef()).thenReturn(xServiceConfigDefDao);
-        Mockito.when(xServiceConfigDefDao.findByServiceDefId(xService.getType())).thenReturn(new ArrayList<>());
+        Mockito.when(xServiceConfigDefDao.findConfigNamesByServiceDefIdAndType(xService.getType(), ServiceDBStore.CONFIG_TYPE_PASSWORD)).thenReturn(new ArrayList<>());
 
         List<RangerService> dbServiceList = serviceService.getAllServices();
         Assertions.assertNotNull(dbServiceList);


### PR DESCRIPTION

## What changes were proposed in this pull request?

Service config masking (read) and encryption (write) previously only matched the literal key "password". Service-defs can declare other config items with type="password" under different names (e.g. NiFi's nifi.ssl.keystorePassword /truststorePassword) - those were left unmasked/unencrypted.

This change treats any config item as a secret if its key is "password" OR the service-def declares it with type="password", applied consistently across RangerServiceService (read/view) and ServiceDBStore (create/update). updateService now preserves the correct per-key value on the hidden-sentinel case instead of a single shared variable. Shared classification logic lives in one place (ServiceDBStore) to avoid drift.


## How was this patch tested?

Added/updated unit tests in TestRangerServiceService and TestServiceDBStore covering masking, encryption, and per-key update behavior for service-def-declared secret keys.
