### PR TITLE
RANGER-5730: Restrict role import createNonExist flag to roles only

### DIFF
--- a/agents-common/src/main/java/org/apache/ranger/plugin/store/RoleStore.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/store/RoleStore.java
@@ -41,6 +41,25 @@ public interface RoleStore {
         return updateRole(role, createNonExistUserGroup);
     }
 
+    /**
+     * Create role with separate controls for creating missing users/groups vs nested roles.
+     * Default implementation combines the flags for stores that do not support the split.
+     */
+    default RangerRole createRole(RangerRole role, Boolean createNonExistUserGroup, Boolean createNonExistRole, Boolean isRefTableCleanupRequired) throws Exception {
+        boolean combined = Boolean.TRUE.equals(createNonExistUserGroup) || Boolean.TRUE.equals(createNonExistRole);
+
+        return createRole(role, combined, isRefTableCleanupRequired);
+    }
+
+    /**
+     * Update role with separate controls for creating missing users/groups vs nested roles.
+     * Default implementation combines the flags for stores that do not support the split.
+     */
+    default RangerRole updateRole(RangerRole role, Boolean createNonExistUserGroup, Boolean createNonExistRole, Boolean isRefTableCleanupRequired) throws Exception {
+        boolean combined = Boolean.TRUE.equals(createNonExistUserGroup) || Boolean.TRUE.equals(createNonExistRole);
+
+        return updateRole(role, combined, isRefTableCleanupRequired);
+    }
 
     void             deleteRole(String roleName) throws Exception;
 

