### PR TITLE
RANGER-5744: Harden plugins-docker-build against Ozone KDC startup race

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,6 +247,22 @@ jobs:
           -f docker-compose.ranger-knox.yml \
           -f docker-compose.ranger-ozone.yml up -d
 
+      - name: Wait for KDC Kerberos readiness
+        run: |
+          cd dev-support/ranger-docker
+          for i in $(seq 1 90); do
+            status=$(docker inspect -f '{{.State.Health.Status}}' ranger-kdc 2>/dev/null || echo missing)
+            if [ "$status" = "healthy" ]; then
+              echo "ranger-kdc is healthy after ${i} attempt(s)"
+              exit 0
+            fi
+            echo "Waiting for ranger-kdc (status=${status})..."
+            sleep 2
+          done
+          echo "ranger-kdc did not become healthy in time"
+          docker logs ranger-kdc || true
+          exit 1
+
       - name: Check status of containers and remove them
         run: |
           sleep 60

--- a/dev-support/ranger-docker/Dockerfile.ranger-kdc
+++ b/dev-support/ranger-docker/Dockerfile.ranger-kdc
@@ -42,7 +42,7 @@ VOLUME /etc/keytabs
 
 EXPOSE 88/tcp 88/udp 749/tcp
 
-HEALTHCHECK --interval=5s --timeout=3s --start-period=120s --retries=30 \
-  CMD test -f /etc/keytabs/.provisioned && echo | nc -w 1 localhost 88 || exit 1
+HEALTHCHECK --interval=5s --timeout=5s --start-period=120s --retries=30 \
+  CMD test -f /etc/keytabs/.provisioned && kinit -kt /etc/keytabs/datanode/dn.keytab dn/datanode.rangernw@EXAMPLE.COM && kdestroy
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/dev-support/ranger-docker/docker-compose.ranger-ozone.yml
+++ b/dev-support/ranger-docker/docker-compose.ranger-ozone.yml
@@ -7,14 +7,16 @@ services:
       - ./downloads/ozone-${OZONE_VERSION}:/opt/hadoop
       - ./dist/keytabs/datanode:/etc/keytabs
       - ./scripts/kdc/krb5.conf:/etc/krb5.conf:ro
+      - ./scripts/ozone/ozone-service-start.sh:/opt/ozone-service-start.sh:ro
     networks:
       - ranger
     ports:
       - 9864
     depends_on:
       ranger-kdc:
-        condition: service_started
-    command: bash -c "unset KERBEROS_ENABLED; sudo mkdir -p /data/hdds /data/metadata && sudo chown -R hadoop:hadoop /data && exec /opt/hadoop/bin/ozone datanode"
+        condition: service_healthy
+    restart: on-failure:3
+    command: bash -c "unset KERBEROS_ENABLED; export OZONE_KEYTAB_NAME=dn.keytab; bash /opt/ozone-service-start.sh bash -c 'sudo mkdir -p /data/hdds /data/metadata && sudo chown -R hadoop:hadoop /data && exec /opt/hadoop/bin/ozone datanode'"
     env_file:
       - ./scripts/ozone/docker-config
     environment:
@@ -43,7 +45,7 @@ services:
       - 9862:9862
     depends_on:
       ranger-kdc:
-        condition: service_started
+        condition: service_healthy
       scm:
         condition: service_started
       datanode:
@@ -68,6 +70,7 @@ services:
       - ./downloads/ozone-${OZONE_VERSION}:/opt/hadoop
       - ./dist/keytabs/scm:/etc/keytabs
       - ./scripts/kdc/krb5.conf:/etc/krb5.conf:ro
+      - ./scripts/ozone/ozone-service-start.sh:/opt/ozone-service-start.sh:ro
     networks:
       - ranger
     ports:
@@ -75,13 +78,14 @@ services:
       - 9860:9860
     depends_on:
       ranger-kdc:
