### PR TITLE
RANGER-5747: Migrate NiFiClient and NiFiRegistryClient to use RangerDefaultHostnameVerifier

### DIFF
--- a/plugin-nifi-registry/src/main/java/org/apache/ranger/services/nifi/registry/client/NiFiRegistryClient.java
+++ b/plugin-nifi-registry/src/main/java/org/apache/ranger/services/nifi/registry/client/NiFiRegistryClient.java
@@ -24,14 +24,13 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.ranger.plugin.client.BaseClient;
 import org.apache.ranger.plugin.service.ResourceLookupContext;
+import org.apache.ranger.plugin.util.RangerDefaultHostnameVerifier;
 import org.apache.ranger.plugin.util.RangerJersey2ClientBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLPeerUnverifiedException;
-import javax.net.ssl.SSLSession;
 import javax.ws.rs.ProcessingException;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.client.Client;
@@ -40,11 +39,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import java.io.InputStream;
-import java.security.cert.Certificate;
-import java.security.cert.CertificateParsingException;
-import java.security.cert.X509Certificate;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
@@ -65,7 +60,7 @@ public class NiFiRegistryClient {
     public NiFiRegistryClient(final String url, final SSLContext sslContext) {
         this.url              = url;
         this.sslContext       = sslContext;
-        this.hostnameVerifier = new NiFiRegistryHostnameVerifier();
+        this.hostnameVerifier = new RangerDefaultHostnameVerifier();
         this.client = buildClient();
     }
 
@@ -174,52 +169,5 @@ public class NiFiRegistryClient {
     protected Response getResponse() {
         WebTarget webTarget = getWebTarget();
         return webTarget.request(MediaType.APPLICATION_JSON).get();
-    }
-
-    /**
-     * Custom hostname verifier that checks subject alternative names against the hostname of the URI.
-     */
-    private static class NiFiRegistryHostnameVerifier implements HostnameVerifier {
-        @Override
-        public boolean verify(final String hostname, final SSLSession ssls) {
-            try {
-                Certificate[] certificates = ssls.getPeerCertificates();
-                if (certificates == null || certificates.length == 0) {
-                    return false;
-                }
-                // verify hostname against server certificate[0]
-                if (certificates[0] instanceof X509Certificate) {
-                    final X509Certificate x509Cert = (X509Certificate) certificates[0];
-                    final List<String> subjectAltNames = getSubjectAlternativeNames(x509Cert);
-                    return subjectAltNames.contains(hostname.toLowerCase());
-                }
-            } catch (final SSLPeerUnverifiedException | CertificateParsingException ex) {
-                LOG.warn("Hostname Verification encountered exception verifying hostname due to: {}", ex, ex);
-            }
-
-            return false;
-        }
-
-        private List<String> getSubjectAlternativeNames(final X509Certificate certificate) throws CertificateParsingException {
-            final List<String>        result   = new ArrayList<>();
-            final Collection<List<?>> altNames = certificate.getSubjectAlternativeNames();
-            if (altNames == null) {
-                return result;
-            }
-
-            for (final List<?> generalName : altNames) {
-                /**
-                 * generalName has the name type as the first element a String or byte array for the second element. We return any general names that are String types.
-                 * We don't inspect the numeric name type because some certificates incorrectly put IPs and DNS names under the wrong name types.
-                 */
-                if (generalName.size() > 1) {
-                    final Object value = generalName.get(1);
-                    if (value instanceof String) {
-                        result.add(((String) value).toLowerCase());
-                    }
-                }
-            }
-            return result;
-        }
     }
 }

--- a/plugin-nifi/src/main/java/org/apache/ranger/services/nifi/client/NiFiClient.java
+++ b/plugin-nifi/src/main/java/org/apache/ranger/services/nifi/client/NiFiClient.java
@@ -24,14 +24,13 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.ranger.plugin.client.BaseClient;
 import org.apache.ranger.plugin.service.ResourceLookupContext;
+import org.apache.ranger.plugin.util.RangerDefaultHostnameVerifier;
 import org.apache.ranger.plugin.util.RangerJersey2ClientBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLPeerUnverifiedException;
-import javax.net.ssl.SSLSession;
 import javax.ws.rs.ProcessingException;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.client.Client;
@@ -40,11 +39,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import java.io.InputStream;
-import java.security.cert.Certificate;
-import java.security.cert.CertificateParsingException;
-import java.security.cert.X509Certificate;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
@@ -67,7 +62,7 @@ public class NiFiClient {
     public NiFiClient(final String url, final SSLContext sslContext) {
         this.url              = url;
         this.sslContext       = sslContext;
-        this.hostnameVerifier = new NiFiHostnameVerifier();
+        this.hostnameVerifier = new RangerDefaultHostnameVerifier();
         this.client           = buildClient();
     }
 
@@ -174,52 +169,5 @@ public class NiFiClient {
 
     protected Response getResponse(WebTarget webTarget, String accept) {
         return webTarget.request(accept).get();
-    }
-
-    /**
-     * Custom hostname verifier that checks subject alternative names against the hostname of the URI.
-     */
-    private static class NiFiHostnameVerifier implements HostnameVerifier {
-        @Override
-        public boolean verify(final String hostname, final SSLSession ssls) {
-            try {
-                Certificate[] certificates = ssls.getPeerCertificates();
-                if (certificates == null || certificates.length == 0) {
-                    return false;
-                }
-                // verify hostname against server certificate[0]
-                if (certificates[0] instanceof X509Certificate) {
-                    final X509Certificate x509Cert = (X509Certificate) certificates[0];
-                    final List<String> subjectAltNames = getSubjectAlternativeNames(x509Cert);
-                    return subjectAltNames.contains(hostname.toLowerCase());
-                }
-            } catch (final SSLPeerUnverifiedException | CertificateParsingException ex) {
-                LOG.warn("Hostname Verification encountered exception verifying hostname due to: {}", ex, ex);
-            }
-
-            return false;
-        }
-
-        private List<String> getSubjectAlternativeNames(final X509Certificate certificate) throws CertificateParsingException {
-            final Collection<List<?>> altNames = certificate.getSubjectAlternativeNames();
-            if (altNames == null) {
-                return new ArrayList<>();
-            }
-
-            final List<String> result = new ArrayList<>();
-            for (final List<?> generalName : altNames) {
-                /**
-                 * generalName has the name type as the first element a String or byte array for the second element. We return any general names that are String types.
-                 * We don't inspect the numeric name type because some certificates incorrectly put IPs and DNS names under the wrong name types.
-                 */
-                if (generalName.size() > 1) {
-                    final Object value = generalName.get(1);
-                    if (value instanceof String) {
-                        result.add(((String) value).toLowerCase());
-                    }
-                }
-            }
-            return result;
-        }
     }
 }

--- a/plugin-nifi/src/test/java/org/apache/ranger/services/nifi/client/TestNiFiClientSSL.java
+++ b/plugin-nifi/src/test/java/org/apache/ranger/services/nifi/client/TestNiFiClientSSL.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.ranger.services.nifi.registry.client;
+package org.apache.ranger.services.nifi.client;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -33,7 +33,6 @@ import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.security.Principal;
 import java.security.cert.Certificate;
-import java.security.cert.CertificateParsingException;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.Collection;
@@ -41,23 +40,22 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * Integration tests for NiFiRegistryClient SSL hostname verification functionality.
+ * Integration tests for NiFiClient SSL hostname verification functionality.
  * These tests verify that the hostname verifier correctly validates SSL certificates
  * and prevents man-in-the-middle attacks.
- *
- * Originally removed during Jersey 1.x to Jersey 2.x migration due to API changes,
- * now restored using Jersey 2.x / Jakarta RS APIs.
+ * Mirrors TestNiFiRegistryClientSSL -- NiFiClient and NiFiRegistryClient share the
+ * same hostname-verifier wiring.
  */
-public class TestNiFiRegistryClientSSL {
+public class TestNiFiClientSSL {
     private static final String HOSTNAME = "example.com";
     private static final int HTTPS_PORT = 443;
 
-    private NiFiRegistryClient sslClient;
+    private NiFiClient sslClient;
 
     @BeforeEach
     public void setup() throws NoSuchAlgorithmException, KeyManagementException {
         SSLContext sslContext = createInitializedSSLContext();
-        sslClient = new NiFiRegistryClient("https://" + HOSTNAME + ":" + HTTPS_PORT, sslContext);
+        sslClient = new NiFiClient("https://" + HOSTNAME + ":" + HTTPS_PORT, sslContext);
     }
 
     /**
@@ -65,13 +63,10 @@ public class TestNiFiRegistryClientSSL {
      * This ensures legitimate connections are accepted.
      */
     @Test
-    public void testHostnameVerifierMatch() throws NoSuchAlgorithmException, KeyManagementException,
-            CertificateParsingException, SSLPeerUnverifiedException {
+    public void testHostnameVerifierMatch() {
         MockSSLSession mockSession = createMockSSLSessionWithCertificate(HOSTNAME);
-
         HostnameVerifier verifier = sslClient.getHostnameVerifier();
         Assertions.assertNotNull(verifier, "Hostname verifier should not be null");
-
         boolean result = verifier.verify(HOSTNAME, mockSession);
         Assertions.assertTrue(result, "Hostname verification should pass for matching hostname");
     }
@@ -81,13 +76,10 @@ public class TestNiFiRegistryClientSSL {
      * This prevents MITM attacks where a certificate for a different hostname is presented.
      */
     @Test
-    public void testHostnameVerifierNoMatch() throws NoSuchAlgorithmException, KeyManagementException,
-            CertificateParsingException, SSLPeerUnverifiedException {
+    public void testHostnameVerifierNoMatch() {
         MockSSLSession mockSession = createMockSSLSessionWithCertificate("attacker.com");
-
         HostnameVerifier verifier = sslClient.getHostnameVerifier();
         Assertions.assertNotNull(verifier, "Hostname verifier should not be null");
-
         boolean result = verifier.verify(HOSTNAME, mockSession);
         Assertions.assertFalse(result, "Hostname verification should fail for non-matching hostname");
     }
@@ -97,12 +89,10 @@ public class TestNiFiRegistryClientSSL {
      * An empty certificate chain should result in verification failure.
      */
     @Test
-    public void testHostnameVerifierNoCerts() throws SSLPeerUnverifiedException {
+    public void testHostnameVerifierNoCerts() {
         MockSSLSession mockSession = createMockSSLSessionWithNoCertificates();
-
         HostnameVerifier verifier = sslClient.getHostnameVerifier();
         Assertions.assertNotNull(verifier, "Hostname verifier should not be null");
-
         boolean result = verifier.verify(HOSTNAME, mockSession);
         Assertions.assertFalse(result, "Hostname verification should fail when certificates are missing");
     }
@@ -112,12 +102,10 @@ public class TestNiFiRegistryClientSSL {
      * Even if peer certificates exist but are empty, verification should fail.
      */
     @Test
-    public void testHostnameVerifierEmptyCerts() throws SSLPeerUnverifiedException {
+    public void testHostnameVerifierEmptyCerts() {
         MockSSLSession mockSession = createMockSSLSessionWithEmptyCertificates();
-
         HostnameVerifier verifier = sslClient.getHostnameVerifier();
         Assertions.assertNotNull(verifier, "Hostname verifier should not be null");
-
         boolean result = verifier.verify(HOSTNAME, mockSession);
         Assertions.assertFalse(result, "Hostname verification should fail when certificate list is empty");
     }
@@ -128,18 +116,13 @@ public class TestNiFiRegistryClientSSL {
      * This is per RFC 6125 and prevents incorrect validation chains.
      */
     @Test
-    public void testHostnameVerifierSanInIntermediateCertFails() throws NoSuchAlgorithmException,
-            KeyManagementException, CertificateParsingException, SSLPeerUnverifiedException {
+    public void testHostnameVerifierSanInIntermediateCertFails() {
         MockSSLSession mockSession = createMockSSLSessionWithSanInIntermediate();
-
         HostnameVerifier verifier = sslClient.getHostnameVerifier();
         Assertions.assertNotNull(verifier, "Hostname verifier should not be null");
-
         boolean result = verifier.verify(HOSTNAME, mockSession);
         Assertions.assertFalse(result, "Hostname verification should fail when SAN is only in intermediate cert");
     }
-
-    // Helper methods for creating mock SSL sessions
 
     private static SSLContext createInitializedSSLContext() throws NoSuchAlgorithmException, KeyManagementException {
         SSLContext sslContext = SSLContext.getInstance("TLS");
@@ -150,8 +133,7 @@ public class TestNiFiRegistryClientSSL {
     /**
      * Create a mock SSL session with a certificate containing the specified SAN hostname.
      */
-    private MockSSLSession createMockSSLSessionWithCertificate(String sanHostname)
-            throws CertificateParsingException {
+    private MockSSLSession createMockSSLSessionWithCertificate(String sanHostname) {
         X509Certificate leafCert = new MockX509Certificate(sanHostname);
         return new MockSSLSession(new Certificate[] {leafCert});
     }
@@ -173,8 +155,7 @@ public class TestNiFiRegistryClientSSL {
     /**
      * Create a mock SSL session where SAN is in intermediate cert, not leaf cert.
      */
-    private MockSSLSession createMockSSLSessionWithSanInIntermediate()
-            throws CertificateParsingException {
+    private MockSSLSession createMockSSLSessionWithSanInIntermediate() {
         X509Certificate leafCert = new MockX509Certificate(null);  // No SAN in leaf
         X509Certificate intermediateCert = new MockX509Certificate("other.com");
         return new MockSSLSession(new Certificate[] {leafCert, intermediateCert});
@@ -251,12 +232,7 @@ public class TestNiFiRegistryClientSSL {
         }
 
         @Override
-        public javax.security.cert.X509Certificate[] getPeerCertificateChain() throws SSLPeerUnverifiedException {
-            return new javax.security.cert.X509Certificate[0];
-        }
-
-        @Override
-        public Principal getPeerPrincipal() throws SSLPeerUnverifiedException {
+        public Principal getPeerPrincipal() {
             return null;
         }
 
@@ -308,7 +284,7 @@ public class TestNiFiRegistryClientSSL {
         }
 
         @Override
-        public Collection<List<?>> getSubjectAlternativeNames() throws CertificateParsingException {
+        public Collection<List<?>> getSubjectAlternativeNames() {
             if (sanHostname == null) {
                 return null;
             }
@@ -366,7 +342,7 @@ public class TestNiFiRegistryClientSSL {
         }
 
         @Override
-        public byte[] getTBSCertificate() throws java.security.cert.CertificateEncodingException {
+        public byte[] getTBSCertificate() {
             return new byte[0];
         }
 
@@ -411,7 +387,7 @@ public class TestNiFiRegistryClientSSL {
         }
 
         @Override
-        public byte[] getEncoded() throws java.security.cert.CertificateEncodingException {
+        public byte[] getEncoded() {
             return new byte[0];
         }
 


### PR DESCRIPTION

## What changes were proposed in this pull request?

RANGER-5689 introduced a shared RangerDefaultHostnameVerifier (backed by Apache HttpClient's DefaultHostnameVerifier) and migrated RangerRESTClient, RangerSslHelper, RangerAdminJersey2RESTClient, and RangerUgSyncRESTClient onto it as the single implementation for TLS hostname verification across Ranger's HTTP clients.

NiFiClient and NiFiRegistryClient were not part of that migration and each maintained their own custom hostname-verifier implementation, independent of the shared one. This PR migrates both to RangerDefaultHostnameVerifier, removing the duplicated custom verifier classes so all Ranger HTTP clients now share one consistently tested implementation, reducing the maintenance burden of keeping multiple custom verifiers in sync.
## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
added a new test
