### PR TITLE
RANGER-5717: Disable SSO in docker, ensure readiness health check registers user in DB

### DIFF
--- a/dev-support/ranger-docker/scripts/admin/ranger-admin-install-mysql.properties
+++ b/dev-support/ranger-docker/scripts/admin/ranger-admin-install-mysql.properties
@@ -121,4 +121,4 @@ audit_jaas_client_option_keyTab=/etc/keytabs/rangeradmin.keytab
 audit_jaas_client_option_principal=rangeradmin/ranger.rangernw@EXAMPLE.COM
 
 #-- SSO Configs --#
-sso_enabled=true
+sso_enabled=false

--- a/dev-support/ranger-docker/scripts/admin/ranger-admin-install-mysql.properties
+++ b/dev-support/ranger-docker/scripts/admin/ranger-admin-install-mysql.properties
@@ -121,4 +121,5 @@ audit_jaas_client_option_keyTab=/etc/keytabs/rangeradmin.keytab
 audit_jaas_client_option_principal=rangeradmin/ranger.rangernw@EXAMPLE.COM
 
 #-- SSO Configs --#
+# set this to true when used along with header based authentication.
 sso_enabled=false

--- a/dev-support/ranger-docker/scripts/admin/ranger-admin-install-oracle.properties
+++ b/dev-support/ranger-docker/scripts/admin/ranger-admin-install-oracle.properties
@@ -122,4 +122,4 @@ audit_jaas_client_option_keyTab=/etc/keytabs/rangeradmin.keytab
 audit_jaas_client_option_principal=rangeradmin/ranger.rangernw@EXAMPLE.COM
 
 #-- SSO Configs --#
-sso_enabled=true
+sso_enabled=false

--- a/dev-support/ranger-docker/scripts/admin/ranger-admin-install-oracle.properties
+++ b/dev-support/ranger-docker/scripts/admin/ranger-admin-install-oracle.properties
@@ -122,4 +122,5 @@ audit_jaas_client_option_keyTab=/etc/keytabs/rangeradmin.keytab
 audit_jaas_client_option_principal=rangeradmin/ranger.rangernw@EXAMPLE.COM
 
 #-- SSO Configs --#
+# set this to true when used along with header based authentication.
 sso_enabled=false

--- a/dev-support/ranger-docker/scripts/admin/ranger-admin-install-postgres.properties
+++ b/dev-support/ranger-docker/scripts/admin/ranger-admin-install-postgres.properties
@@ -128,4 +128,5 @@ audit_jaas_client_option_keyTab=/etc/keytabs/rangeradmin.keytab
 audit_jaas_client_option_principal=rangeradmin/ranger.rangernw@EXAMPLE.COM
 
 #-- SSO Configs --#
+# set this to true when used along with header based authentication.
 sso_enabled=false

--- a/dev-support/ranger-docker/scripts/admin/ranger-admin-install-postgres.properties
+++ b/dev-support/ranger-docker/scripts/admin/ranger-admin-install-postgres.properties
@@ -128,4 +128,4 @@ audit_jaas_client_option_keyTab=/etc/keytabs/rangeradmin.keytab
 audit_jaas_client_option_principal=rangeradmin/ranger.rangernw@EXAMPLE.COM
 
 #-- SSO Configs --#
-sso_enabled=true
+sso_enabled=false

--- a/dev-support/ranger-docker/scripts/admin/ranger-admin-install-sqlserver.properties
+++ b/dev-support/ranger-docker/scripts/admin/ranger-admin-install-sqlserver.properties
@@ -119,4 +119,5 @@ audit_jaas_client_1_option_keyTab=/etc/keytabs/rangeradmin.keytab
 audit_jaas_client_1_option_principal=rangeradmin/ranger.rangernw@EXAMPLE.COM
 
 #-- SSO Configs --#
+# set this to true when used along with header based authentication.
 sso_enabled=false

--- a/dev-support/ranger-docker/scripts/admin/ranger-admin-install-sqlserver.properties
+++ b/dev-support/ranger-docker/scripts/admin/ranger-admin-install-sqlserver.properties
@@ -119,4 +119,4 @@ audit_jaas_client_1_option_keyTab=/etc/keytabs/rangeradmin.keytab
 audit_jaas_client_1_option_principal=rangeradmin/ranger.rangernw@EXAMPLE.COM
 
 #-- SSO Configs --#
-sso_enabled=true
+sso_enabled=false

--- a/security-admin/src/main/java/org/apache/ranger/biz/SessionMgr.java
+++ b/security-admin/src/main/java/org/apache/ranger/biz/SessionMgr.java
@@ -528,7 +528,7 @@ public class SessionMgr {
         boolean               ssoEnabled = session != null ? session.isSSOEnabled() : PropertiesUtil.getBooleanProperty("ranger.sso.enabled", false);
         XXPortalUser          gjUser     = daoManager.getXXPortalUser().findByLoginId(currentLoginId);
 
-        if (gjUser == null && ((request.getAttribute("spnegoEnabled") != null && (boolean) request.getAttribute("spnegoEnabled")) || (ssoEnabled))) {
+        if (gjUser == null && ((request.getAttribute("spnegoEnabled") != null && (boolean) request.getAttribute("spnegoEnabled")) || (ssoEnabled) || bizUtil.isHealthCheckUser(currentLoginId))) {
             logger.debug("User : {} doesn't exist in Ranger DB So creating user as it's SSO or Spnego authenticated", currentLoginId);
 
             if (bizUtil.isHealthCheckUser(currentLoginId)) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

In docker env, `ranger.sso.enabled=true` was added in https://github.com/apache/ranger/pull/1120.

To ensure readiness healthcheck API registers the healthcheck user (`ranger.admin.healthcheck.username`) in the DB, update `SessionMgr.java` to allow user creation irrespective of config: `ranger.sso.enabled`.

Setting `ranger.sso.enabled=false` to allow logout from Ranger UI to be functional.
 
Note: When using header based authentication, `ranger.sso.enabled` must be set to true to allow any authenticated user to be created in Ranger DB.

## How was this patch tested?

Tested using both scenarios:
- ranger.sso.enabled=true
- ranger.sso.enabled=false

that the API endpoint is accessible via `ranger.admin.healthcheck.username` user and results in user creation in DB.