-        condition: service_started
+        condition: service_healthy
     env_file:
       - ./scripts/ozone/docker-config
     environment:
       RANGER_KERBEROS_ENABLED: ${KERBEROS_ENABLED}
       OZONE-SITE.XML_hdds.scm.safemode.min.datanode: "${OZONE_SAFEMODE_MIN_DATANODES:-1}"
-    command: bash -c "unset KERBEROS_ENABLED; (test -f /data/metadata/scm/current/VERSION || /opt/hadoop/bin/ozone scm --init) && exec /opt/hadoop/bin/ozone scm"
+    restart: on-failure:3
+    command: bash -c "unset KERBEROS_ENABLED; export OZONE_KEYTAB_NAME=scm.keytab; bash /opt/ozone-service-start.sh bash -c '(test -f /data/metadata/scm/current/VERSION || /opt/hadoop/bin/ozone scm --init) && exec /opt/hadoop/bin/ozone scm'"
 
 networks:
   ranger:

--- a/dev-support/ranger-docker/scripts/kdc/krb5.conf
+++ b/dev-support/ranger-docker/scripts/kdc/krb5.conf
@@ -5,6 +5,8 @@
  dns_lookup_realm = false
  ticket_lifetime = 24h
  forwardable = true
+ # Docker CI: avoid UDP KDC probes (PortUnreachableException) when KDC TCP is up first.
+ udp_preference_limit = 0
 
 [realms]
  EXAMPLE.COM = {

--- a/dev-support/ranger-docker/scripts/ozone/ozone-service-start.sh
+++ b/dev-support/ranger-docker/scripts/ozone/ozone-service-start.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Waits for Kerberos keytab + KDC before exec'ing Ozone SCM/datanode. CI smoke tests
+# hit PortUnreachableException when the datanode starts before KDC UDP/TCP is ready.
+
+set -euo pipefail
+
+KEYTAB_NAME="${OZONE_KEYTAB_NAME:-}"
+KDC_HOST="${KDC_HOST:-ranger-kdc.rangernw}"
+KDC_PORT="${KDC_PORT:-88}"
+MAX_WAIT_SEC="${OZONE_KERBEROS_WAIT_SEC:-120}"
+
+wait_for_keytab() {
+  if [[ -z "${KEYTAB_NAME}" ]] || [[ "${RANGER_KERBEROS_ENABLED:-}" != "true" ]]; then
+    return 0
+  fi
+
+  local keytab_path="/etc/keytabs/${KEYTAB_NAME}"
+  local deadline=$((SECONDS + MAX_WAIT_SEC))
+
+  echo "Waiting for keytab ${keytab_path} (up to ${MAX_WAIT_SEC}s)..."
+  while (( SECONDS < deadline )); do
+    if [[ -f "${keytab_path}" ]]; then
+      echo "Found keytab ${keytab_path}"
+      return 0
+    fi
+    sleep 2
+  done
+
+  echo "ERROR: timed out waiting for keytab ${keytab_path}" >&2
+  exit 1
+}
+
+wait_for_kdc() {
+  if [[ "${RANGER_KERBEROS_ENABLED:-}" != "true" ]]; then
+    return 0
+  fi
+
+  local deadline=$((SECONDS + MAX_WAIT_SEC))
+
+  echo "Waiting for KDC at ${KDC_HOST}:${KDC_PORT} (up to ${MAX_WAIT_SEC}s)..."
+  while (( SECONDS < deadline )); do
+    if (echo > "/dev/tcp/${KDC_HOST}/${KDC_PORT}") 2>/dev/null; then
+      # KDC healthcheck can pass slightly before clients succeed; brief settle.
+      sleep 3
+      echo "KDC reachable at ${KDC_HOST}:${KDC_PORT}"
+      return 0
+    fi
+    sleep 2
+  done
+
+  echo "ERROR: timed out waiting for KDC at ${KDC_HOST}:${KDC_PORT}" >&2
+  exit 1
+}
+
+wait_for_keytab
+wait_for_kdc
+exec "$@"


### PR DESCRIPTION
## Summary

Fixes intermittent `plugins-docker-build` CI failures where `ozone-datanode` exits during Kerberos login before the Ranger KDC is fully ready in the Docker Compose smoke stack.

Example failure: https://github.com/apache/ranger/actions/runs/31185432016/job/93444713551

Root cause: Ozone datanode/scm started on `ranger-kdc: service_started` while Java Kerberos clients probe KDC over UDP first; the existing KDC healthcheck only validated TCP port 88. Re-running the job usually passes once the KDC is warm.

## Changes

- **KDC healthcheck** (`Dockerfile.ranger-kdc`): replace TCP `nc` probe with `kinit` using the datanode keytab so healthy means Kerberos actually works
- **Compose ordering** (`docker-compose.ranger-ozone.yml`): Ozone datanode/scm/om wait for `ranger-kdc: service_healthy` (same pattern as `ranger-zk`)
- **krb5.conf**: set `udp_preference_limit = 0` to avoid UDP `PortUnreachableException` in Docker CI when TCP is ready first (see below)
- **Startup script** (`ozone-service-start.sh`): wait for keytab file and KDC reachability before starting Ozone SCM/datanode
- **Restart policy**: `restart: on-failure:3` on ozone-datanode and ozone-scm for one-shot race recovery
- **CI workflow** (`.github/workflows/ci.yml`): explicit wait for `ranger-kdc` healthy before the container status check

## `udp_preference_limit = 0` in `krb5.conf`

Defined once in `dev-support/ranger-docker/scripts/kdc/krb5.conf` and shared across the Docker CI stack (mounted into Ranger Admin, ZK, Hadoop, Hive, HBase, Kafka, Knox, Ozone, OpenSearch, Solr, KMS, PDP, UserSync, TagSync; also baked into the KDC image). It does **not** affect production Ranger installs outside `dev-support/ranger-docker`.

### What it does

`udp_preference_limit` controls how Kerberos **clients** reach the KDC. By default, clients (Java `kinit`, Hadoop, Ozone, etc.) try the KDC over **UDP port 88 first**, then fall back to **TCP** if UDP fails.

Setting:

```ini
udp_preference_limit = 0
```

means the client **never uses UDP** for KDC ticket requests (AS-REQ / TGS-REQ). All KDC communication uses **TCP port 88 only**.

Per MIT Kerberos: *“If this flag is set to 0, UDP will not be used to send messages to the KDC.”*

```mermaid
flowchart LR
    A[Client needs ticket] --> B{udp_preference_limit}
    B -->|default| C[Try UDP :88]
    C -->|fail| D[Try TCP :88]
    C -->|ok| E[Got ticket]
    D --> E
    B -->|0| F[Use TCP :88 only]
    F --> E
```

### Why it helps in this CI flake

The Ozone failure showed:

```
Caused by: java.net.PortUnreachableException
  at ... KdcComm.send ...
```

The Java client sent a **UDP** request to the KDC before UDP was reliably reachable, while the old KDC healthcheck only validated **TCP** with `nc`. So healthcheck could pass (TCP ✅) while Ozone login failed (UDP ❌).

Forcing TCP aligns client behavior with the healthcheck and avoids UDP startup races in Docker Compose.

### Trade-offs

| Aspect | Effect |
|--------|--------|
| Reliability in Docker CI | Better — avoids UDP race with KDC startup |
| Performance | Slightly more TCP overhead; negligible for CI smoke tests |
| Kerberos behavior | Does not disable Kerberos or change principals/keytabs — transport only |
| Scope | `dev-support/ranger-docker` only; production clusters use their own `krb5.conf` |

## Test plan

- [ ] `plugins-docker-build` passes on this PR (watch for multiple consecutive green runs)
- [ ] Local smoke: `cd dev-support/ranger-docker && docker compose ... -f docker-compose.ranger-ozone.yml up -d` — verify `ozone-datanode`, `ozone-scm`, `ozone-om` stay running
- [ ] Confirm `docker inspect ranger-kdc` reports `healthy` only after keytabs are provisioned
- [ ] Verify unrelated plugin containers (Hadoop, Hive, HBase, Kafka, Knox) still start normally

https://issues.apache.org/jira/browse/RANGER-5744