--- a/security-admin/src/main/java/org/apache/ranger/biz/RoleDBStore.java
+++ b/security-admin/src/main/java/org/apache/ranger/biz/RoleDBStore.java
@@ -118,6 +118,11 @@ public class RoleDBStore implements RoleStore {
 
     @Override
     public RangerRole createRole(RangerRole role, Boolean createNonExistUserGroupRole, Boolean isRefTableCleanupRequired) throws Exception {
+        return createRole(role, createNonExistUserGroupRole, createNonExistUserGroupRole, isRefTableCleanupRequired);
+    }
+
+    @Override
+    public RangerRole createRole(RangerRole role, Boolean createNonExistUserGroup, Boolean createNonExistRole, Boolean isRefTableCleanupRequired) throws Exception {
         if (LOG.isDebugEnabled()) {
             LOG.debug("==> RoleDBStore.createRole()");
         }
@@ -137,7 +142,7 @@ public class RoleDBStore implements RoleStore {
             throw new Exception("Cannot create role:[" + role + "]");
         }
 
-        roleRefUpdater.createNewRoleMappingForRefTable(createdRole, createNonExistUserGroupRole, isRefTableCleanupRequired);
+        roleRefUpdater.createNewRoleMappingForRefTable(createdRole, createNonExistUserGroup, createNonExistRole, isRefTableCleanupRequired);
 
         roleService.createTransactionLog(createdRole, null, RangerBaseModelService.OPERATION_CREATE_CONTEXT);
         return createdRole;
@@ -145,6 +150,11 @@ public class RoleDBStore implements RoleStore {
 
     @Override
     public RangerRole updateRole(RangerRole role, Boolean createNonExistUserGroupRole, Boolean isRefTableCleanupRequired) throws Exception {
+        return updateRole(role, createNonExistUserGroupRole, createNonExistUserGroupRole, isRefTableCleanupRequired);
+    }
+
+    @Override
+    public RangerRole updateRole(RangerRole role, Boolean createNonExistUserGroup, Boolean createNonExistRole, Boolean isRefTableCleanupRequired) throws Exception {
         XXRole xxRole = daoMgr.getXXRole().findByRoleId(role.getId());
         if (xxRole == null) {
             throw restErrorUtil.createRESTException("role with id: " + role.getId() + " does not exist");
@@ -167,7 +177,7 @@ public class RoleDBStore implements RoleStore {
             throw new Exception("Cannot update role:[" + role + "]");
         }
 
-        roleRefUpdater.createNewRoleMappingForRefTable(updatedRole, createNonExistUserGroupRole, isRefTableCleanupRequired);
+        roleRefUpdater.createNewRoleMappingForRefTable(updatedRole, createNonExistUserGroup, createNonExistRole, isRefTableCleanupRequired);
 
         roleService.updatePolicyVersions(updatedRole.getId());
 

--- a/security-admin/src/main/java/org/apache/ranger/biz/RoleRefUpdater.java
+++ b/security-admin/src/main/java/org/apache/ranger/biz/RoleRefUpdater.java
@@ -84,7 +84,21 @@ public class RoleRefUpdater {
         return daoMgr;
     }
 
+    /**
+     * Creates role-user/group/role ref mappings.
+     * When {@code createNonExistUserGroupRole} is true, missing users, groups, and nested roles may be created
+     * (existing create/update role API behavior).
+     */
     public void createNewRoleMappingForRefTable(RangerRole rangerRole, Boolean createNonExistUserGroupRole, Boolean isRefTableCleanupRequired) {
+        createNewRoleMappingForRefTable(rangerRole, createNonExistUserGroupRole, createNonExistUserGroupRole, isRefTableCleanupRequired);
+    }
+
+    /**
+     * Creates role-user/group/role ref mappings with separate controls for creating missing users/groups vs nested roles.
+     * Role import uses createNonExistUserGroup=false and createNonExistRole=true so nested roles can be created
+     * without forcing creation of missing users or groups.
+     */
+    public void createNewRoleMappingForRefTable(RangerRole rangerRole, Boolean createNonExistUserGroup, Boolean createNonExistRole, Boolean isRefTableCleanupRequired) {
         if (rangerRole == null) {
             return;
         }
@@ -109,11 +123,13 @@ public class RoleRefUpdater {
             roleRoles.add(role.getName());
         }
 
-        if (isRefTableCleanupRequired) {
+        if (Boolean.TRUE.equals(isRefTableCleanupRequired)) {
             cleanupRefTablesForUpdate(rangerRole, roleUsers, roleGroups, roleRoles);
         }
 
-        final boolean isCreateNonExistentUGRs = createNonExistUserGroupRole && xaBizUtil.checkAdminAccess();
+        final boolean adminAccess              = xaBizUtil.checkAdminAccess();
+        final boolean isCreateNonExistentUGs   = Boolean.TRUE.equals(createNonExistUserGroup) && adminAccess;
+        final boolean isCreateNonExistentRoles = Boolean.TRUE.equals(createNonExistRole) && adminAccess;
 
         if (CollectionUtils.isNotEmpty(roleUsers)) {
             LOG.debug("New user entries to be inserted into x_role_ref_user for role ID {}: {}", roleId, roleUsers);
@@ -135,7 +151,7 @@ public class RoleRefUpdater {
                     if (userRef != null) {
                         xxRoleRefUsers.add(userRef);
                     }
-                } else if (isCreateNonExistentUGRs) {
+                } else if (isCreateNonExistentUGs) {
                     rangerTransactionSynchronizationAdapter.executeOnTransactionCommit(associator);
                 } else {
                     throw restErrorUtil.createRESTException("user with name: " + userName + " does not exist ", MessageEnums.INVALID_INPUT_DATA);
@@ -165,7 +181,7 @@ public class RoleRefUpdater {
                     if (groupRef != null) {
                         xxRoleRefGroups.add(groupRef);
                     }
-                } else if (isCreateNonExistentUGRs) {
+                } else if (isCreateNonExistentUGs) {
                     rangerTransactionSynchronizationAdapter.executeOnTransactionCommit(associator);
                 } else {
                     throw restErrorUtil.createRESTException("Group with name: " + groupName + " does not exist ", MessageEnums.INVALID_INPUT_DATA);
@@ -195,7 +211,7 @@ public class RoleRefUpdater {
                     if (roleRef != null) {
                         xxRoleRefRoles.add(roleRef);
                     }
-                } else if (isCreateNonExistentUGRs) {
+                } else if (isCreateNonExistentRoles) {
                     rangerTransactionSynchronizationAdapter.executeOnTransactionCommit(associator);
                 } else {
                     throw restErrorUtil.createRESTException("Role with name: " + subRoleName + " does not exist ", MessageEnums.INVALID_INPUT_DATA);

--- a/security-admin/src/main/java/org/apache/ranger/rest/RoleREST.java
+++ b/security-admin/src/main/java/org/apache/ranger/rest/RoleREST.java
@@ -482,6 +482,12 @@ public class RoleREST {
 			if (updateIfExists == null) {
 				updateIfExists = false;
 			}
+
+			// For role import, createNonExistUserGroupRole only creates missing nested roles.
+			// Missing users/groups are never created during import (RANGER-5730).
+			final Boolean createNonExistUserGroup = Boolean.FALSE;
+			final Boolean createNonExistRole      = Boolean.TRUE.equals(createNonExistUserGroupRole);
+
 			List<String> roleNameList = new ArrayList<String>();
 
 			roleNameList = getRoleNameList(request, roleNameList);
@@ -527,7 +533,7 @@ public class RoleREST {
 												}
 											}
 											else {
-												roleStore.updateRole(roleInJson, createNonExistUserGroupRole, true);
+												roleStore.updateRole(roleInJson, createNonExistUserGroup, createNonExistRole, true);
 												totalRoleUpdate++;
 											}
 										} catch (WebApplicationException excp) {
@@ -546,7 +552,7 @@ public class RoleREST {
 									ret.setStatusCode(RESTResponse.STATUS_SUCCESS);
 								} else if (!roleNameList.contains(roleNameInJson) && (!roleNameInJson.isEmpty())) {
 									try {
-										roleStore.createRole(roleInJson, createNonExistUserGroupRole, false);
+										roleStore.createRole(roleInJson, createNonExistUserGroup, createNonExistRole, false);
 									} catch (WebApplicationException excp) {
 										throw excp;
 									} catch (Throwable excp) {

--- a/security-admin/src/test/java/org/apache/ranger/biz/TestRoleDBStore.java
+++ b/security-admin/src/test/java/org/apache/ranger/biz/TestRoleDBStore.java
@@ -440,7 +440,7 @@ public class TestRoleDBStore {
         Mockito.when(roleService.create(rangerRole)).thenReturn(rangerRole);
         Mockito.when(roleService.read(xxRole.getId())).thenReturn(rangerRole);
         Mockito.doNothing().when(transactionSynchronizationAdapter).executeOnTransactionCommit(Mockito.any());
-        Mockito.doNothing().when(roleRefUpdater).createNewRoleMappingForRefTable(Mockito.any(), Mockito.anyBoolean(), Mockito.anyBoolean());
+        Mockito.doNothing().when(roleRefUpdater).createNewRoleMappingForRefTable(Mockito.any(), Mockito.anyBoolean(), Mockito.anyBoolean(), Mockito.anyBoolean());
         Mockito.doNothing().when(roleService).createTransactionLog( Mockito.any(), Mockito.any(), Mockito.anyInt());
 
         roleDBStore.createRole(rangerRole, true, false);
@@ -469,7 +469,7 @@ public class TestRoleDBStore {
         Mockito.when(xxRoleDao.findByRoleId(rangerRole.getId())).thenReturn(xxRole);
         Mockito.doNothing().when(transactionSynchronizationAdapter).executeOnTransactionCommit(Mockito.any());
         Mockito.when(roleService.update(rangerRole)).thenReturn(rangerRole);
-        Mockito.doNothing().when(roleRefUpdater).createNewRoleMappingForRefTable(Mockito.any(), Mockito.anyBoolean(), Mockito.anyBoolean());
+        Mockito.doNothing().when(roleRefUpdater).createNewRoleMappingForRefTable(Mockito.any(), Mockito.anyBoolean(), Mockito.anyBoolean(), Mockito.anyBoolean());
         Mockito.doNothing().when(roleService).updatePolicyVersions(rangerRole.getId());
         Mockito.doNothing().when(roleService).createTransactionLog( Mockito.any(),  Mockito.any(), Mockito.anyInt());
 

--- a/security-admin/src/test/java/org/apache/ranger/biz/TestRoleRefUpdater.java
+++ b/security-admin/src/test/java/org/apache/ranger/biz/TestRoleRefUpdater.java
@@ -196,6 +196,55 @@ public class TestRoleRefUpdater {
     }
 
     @Test
+    public void test05a_createNewRoleMapping_createRoleOnlyDoesNotCreateMissingUser() throws Exception {
+        RoleRefUpdater updater = new RoleRefUpdater();
+        RangerDaoManager dao = mock(RangerDaoManager.class);
+        XXUserDao xUserDao = mock(XXUserDao.class);
+        RESTErrorUtil rest = mock(RESTErrorUtil.class);
+        RangerBizUtil biz = mock(RangerBizUtil.class);
+
+        setField(updater, RoleRefUpdater.class, "daoMgr", dao);
+        setField(updater, RoleRefUpdater.class, "restErrorUtil", rest);
+        setField(updater, RoleRefUpdater.class, "xaBizUtil", biz);
+
+        when(dao.getXXUser()).thenReturn(xUserDao);
+        when(xUserDao.getIdsByUserNames(anySet())).thenReturn(Collections.emptyMap());
+        when(biz.checkAdminAccess()).thenReturn(true);
+
+        RuntimeException expected = new RuntimeException("missing user");
+        when(rest.createRESTException(anyString(), any())).thenThrow(expected);
+
+        // Missing user with createNonExistUserGroup=false, createNonExistRole=true -> must fail (no user create)
+        RangerRole roleWithMissingUser = buildRole(9L, Collections.singletonList("missingUser"), Collections.emptyList(),
+                Collections.emptyList());
+        Assertions.assertThrows(RuntimeException.class,
+                () -> updater.createNewRoleMappingForRefTable(roleWithMissingUser, false, true, false));
+    }
+
+    @Test
+    public void test05b_createNewRoleMapping_createRoleOnlyCreatesMissingNestedRole() throws Exception {
+        RoleRefUpdater updater = new RoleRefUpdater();
+        RangerDaoManager dao = mock(RangerDaoManager.class);
+        XXRoleDao xRoleDao = mock(XXRoleDao.class);
+        RangerTransactionSynchronizationAdapter adapter = mock(RangerTransactionSynchronizationAdapter.class);
+        RangerBizUtil biz = mock(RangerBizUtil.class);
+
+        setField(updater, RoleRefUpdater.class, "daoMgr", dao);
+        setField(updater, RoleRefUpdater.class, "rangerTransactionSynchronizationAdapter", adapter);
+        setField(updater, RoleRefUpdater.class, "xaBizUtil", biz);
+
+        when(dao.getXXRole()).thenReturn(xRoleDao);
+        when(xRoleDao.getIdsByRoleNames(anySet())).thenReturn(Collections.emptyMap());
+        when(biz.checkAdminAccess()).thenReturn(true);
+
+        // Missing nested role with createNonExistUserGroup=false, createNonExistRole=true -> schedule role create only
+        RangerRole roleWithMissingNestedRole = buildRole(9L, Collections.emptyList(), Collections.emptyList(),
+                Collections.singletonList("missingRole"));
+        updater.createNewRoleMappingForRefTable(roleWithMissingNestedRole, false, true, false);
+        verify(adapter, times(1)).executeOnTransactionCommit(any(Runnable.class));
+    }
+
+    @Test
     public void test04_cleanupRefTablesForUpdate_selectivePrincipalCleanup() throws Exception {
         RoleRefUpdater updater = new RoleRefUpdater();
         RangerDaoManager dao = mock(RangerDaoManager.class);

--- a/security-admin/src/test/java/org/apache/ranger/rest/TestRoleREST.java
+++ b/security-admin/src/test/java/org/apache/ranger/rest/TestRoleREST.java
@@ -1147,7 +1147,7 @@ public class TestRoleREST {
 
 		Mockito.when(searchUtil.getSearchFilter(request, roleService.sortFields)).thenReturn(filter);
 		Mockito.when(roleStore.getRoleNames(Mockito.any(SearchFilter.class))).thenReturn(roleList);
-		Mockito.when(roleStore.createRole(Mockito.any(RangerRole.class), eq(createNonExistUserGroupRole), eq(false)))
+		Mockito.when(roleStore.createRole(Mockito.any(RangerRole.class), eq(false), eq(createNonExistUserGroupRole), eq(false)))
 				.thenReturn(rangerRole);
 
 		RESTResponse resp = roleRest.importRolesFromFile(request, uploadedInputStream, fileDetail, updateIfExists,
@@ -1177,7 +1177,7 @@ public class TestRoleREST {
 
 		Mockito.when(searchUtil.getSearchFilter(request, roleService.sortFields)).thenReturn(filter);
 		Mockito.when(roleStore.getRoleNames(Mockito.any(SearchFilter.class))).thenReturn(roleList);
-		Mockito.when(roleStore.createRole(Mockito.any(RangerRole.class), eq(createNonExistUserGroupRole), eq(false)))
+		Mockito.when(roleStore.createRole(Mockito.any(RangerRole.class), eq(false), eq(createNonExistUserGroupRole), eq(false)))
 				.thenReturn(rangerRole);
 
 		RESTResponse resp = roleRest.importRolesFromFile(request, uploadedInputStream, fileDetail, updateIfExists,
@@ -1185,6 +1185,7 @@ public class TestRoleREST {
 		Assert.assertNotNull(resp);
 		Assert.assertEquals(resp.getStatusCode(), RESTResponse.STATUS_SUCCESS);
 		Assert.assertEquals(resp.getMsgDesc(), "Total Role Created = 6 , Total Role Unchanged = 1");
+		Mockito.verify(roleStore, Mockito.atLeastOnce()).createRole(Mockito.any(RangerRole.class), eq(false), eq(true), eq(false));
 	}
 
 	// import role with updateIfExists=true and createNonExistUserGroupRole=true
@@ -1208,9 +1209,9 @@ public class TestRoleREST {
 		Mockito.when(searchUtil.getSearchFilter(request, roleService.sortFields)).thenReturn(filter);
 		Mockito.when(roleStore.getRoleNames(Mockito.any(SearchFilter.class))).thenReturn(roleList);
 		Mockito.when(roleStore.getRole(Mockito.anyString())).thenReturn(rangerRole);
-		Mockito.when(roleStore.createRole(Mockito.any(RangerRole.class), eq(createNonExistUserGroupRole), eq(false)))
+		Mockito.when(roleStore.createRole(Mockito.any(RangerRole.class), eq(false), eq(createNonExistUserGroupRole), eq(false)))
 				.thenReturn(rangerRole);
-		Mockito.when(roleStore.updateRole(Mockito.any(RangerRole.class), eq(createNonExistUserGroupRole), eq(true)))
+		Mockito.when(roleStore.updateRole(Mockito.any(RangerRole.class), eq(false), eq(createNonExistUserGroupRole), eq(true)))
 				.thenReturn(rangerRole);
 
 		RESTResponse resp = roleRest.importRolesFromFile(request, uploadedInputStream, fileDetail, updateIfExists,
@@ -1219,6 +1220,8 @@ public class TestRoleREST {
 		Assert.assertEquals(resp.getStatusCode(), RESTResponse.STATUS_SUCCESS);
 		Assert.assertEquals(resp.getMsgDesc(),
 				"Total Role Created = 6 , Total Role Updated = 1 , Total Role Unchanged = 0");
+		Mockito.verify(roleStore, Mockito.atLeastOnce()).createRole(Mockito.any(RangerRole.class), eq(false), eq(true), eq(false));
+		Mockito.verify(roleStore, Mockito.atLeastOnce()).updateRole(Mockito.any(RangerRole.class), eq(false), eq(true), eq(true));
 	}
 
 	// import role throws exceptions


### PR DESCRIPTION
Cherry-pick of 8dba041 (#1142) from master.

https://issues.apache.org/jira/browse/RANGER-5730

What changes were proposed in this pull request?
[RANGER-5730](https://issues.apache.org/jira/browse/RANGER-5730): Restrict createNonExistUserGroupRole during role import so it creates missing nested roles only, and does not create missing users or groups.

Previously, importRolesFromFile with createNonExistUserGroupRole=true treated users, groups, and nested roles the same way. That forced creation of missing users/groups during role import, which is undesirable for large synced environments.

This change:

Splits create-missing behavior in RoleRefUpdater into separate controls for users/groups vs nested roles
Updates RoleREST.importRolesFromFile so createNonExistUserGroupRole=true means create missing nested roles only (createNonExistUserGroup=false)
Leaves existing create/update role API behavior (createNonExistUserGroup) unchanged

How was this patch tested?
Unit tests:

TestRoleRefUpdater — verifies missing users are not created when only role creation is enabled, and missing nested roles are scheduled for creation
TestRoleREST — verifies import passes (createNonExistUserGroup=false, createNonExistRole=true) when the import flag is true
TestRoleDBStore — existing create/update role coverage
Focused run result: TestRoleRefUpdater, TestRoleDBStore, and TestRoleREST — 102 tests passed (0 failures)
