### PR TITLE
RANGER-5595: Audit grant and revoke role operations

### DIFF
--- a/agents-common/src/main/java/org/apache/ranger/plugin/service/RangerBasePlugin.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/service/RangerBasePlugin.java
@@ -1030,7 +1030,15 @@ public class RangerBasePlugin {
     public void grantRole(GrantRevokeRoleRequest request, RangerAccessResultProcessor resultProcessor) throws Exception {
         LOG.debug("==> RangerBasePlugin.grantRole({})", request);
 
-        getAdminClient().grantRole(request);
+        boolean isSuccess = false;
+
+        try {
+            getAdminClient().grantRole(request);
+
+            isSuccess = true;
+        } finally {
+            auditGrantRevokeRole(request, "GRANT_ROLE", isSuccess, resultProcessor);
+        }
 
         LOG.debug("<== RangerBasePlugin.grantRole({})", request);
     }
@@ -1038,7 +1046,15 @@ public class RangerBasePlugin {
     public void revokeRole(GrantRevokeRoleRequest request, RangerAccessResultProcessor resultProcessor) throws Exception {
         LOG.debug("==> RangerBasePlugin.revokeRole({})", request);
 
-        getAdminClient().revokeRole(request);
+        boolean isSuccess = false;
+
+        try {
+            getAdminClient().revokeRole(request);
+
+            isSuccess = true;
+        } finally {
+            auditGrantRevokeRole(request, "REVOKE_ROLE", isSuccess, resultProcessor);
+        }
 
         LOG.debug("<== RangerBasePlugin.revokeRole({})", request);
     }
@@ -1263,6 +1279,7 @@ public class RangerBasePlugin {
             accessRequest.setAction(action);
             accessRequest.setClientIPAddress(request.getClientIPAddress());
             accessRequest.setClientType(request.getClientType());
+            accessRequest.setClusterName(request.getClusterName());
             accessRequest.setRequestData(request.getRequestData());
             accessRequest.setSessionId(request.getSessionId());
 
@@ -1271,6 +1288,34 @@ public class RangerBasePlugin {
 
             if (accessResult != null && accessResult.getIsAudited()) {
                 accessRequest.setAccessType(action);
+                accessResult.setIsAllowed(isSuccess);
+
+                if (!isSuccess) {
+                    accessResult.setPolicyId(-1);
+                }
+
+                resultProcessor.processResult(accessResult);
+            }
+        }
+    }
+
+    private void auditGrantRevokeRole(GrantRevokeRoleRequest request, String action, boolean isSuccess, RangerAccessResultProcessor resultProcessor) {
+        if (request != null && resultProcessor != null) {
+            RangerAccessRequestImpl accessRequest = new RangerAccessRequestImpl();
+
+            accessRequest.setResource(new RangerAccessResourceImpl(Collections.singletonMap("global", "*")));
+            accessRequest.setUser(request.getGrantor());
+            accessRequest.setAccessType("alter");
+            accessRequest.setAction(action);
+            accessRequest.setClientIPAddress(request.getClientIPAddress());
+            accessRequest.setClientType(request.getClientType());
+            accessRequest.setRequestData(request.getRequestData());
+            accessRequest.setSessionId(request.getSessionId());
+
+            // call isAccessAllowed() to determine if audit is enabled or not
+            RangerAccessResult accessResult = isAccessAllowed(accessRequest, null);
+
+            if (accessResult != null && accessResult.getIsAudited()) {
                 accessResult.setIsAllowed(isSuccess);
 
                 if (!isSuccess) {

--- a/agents-common/src/test/java/org/apache/ranger/plugin/service/TestRangerBasePluginRoleAudit.java
+++ b/agents-common/src/test/java/org/apache/ranger/plugin/service/TestRangerBasePluginRoleAudit.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.plugin.service;
+
+import java.lang.reflect.Field;
+
+import org.apache.ranger.admin.client.RangerAdminClient;
+import org.apache.ranger.plugin.model.RangerPolicy;
+import org.apache.ranger.plugin.policyengine.RangerAccessRequest;
+import org.apache.ranger.plugin.policyengine.RangerAccessResult;
+import org.apache.ranger.plugin.policyengine.RangerAccessResultProcessor;
+import org.apache.ranger.plugin.util.GrantRevokeRoleRequest;
+import org.apache.ranger.plugin.util.PolicyRefresher;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TestRangerBasePluginRoleAudit {
+    private RangerBasePlugin            plugin;
+    private RangerAdminClient            adminClient;
+    private RangerAccessResultProcessor resultProcessor;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        plugin          = Mockito.spy(new RangerBasePlugin("hive", "test-hive", "test-app"));
+        adminClient     = mock(RangerAdminClient.class);
+        resultProcessor = mock(RangerAccessResultProcessor.class);
+
+        PolicyRefresher refresher = mock(PolicyRefresher.class);
+
+        when(refresher.getRangerAdminClient()).thenReturn(adminClient);
+
+        Field refresherField = RangerBasePlugin.class.getDeclaredField("refresher");
+
+        refresherField.setAccessible(true);
+        refresherField.set(plugin, refresher);
+
+        doAnswer(invocation -> {
+            RangerAccessRequest accessRequest = invocation.getArgument(0);
+            RangerAccessResult  ret           = new RangerAccessResult(RangerPolicy.POLICY_TYPE_ACCESS, plugin.getServiceName(), plugin.getServiceDef(), accessRequest);
+
+            ret.setIsAudited(true);
+
+            return ret;
+        }).when(plugin).isAccessAllowed(any(RangerAccessRequest.class), isNull());
+    }
+
+    @Test
+    public void testGrantRoleProducesAuditResult() throws Exception {
+        GrantRevokeRoleRequest request = createRequest();
+
+        plugin.grantRole(request, resultProcessor);
+
+        verify(adminClient).grantRole(request);
+
+        RangerAccessResult result = getAuditResult();
+
+        assertTrue(result.getIsAllowed());
+        assertEquals("GRANT_ROLE", result.getAccessRequest().getAction());
+        assertEquals("alter", result.getAccessRequest().getAccessType());
+        assertEquals("*", result.getAccessRequest().getResource().getValue("global"));
+    }
+
+    @Test
+    public void testRevokeRoleFailureProducesDeniedAuditResult() throws Exception {
+        GrantRevokeRoleRequest request = createRequest();
+
+        doThrow(new Exception("revoke failed")).when(adminClient).revokeRole(request);
+
+        assertThrows(Exception.class, () -> plugin.revokeRole(request, resultProcessor));
+
+        RangerAccessResult result = getAuditResult();
+
+        assertFalse(result.getIsAllowed());
+        assertEquals(-1, result.getPolicyId());
+        assertEquals("REVOKE_ROLE", result.getAccessRequest().getAction());
+    }
+
+    private GrantRevokeRoleRequest createRequest() {
+        GrantRevokeRoleRequest ret = new GrantRevokeRoleRequest();
+
+        ret.setGrantor("admin");
+        ret.setClientIPAddress("192.0.2.10");
+        ret.setClientType("test-client");
+        ret.setRequestData("grant role test_role to user test_user");
+        ret.setSessionId("test-session");
+
+        return ret;
+    }
+
+    private RangerAccessResult getAuditResult() {
+        ArgumentCaptor<RangerAccessResult> captor = ArgumentCaptor.forClass(RangerAccessResult.class);
+
+        verify(resultProcessor).processResult(captor.capture());
+
+        return captor.getValue();
+    }
+}

--- a/hive-agent/src/main/java/org/apache/ranger/authorization/hive/authorizer/RangerHiveAuthorizer.java
+++ b/hive-agent/src/main/java/org/apache/ranger/authorization/hive/authorizer/RangerHiveAuthorizer.java
@@ -532,10 +532,8 @@ public class RangerHiveAuthorizer extends RangerHiveAuthorizerBase {
     public void grantRole(List<HivePrincipal> hivePrincipals, List<String> roles, boolean grantOption, HivePrincipal grantorPrinc) throws HiveAccessControlException {
         LOG.debug("RangerHiveAuthorizerBase.grantRole()");
 
-        boolean                result       = false;
         RangerHiveAuditHandler auditHandler = new RangerHiveAuditHandler(hivePlugin.getConfig());
         String                 username     = getGrantorUsername(grantorPrinc);
-        List<String>           principals   = new ArrayList<>();
 
         try {
             GrantRevokeRoleRequest request   = new GrantRevokeRoleRequest();
@@ -554,21 +552,18 @@ public class RangerHiveAuthorizer extends RangerHiveAuthorizerBase {
                         name = principal.getName();
 
                         userList.add(name);
-                        principals.add("USER " + name);
                         break;
 
                     case GROUP:
                         name = principal.getName();
 
                         groupList.add(name);
-                        principals.add("GROUP " + name);
                         break;
 
                     case ROLE:
                         name = principal.getName();
 
                         roleList.add(name);
-                        principals.add("ROLE " + name);
                         break;
 
                     case UNKNOWN:
@@ -603,13 +598,9 @@ public class RangerHiveAuthorizer extends RangerHiveAuthorizerBase {
 
             hivePlugin.grantRole(request, auditHandler);
 
-            result = true;
         } catch (Exception excp) {
             throw new HiveAccessControlException(excp);
         } finally {
-            RangerAccessResult accessResult = createAuditEvent(hivePlugin, username, principals, HiveOperationType.GRANT_ROLE, HiveAccessType.ALTER, roles, result);
-
-            auditHandler.processResult(accessResult);
             auditHandler.flushAudit();
         }
     }
@@ -618,10 +609,8 @@ public class RangerHiveAuthorizer extends RangerHiveAuthorizerBase {
     public void revokeRole(List<HivePrincipal> hivePrincipals, List<String> roles, boolean grantOption, HivePrincipal grantorPrinc) throws HiveAccessControlException {
         LOG.debug("RangerHiveAuthorizerBase.revokeRole()");
 
-        boolean                result          = false;
         RangerHiveAuditHandler auditHandler    = new RangerHiveAuditHandler(hivePlugin.getConfig());
         String                 grantorUserName = getGrantorUsername(grantorPrinc);
-        List<String>           principals      = new ArrayList<>();
 
         try {
             GrantRevokeRoleRequest request   = new GrantRevokeRoleRequest();
@@ -640,20 +629,17 @@ public class RangerHiveAuthorizer extends RangerHiveAuthorizerBase {
                         principalName = principal.getName();
 
                         userList.add(principalName);
-                        principals.add("USER " + principalName);
                         break;
 
                     case GROUP:
                         principalName = principal.getName();
 
                         groupList.add(principalName);
-                        principals.add("GROUP " + principalName);
                         break;
                     case ROLE:
                         principalName = principal.getName();
 
                         roleList.add(principalName);
-                        principals.add("ROLE " + principalName);
                         break;
 
                     case UNKNOWN:
@@ -690,13 +676,9 @@ public class RangerHiveAuthorizer extends RangerHiveAuthorizerBase {
 
             hivePlugin.revokeRole(request, auditHandler);
 
-            result = true;
         } catch (Exception excp) {
             throw new HiveAccessControlException(excp);
         } finally {
-            RangerAccessResult accessResult = createAuditEvent(hivePlugin, grantorUserName, principals, HiveOperationType.REVOKE_ROLE, HiveAccessType.ALTER, roles, result);
-
-            auditHandler.processResult(accessResult);
             auditHandler.flushAudit();
         }
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pull request fixes RANGER-5595 by generating audit results for role grant and revoke operations when a non-null `RangerAccessResultProcessor` is provided.

The changes:

- Add audit processing to `RangerBasePlugin#grantRole()` and `RangerBasePlugin#revokeRole()`.
- Generate audit results for both successful and failed operations.
- Preserve the existing role audit semantics and request metadata.
- Remove the Hive authorizer’s manual role audit generation to prevent duplicate audit events.
- Add focused unit tests covering successful role grants and failed role revocations.

## How was this patch tested?

The focused unit tests for role grant and revoke auditing were run with:

```bash
mvn -pl agents-common -DskipTests=false -Dtest=TestRangerBasePluginRoleAudit test
```

Results:

```text
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

The tests verify:

- Audit result generation for a successful role grant.
- Denied audit result generation for a failed role revocation.
- Audit action, access type, global resource, and failure policy ID values.