### PR TITLE
RANGER-5748: Role resource type in Ozone repo is missing after upgrade

### DIFF
--- a/dev-support/checkstyle-suppressions.xml
+++ b/dev-support/checkstyle-suppressions.xml
@@ -92,4 +92,5 @@
   <suppress files="PatchTagModulePermission_J10005" checks="TypeName"/>
   <suppress files="PatchForAtlasPolicyUpdateForEntityRead_J10064" checks="TypeName"/>
   <suppress files="PatchForOzoneServiceDefPolicyConditionUpdate_J10065" checks="TypeName"/>
+  <suppress files="PatchForOzoneServiceDefAssumeRoleUpdate_J10066" checks="TypeName"/>
 </suppressions>

--- a/dev-support/checkstyle-suppressions.xml
+++ b/dev-support/checkstyle-suppressions.xml
@@ -91,6 +91,6 @@
   <suppress files="PatchSetAccessTypeCategory_J10061" checks="TypeName"/>
   <suppress files="PatchTagModulePermission_J10005" checks="TypeName"/>
   <suppress files="PatchForAtlasPolicyUpdateForEntityRead_J10064" checks="TypeName"/>
-  <suppress files="PatchForOzoneServiceDefPolicyConditionUpdate_J10065" checks="TypeName"/>
-  <suppress files="PatchForOzoneServiceDefAssumeRoleUpdate_J10066" checks="TypeName"/>
+  <suppress files="PatchForOzoneServiceDefPolicyConditionUpdate_J10066" checks="TypeName"/>
+  <suppress files="PatchForOzoneServiceDefAssumeRoleUpdate_J10065" checks="TypeName"/>
 </suppressions>

--- a/security-admin/db/mysql/optimized/current/ranger_core_db_mysql.sql
+++ b/security-admin/db/mysql/optimized/current/ranger_core_db_mysql.sql
@@ -2005,4 +2005,6 @@ INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active
 INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('J10062',UTC_TIMESTAMP(),'Ranger 3.0.0',UTC_TIMESTAMP(),'localhost','Y');
 INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('J10063',UTC_TIMESTAMP(),'Ranger 3.0.0',UTC_TIMESTAMP(),'localhost','Y');
 INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('J10064',UTC_TIMESTAMP(),'Ranger 3.0.0',UTC_TIMESTAMP(),'localhost','Y');
+INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('J10065',UTC_TIMESTAMP(),'Ranger 3.0.0',UTC_TIMESTAMP(),'localhost','Y');
+INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('J10066',UTC_TIMESTAMP(),'Ranger 3.0.0',UTC_TIMESTAMP(),'localhost','Y');
 INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('JAVA_PATCHES',UTC_TIMESTAMP(),'Ranger 1.0.0',UTC_TIMESTAMP(),'localhost','Y');

--- a/security-admin/db/oracle/optimized/current/ranger_core_db_oracle.sql
+++ b/security-admin/db/oracle/optimized/current/ranger_core_db_oracle.sql
@@ -2228,5 +2228,7 @@ INSERT INTO x_db_version_h (id,version,inst_at,inst_by,updated_at,updated_by,act
 INSERT INTO x_db_version_h (id,version,inst_at,inst_by,updated_at,updated_by,active) VALUES (X_DB_VERSION_H_SEQ.nextval,'J10062',sys_extract_utc(systimestamp),'Ranger 3.0.0',sys_extract_utc(systimestamp),'localhost','Y');
 INSERT INTO x_db_version_h (id,version,inst_at,inst_by,updated_at,updated_by,active) VALUES (X_DB_VERSION_H_SEQ.nextval,'J10063',sys_extract_utc(systimestamp),'Ranger 3.0.0',sys_extract_utc(systimestamp),'localhost','Y');
 INSERT INTO x_db_version_h (id,version,inst_at,inst_by,updated_at,updated_by,active) VALUES (X_DB_VERSION_H_SEQ.nextval,'J10064',sys_extract_utc(systimestamp),'Ranger 3.0.0',sys_extract_utc(systimestamp),'localhost','Y');
+INSERT INTO x_db_version_h (id,version,inst_at,inst_by,updated_at,updated_by,active) VALUES (X_DB_VERSION_H_SEQ.nextval,'J10065',sys_extract_utc(systimestamp),'Ranger 3.0.0',sys_extract_utc(systimestamp),'localhost','Y');
+INSERT INTO x_db_version_h (id,version,inst_at,inst_by,updated_at,updated_by,active) VALUES (X_DB_VERSION_H_SEQ.nextval,'J10066',sys_extract_utc(systimestamp),'Ranger 3.0.0',sys_extract_utc(systimestamp),'localhost','Y');
 INSERT INTO x_db_version_h (id,version,inst_at,inst_by,updated_at,updated_by,active) VALUES (X_DB_VERSION_H_SEQ.nextval,'JAVA_PATCHES',sys_extract_utc(systimestamp),'Ranger 1.0.0',sys_extract_utc(systimestamp),'localhost','Y');
 commit;

--- a/security-admin/db/postgres/optimized/current/ranger_core_db_postgres.sql
+++ b/security-admin/db/postgres/optimized/current/ranger_core_db_postgres.sql
@@ -2161,6 +2161,8 @@ INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active
 INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('J10062',current_timestamp,'Ranger 3.0.0',current_timestamp,'localhost','Y');
 INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('J10063',current_timestamp,'Ranger 3.0.0',current_timestamp,'localhost','Y');
 INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('J10064',current_timestamp,'Ranger 3.0.0',current_timestamp,'localhost','Y');
+INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('J10065',current_timestamp,'Ranger 3.0.0',current_timestamp,'localhost','Y');
+INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('J10066',current_timestamp,'Ranger 3.0.0',current_timestamp,'localhost','Y');
 INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('JAVA_PATCHES',current_timestamp,'Ranger 1.0.0',current_timestamp,'localhost','Y');
 
 DROP VIEW IF EXISTS vx_principal;

--- a/security-admin/db/sqlanywhere/optimized/current/ranger_core_db_sqlanywhere.sql
+++ b/security-admin/db/sqlanywhere/optimized/current/ranger_core_db_sqlanywhere.sql
@@ -2390,6 +2390,10 @@ INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active
 GO
 INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('J10064',CURRENT_TIMESTAMP,'Ranger 3.0.0',CURRENT_TIMESTAMP,'localhost','Y');
 GO
+INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('J10065',CURRENT_TIMESTAMP,'Ranger 3.0.0',CURRENT_TIMESTAMP,'localhost','Y');
+GO
+INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('J10066',CURRENT_TIMESTAMP,'Ranger 3.0.0',CURRENT_TIMESTAMP,'localhost','Y');
+GO
 INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('JAVA_PATCHES',CURRENT_TIMESTAMP,'Ranger 1.0.0',CURRENT_TIMESTAMP,'localhost','Y');
 GO
 exit

--- a/security-admin/db/sqlserver/optimized/current/ranger_core_db_sqlserver.sql
+++ b/security-admin/db/sqlserver/optimized/current/ranger_core_db_sqlserver.sql
@@ -4594,5 +4594,7 @@ INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active
 INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('J10062',CURRENT_TIMESTAMP,'Ranger 3.0.0',CURRENT_TIMESTAMP,'localhost','Y');
 INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('J10063',CURRENT_TIMESTAMP,'Ranger 3.0.0',CURRENT_TIMESTAMP,'localhost','Y');
 INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('J10064',CURRENT_TIMESTAMP,'Ranger 3.0.0',CURRENT_TIMESTAMP,'localhost','Y');
+INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('J10065',CURRENT_TIMESTAMP,'Ranger 3.0.0',CURRENT_TIMESTAMP,'localhost','Y');
+INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('J10066',CURRENT_TIMESTAMP,'Ranger 3.0.0',CURRENT_TIMESTAMP,'localhost','Y');
 INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('JAVA_PATCHES',CURRENT_TIMESTAMP,'Ranger 1.0.0',CURRENT_TIMESTAMP,'localhost','Y');
 GO

--- a/security-admin/src/main/java/org/apache/ranger/patch/PatchForOzoneServiceDefAssumeRoleUpdate_J10065.java
+++ b/security-admin/src/main/java/org/apache/ranger/patch/PatchForOzoneServiceDefAssumeRoleUpdate_J10065.java
@@ -41,8 +41,8 @@ import java.util.List;
 import java.util.Map;
 
 @Component
-public class PatchForOzoneServiceDefAssumeRoleUpdate_J10066 extends BaseLoader {
-    private static final Logger logger = LoggerFactory.getLogger(PatchForOzoneServiceDefAssumeRoleUpdate_J10066.class);
+public class PatchForOzoneServiceDefAssumeRoleUpdate_J10065 extends BaseLoader {
+    private static final Logger logger = LoggerFactory.getLogger(PatchForOzoneServiceDefAssumeRoleUpdate_J10065.class);
 
     private static final String       OZONE_RESOURCE_ROLE                             = "role";
     private static final String       ACCESS_TYPE_ASSUME_ROLE                         = "assume_role";
@@ -64,7 +64,7 @@ public class PatchForOzoneServiceDefAssumeRoleUpdate_J10066 extends BaseLoader {
         logger.info("main()");
 
         try {
-            PatchForOzoneServiceDefAssumeRoleUpdate_J10066 loader = (PatchForOzoneServiceDefAssumeRoleUpdate_J10066) CLIUtil.getBean(PatchForOzoneServiceDefAssumeRoleUpdate_J10066.class);
+            PatchForOzoneServiceDefAssumeRoleUpdate_J10065 loader = (PatchForOzoneServiceDefAssumeRoleUpdate_J10065) CLIUtil.getBean(PatchForOzoneServiceDefAssumeRoleUpdate_J10065.class);
 
             loader.init();
 
@@ -89,7 +89,7 @@ public class PatchForOzoneServiceDefAssumeRoleUpdate_J10066 extends BaseLoader {
 
     @Override
     public void printStats() {
-        logger.info("PatchForOzoneServiceDefAssumeRoleUpdate_J10066 data ");
+        logger.info("PatchForOzoneServiceDefAssumeRoleUpdate_J10065 data ");
     }
 
     @Override
@@ -141,7 +141,7 @@ public class PatchForOzoneServiceDefAssumeRoleUpdate_J10066 extends BaseLoader {
     }
 
     private boolean updateOzoneServiceDef() throws Exception {
-        logger.info("==> PatchForOzoneServiceDefAssumeRoleUpdate_J10066.updateOzoneServiceDef()");
+        logger.info("==> PatchForOzoneServiceDefAssumeRoleUpdate_J10065.updateOzoneServiceDef()");
 
         RangerServiceDef embeddedOzoneServiceDef = EmbeddedServiceDefsUtil.instance().getEmbeddedServiceDef(EmbeddedServiceDefsUtil.EMBEDDED_SERVICEDEF_OZONE_NAME);
 
@@ -220,7 +220,7 @@ public class PatchForOzoneServiceDefAssumeRoleUpdate_J10066 extends BaseLoader {
             }
         }
 
-        logger.info("<== PatchForOzoneServiceDefAssumeRoleUpdate_J10066.updateOzoneServiceDef()");
+        logger.info("<== PatchForOzoneServiceDefAssumeRoleUpdate_J10065.updateOzoneServiceDef()");
 
         return true;
     }

--- a/security-admin/src/main/java/org/apache/ranger/patch/PatchForOzoneServiceDefAssumeRoleUpdate_J10066.java
+++ b/security-admin/src/main/java/org/apache/ranger/patch/PatchForOzoneServiceDefAssumeRoleUpdate_J10066.java
@@ -1,0 +1,420 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ranger.patch;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.ranger.biz.ServiceDBStore;
+import org.apache.ranger.common.JSONUtil;
+import org.apache.ranger.common.RangerValidatorFactory;
+import org.apache.ranger.db.RangerDaoManager;
+import org.apache.ranger.entity.XXServiceDef;
+import org.apache.ranger.plugin.model.RangerServiceDef;
+import org.apache.ranger.plugin.model.validation.RangerServiceDefValidator;
+import org.apache.ranger.plugin.model.validation.RangerValidator;
+import org.apache.ranger.plugin.store.EmbeddedServiceDefsUtil;
+import org.apache.ranger.util.CLIUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class PatchForOzoneServiceDefAssumeRoleUpdate_J10066 extends BaseLoader {
+    private static final Logger logger = LoggerFactory.getLogger(PatchForOzoneServiceDefAssumeRoleUpdate_J10066.class);
+
+    private static final String       OZONE_RESOURCE_ROLE                             = "role";
+    private static final String       ACCESS_TYPE_ASSUME_ROLE                         = "assume_role";
+    private static final List<String> OZONE_RESOURCES_WITH_ACCESS_TYPE_RESTRICTIONS = Arrays.asList("volume", "bucket", "key");
+
+    @Autowired
+    RangerDaoManager daoMgr;
+
+    @Autowired
+    ServiceDBStore svcDBStore;
+
+    @Autowired
+    JSONUtil jsonUtil;
+
+    @Autowired
+    RangerValidatorFactory validatorFactory;
+
+    public static void main(String[] args) {
+        logger.info("main()");
+
+        try {
+            PatchForOzoneServiceDefAssumeRoleUpdate_J10066 loader = (PatchForOzoneServiceDefAssumeRoleUpdate_J10066) CLIUtil.getBean(PatchForOzoneServiceDefAssumeRoleUpdate_J10066.class);
+
+            loader.init();
+
+            while (loader.isMoreToProcess()) {
+                loader.load();
+            }
+
+            logger.info("Load complete. Exiting.");
+
+            System.exit(0);
+        } catch (Exception e) {
+            logger.error("Error loading", e);
+
+            System.exit(1);
+        }
+    }
+
+    @Override
+    public void init() throws Exception {
+        // Do Nothing
+    }
+
+    @Override
+    public void printStats() {
+        logger.info("PatchForOzoneServiceDefAssumeRoleUpdate_J10066 data ");
+    }
+
+    @Override
+    public void execLoad() {
+        try {
+            if (!updateOzoneServiceDef()) {
+                logger.error("Failed to apply the patch.");
+
+                System.exit(1);
+            }
+        } catch (Exception e) {
+            logger.error("Error while updateOzoneServiceDef()data.", e);
+
+            System.exit(1);
+        }
+    }
+
+    protected Map<String, String> jsonStringToMap(String jsonStr) {
+        Map<String, String> ret = null;
+
+        if (!StringUtils.isEmpty(jsonStr)) {
+            try {
+                ret = jsonUtil.jsonToMap(jsonStr);
+            } catch (Exception ex) {
+                // fallback to earlier format: "name1=value1;name2=value2"
+                for (String optionString : jsonStr.split(";")) {
+                    if (StringUtils.isEmpty(optionString)) {
+                        continue;
+                    }
+
+                    String[] nvArr = optionString.split("=");
+                    String   name  = (nvArr != null && nvArr.length > 0) ? nvArr[0].trim() : null;
+                    String   value = (nvArr != null && nvArr.length > 1) ? nvArr[1].trim() : null;
+
+                    if (StringUtils.isEmpty(name)) {
+                        continue;
+                    }
+
+                    if (ret == null) {
+                        ret = new HashMap<>();
+                    }
+
+                    ret.put(name, value);
+                }
+            }
+        }
+
+        return ret;
+    }
+
+    private boolean updateOzoneServiceDef() throws Exception {
+        logger.info("==> PatchForOzoneServiceDefAssumeRoleUpdate_J10066.updateOzoneServiceDef()");
+
+        RangerServiceDef embeddedOzoneServiceDef = EmbeddedServiceDefsUtil.instance().getEmbeddedServiceDef(EmbeddedServiceDefsUtil.EMBEDDED_SERVICEDEF_OZONE_NAME);
+
+        if (embeddedOzoneServiceDef == null) {
+            logger.error("The embedded Ozone service-definition does not exist.");
+
+            return false;
+        }
+
+        XXServiceDef xXServiceDefObj = daoMgr.getXXServiceDef().findByName(EmbeddedServiceDefsUtil.EMBEDDED_SERVICEDEF_OZONE_NAME);
+
+        if (xXServiceDefObj == null) {
+            logger.error("Ozone service-definition does not exist in the Ranger DAO.");
+
+            return false;
+        }
+
+        Map<String, String> serviceDefOptionsPreUpdate = jsonStringToMap(xXServiceDefObj.getDefOptions());
+
+        RangerServiceDef dbOzoneServiceDef = svcDBStore.getServiceDefByName(EmbeddedServiceDefsUtil.EMBEDDED_SERVICEDEF_OZONE_NAME);
+
+        if (dbOzoneServiceDef == null) {
+            logger.error("Ozone service-definition does not exist in the db store.");
+
+            return false;
+        }
+
+        List<RangerServiceDef.RangerPolicyConditionDef> policyConditionsSnapshot = copyPolicyConditions(dbOzoneServiceDef.getPolicyConditions());
+
+        detachServiceDefCollections(dbOzoneServiceDef);
+
+        if (!requiresServiceDefUpdate(dbOzoneServiceDef)) {
+            logger.info("Ozone service-definition already has role resource, assume_role access type and resource access-type restrictions. No patching is needed.");
+
+            return true;
+        }
+
+        applyServiceDefUpdates(dbOzoneServiceDef, embeddedOzoneServiceDef);
+
+        dbOzoneServiceDef.setPolicyConditions(copyPolicyConditions(policyConditionsSnapshot));
+
+        RangerServiceDefValidator validator = validatorFactory.getServiceDefValidator(svcDBStore);
+
+        validator.validate(dbOzoneServiceDef, RangerValidator.Action.UPDATE);
+
+        RangerServiceDef ret = svcDBStore.updateServiceDef(dbOzoneServiceDef);
+
+        if (ret == null) {
+            throw new RuntimeException("Error while updating " + EmbeddedServiceDefsUtil.EMBEDDED_SERVICEDEF_OZONE_NAME + " service-def");
+        }
+
+        xXServiceDefObj = daoMgr.getXXServiceDef().findByName(EmbeddedServiceDefsUtil.EMBEDDED_SERVICEDEF_OZONE_NAME);
+
+        if (xXServiceDefObj == null) {
+            logger.error("Ozone service-definition does not exist in the Ranger DAO.");
+
+            return false;
+        }
+
+        String              jsonStrPostUpdate           = xXServiceDefObj.getDefOptions();
+        Map<String, String> serviceDefOptionsPostUpdate = jsonStringToMap(jsonStrPostUpdate);
+
+        if (serviceDefOptionsPostUpdate != null && serviceDefOptionsPostUpdate.containsKey(RangerServiceDef.OPTION_ENABLE_DENY_AND_EXCEPTIONS_IN_POLICIES)) {
+            if (serviceDefOptionsPreUpdate == null || !serviceDefOptionsPreUpdate.containsKey(RangerServiceDef.OPTION_ENABLE_DENY_AND_EXCEPTIONS_IN_POLICIES)) {
+                String preUpdateValue = serviceDefOptionsPreUpdate == null ? null : serviceDefOptionsPreUpdate.get(RangerServiceDef.OPTION_ENABLE_DENY_AND_EXCEPTIONS_IN_POLICIES);
+
+                if (preUpdateValue == null) {
+                    serviceDefOptionsPostUpdate.remove(RangerServiceDef.OPTION_ENABLE_DENY_AND_EXCEPTIONS_IN_POLICIES);
+                } else {
+                    serviceDefOptionsPostUpdate.put(RangerServiceDef.OPTION_ENABLE_DENY_AND_EXCEPTIONS_IN_POLICIES, preUpdateValue);
+                }
+
+                xXServiceDefObj.setDefOptions(mapToJsonString(serviceDefOptionsPostUpdate));
+
+                daoMgr.getXXServiceDef().update(xXServiceDefObj);
+            }
+        }
+
+        logger.info("<== PatchForOzoneServiceDefAssumeRoleUpdate_J10066.updateOzoneServiceDef()");
+
+        return true;
+    }
+
+    private void applyServiceDefUpdates(RangerServiceDef dbOzoneServiceDef, RangerServiceDef embeddedOzoneServiceDef) {
+        List<RangerServiceDef.RangerResourceDef> dbResources = dbOzoneServiceDef.getResources();
+
+        if (dbResources == null) {
+            dbResources = new ArrayList<>();
+            dbOzoneServiceDef.setResources(dbResources);
+        }
+
+        if (!isRoleResourcePresent(dbResources)) {
+            RangerServiceDef.RangerResourceDef embeddedRoleResource = findResourceDef(embeddedOzoneServiceDef.getResources(), OZONE_RESOURCE_ROLE);
+
+            if (embeddedRoleResource != null) {
+                dbResources.add(new RangerServiceDef.RangerResourceDef(embeddedRoleResource));
+
+                logger.info("Added role resource to Ozone service-definition.");
+            }
+        }
+
+        for (String resourceName : OZONE_RESOURCES_WITH_ACCESS_TYPE_RESTRICTIONS) {
+            RangerServiceDef.RangerResourceDef dbResource       = findResourceDef(dbResources, resourceName);
+            RangerServiceDef.RangerResourceDef embeddedResource = findResourceDef(embeddedOzoneServiceDef.getResources(), resourceName);
+
+            if (dbResource != null && embeddedResource != null && CollectionUtils.isEmpty(dbResource.getAccessTypeRestrictions())) {
+                dbResource.setAccessTypeRestrictions(embeddedResource.getAccessTypeRestrictions());
+
+                logger.info("Updated access-type restrictions on {} resource in Ozone service-definition.", resourceName);
+            }
+        }
+
+        if (!isAssumeRoleAccessTypePresent(dbOzoneServiceDef.getAccessTypes())) {
+            RangerServiceDef.RangerAccessTypeDef embeddedAssumeRoleAccessType = findAccessTypeDef(embeddedOzoneServiceDef.getAccessTypes(), ACCESS_TYPE_ASSUME_ROLE);
+
+            if (embeddedAssumeRoleAccessType != null) {
+                List<RangerServiceDef.RangerAccessTypeDef> updatedAccessTypes = new ArrayList<>();
+
+                if (CollectionUtils.isNotEmpty(dbOzoneServiceDef.getAccessTypes())) {
+                    for (RangerServiceDef.RangerAccessTypeDef accessType : dbOzoneServiceDef.getAccessTypes()) {
+                        updatedAccessTypes.add(new RangerServiceDef.RangerAccessTypeDef(accessType));
+                    }
+                }
+
+                updatedAccessTypes.add(new RangerServiceDef.RangerAccessTypeDef(embeddedAssumeRoleAccessType));
+
+                dbOzoneServiceDef.setAccessTypes(updatedAccessTypes);
+
+                logger.info("Added assume_role access type to Ozone service-definition.");
+            }
+        }
+    }
+
+    private void detachServiceDefCollections(RangerServiceDef serviceDef) {
+        List<RangerServiceDef.RangerResourceDef> resources = serviceDef.getResources();
+
+        if (CollectionUtils.isNotEmpty(resources)) {
+            List<RangerServiceDef.RangerResourceDef> copiedResources = new ArrayList<>(resources.size());
+
+            for (RangerServiceDef.RangerResourceDef resource : resources) {
+                copiedResources.add(new RangerServiceDef.RangerResourceDef(resource));
+            }
+
+            serviceDef.setResources(copiedResources);
+        }
+
+        List<RangerServiceDef.RangerAccessTypeDef> accessTypes = serviceDef.getAccessTypes();
+
+        if (CollectionUtils.isNotEmpty(accessTypes)) {
+            List<RangerServiceDef.RangerAccessTypeDef> copiedAccessTypes = new ArrayList<>(accessTypes.size());
+
+            for (RangerServiceDef.RangerAccessTypeDef accessType : accessTypes) {
+                copiedAccessTypes.add(new RangerServiceDef.RangerAccessTypeDef(accessType));
+            }
+
+            serviceDef.setAccessTypes(copiedAccessTypes);
+        }
+    }
+
+    private List<RangerServiceDef.RangerPolicyConditionDef> copyPolicyConditions(List<RangerServiceDef.RangerPolicyConditionDef> policyConditions) {
+        List<RangerServiceDef.RangerPolicyConditionDef> ret = new ArrayList<>();
+
+        if (CollectionUtils.isNotEmpty(policyConditions)) {
+            for (RangerServiceDef.RangerPolicyConditionDef policyCondition : policyConditions) {
+                Map<String, String> evaluatorOptions = policyCondition.getEvaluatorOptions();
+
+                ret.add(new RangerServiceDef.RangerPolicyConditionDef(
+                        policyCondition.getItemId(),
+                        policyCondition.getName(),
+                        policyCondition.getEvaluator(),
+                        evaluatorOptions == null ? null : new HashMap<>(evaluatorOptions),
+                        policyCondition.getValidationRegEx(),
+                        policyCondition.getValidationMessage(),
+                        policyCondition.getUiHint(),
+                        policyCondition.getLabel(),
+                        policyCondition.getDescription(),
+                        policyCondition.getRbKeyLabel(),
+                        policyCondition.getRbKeyDescription(),
+                        policyCondition.getRbKeyValidationMessage()));
+            }
+        }
+
+        return ret;
+    }
+
+    private RangerServiceDef.RangerResourceDef findResourceDef(List<RangerServiceDef.RangerResourceDef> resourceDefs, String resourceName) {
+        if (CollectionUtils.isEmpty(resourceDefs)) {
+            return null;
+        }
+
+        for (RangerServiceDef.RangerResourceDef resourceDef : resourceDefs) {
+            if (resourceName.equals(resourceDef.getName())) {
+                return resourceDef;
+            }
+        }
+
+        return null;
+    }
+
+    private RangerServiceDef.RangerAccessTypeDef findAccessTypeDef(List<RangerServiceDef.RangerAccessTypeDef> accessTypeDefs, String accessTypeName) {
+        if (CollectionUtils.isEmpty(accessTypeDefs)) {
+            return null;
+        }
+
+        for (RangerServiceDef.RangerAccessTypeDef accessTypeDef : accessTypeDefs) {
+            if (accessTypeName.equals(accessTypeDef.getName())) {
+                return accessTypeDef;
+            }
+        }
+
+        return null;
+    }
+
+    private boolean requiresServiceDefUpdate(RangerServiceDef dbOzoneServiceDef) {
+        return !isRoleResourcePresent(dbOzoneServiceDef.getResources())
+                || !isAssumeRoleAccessTypePresent(dbOzoneServiceDef.getAccessTypes())
+                || !areAccessTypeRestrictionsPresent(dbOzoneServiceDef.getResources());
+    }
+
+    private boolean isRoleResourcePresent(List<RangerServiceDef.RangerResourceDef> resourceDefs) {
+        if (CollectionUtils.isEmpty(resourceDefs)) {
+            return false;
+        }
+
+        for (RangerServiceDef.RangerResourceDef resourceDef : resourceDefs) {
+            if (OZONE_RESOURCE_ROLE.equals(resourceDef.getName())) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private boolean isAssumeRoleAccessTypePresent(List<RangerServiceDef.RangerAccessTypeDef> accessTypeDefs) {
+        if (CollectionUtils.isEmpty(accessTypeDefs)) {
+            return false;
+        }
+
+        for (RangerServiceDef.RangerAccessTypeDef accessTypeDef : accessTypeDefs) {
+            if (ACCESS_TYPE_ASSUME_ROLE.equals(accessTypeDef.getName())) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private boolean areAccessTypeRestrictionsPresent(List<RangerServiceDef.RangerResourceDef> resourceDefs) {
+        if (CollectionUtils.isEmpty(resourceDefs)) {
+            return false;
+        }
+
+        for (RangerServiceDef.RangerResourceDef resourceDef : resourceDefs) {
+            if (OZONE_RESOURCES_WITH_ACCESS_TYPE_RESTRICTIONS.contains(resourceDef.getName())
+                    && CollectionUtils.isEmpty(resourceDef.getAccessTypeRestrictions())) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private String mapToJsonString(Map<String, String> map) {
+        String ret = null;
+
+        if (map != null) {
+            try {
+                ret = jsonUtil.readMapToString(map);
+            } catch (Exception ex) {
+                logger.warn("mapToJsonString() failed to convert map: {}", map, ex);
+            }
+        }
+
+        return ret;
+    }
+}

--- a/security-admin/src/main/java/org/apache/ranger/patch/PatchForOzoneServiceDefPolicyConditionUpdate_J10066.java
+++ b/security-admin/src/main/java/org/apache/ranger/patch/PatchForOzoneServiceDefPolicyConditionUpdate_J10066.java
@@ -22,6 +22,7 @@ import org.apache.ranger.biz.ServiceDBStore;
 import org.apache.ranger.common.JSONUtil;
 import org.apache.ranger.common.RangerValidatorFactory;
 import org.apache.ranger.db.RangerDaoManager;
+import org.apache.ranger.entity.XXPolicyConditionDef;
 import org.apache.ranger.entity.XXServiceDef;
 import org.apache.ranger.plugin.model.RangerServiceDef;
 import org.apache.ranger.plugin.model.validation.RangerServiceDefValidator;
@@ -33,12 +34,15 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
 @Component
-public class PatchForOzoneServiceDefPolicyConditionUpdate_J10065 extends BaseLoader {
-    private static final Logger logger = LoggerFactory.getLogger(PatchForOzoneServiceDefPolicyConditionUpdate_J10065.class);
+public class PatchForOzoneServiceDefPolicyConditionUpdate_J10066 extends BaseLoader {
+    private static final Logger logger = LoggerFactory.getLogger(PatchForOzoneServiceDefPolicyConditionUpdate_J10066.class);
+
+    private static final String POLICY_CONDITION_ACTION_MATCHES = "action-matches";
 
     @Autowired
     RangerDaoManager daoMgr;
@@ -52,13 +56,10 @@ public class PatchForOzoneServiceDefPolicyConditionUpdate_J10065 extends BaseLoa
     @Autowired
     RangerValidatorFactory validatorFactory;
 
-    @Autowired
-    ServiceDBStore svcStore;
-
     public static void main(String[] args) {
         logger.info("main()");
         try {
-            PatchForOzoneServiceDefPolicyConditionUpdate_J10065 loader = (PatchForOzoneServiceDefPolicyConditionUpdate_J10065) CLIUtil.getBean(PatchForOzoneServiceDefPolicyConditionUpdate_J10065.class);
+            PatchForOzoneServiceDefPolicyConditionUpdate_J10066 loader = (PatchForOzoneServiceDefPolicyConditionUpdate_J10066) CLIUtil.getBean(PatchForOzoneServiceDefPolicyConditionUpdate_J10066.class);
             loader.init();
             while (loader.isMoreToProcess()) {
                 loader.load();
@@ -78,19 +79,19 @@ public class PatchForOzoneServiceDefPolicyConditionUpdate_J10065 extends BaseLoa
 
     @Override
     public void printStats() {
-        logger.info("PatchForOzoneServiceDefPolicyConditionUpdate_J10065");
+        logger.info("PatchForOzoneServiceDefPolicyConditionUpdate_J10066");
     }
 
     @Override
     public void execLoad() {
-        logger.info("==> PatchForOzoneServiceDefPolicyConditionUpdate_J10065.execLoad()");
+        logger.info("==> PatchForOzoneServiceDefPolicyConditionUpdate_J10066.execLoad()");
         try {
             updateOzoneServiceDef();
         } catch (Exception e) {
-            logger.error("Error while applying PatchForOzoneServiceDefPolicyConditionUpdate_J10065", e);
-            throw new RuntimeException("PatchForOzoneServiceDefPolicyConditionUpdate_J10065 failed", e);
+            logger.error("Error while applying PatchForOzoneServiceDefPolicyConditionUpdate_J10066", e);
+            throw new RuntimeException("PatchForOzoneServiceDefPolicyConditionUpdate_J10066 failed", e);
         }
-        logger.info("<== PatchForOzoneServiceDefPolicyConditionUpdate_J10065.execLoad()");
+        logger.info("<== PatchForOzoneServiceDefPolicyConditionUpdate_J10066.execLoad()");
     }
 
     private void updateOzoneServiceDef() {
@@ -117,6 +118,28 @@ public class PatchForOzoneServiceDefPolicyConditionUpdate_J10065 extends BaseLoa
                 return;
             }
 
+            XXPolicyConditionDef existingActionMatches = daoMgr.getXXPolicyConditionDef().findByServiceDefIdAndName(
+                    xXServiceDefObj.getId(), POLICY_CONDITION_ACTION_MATCHES);
+
+            if (existingActionMatches != null) {
+                logger.info("Ozone service-definition already has {} in DB. No patching needed.", POLICY_CONDITION_ACTION_MATCHES);
+                return;
+            }
+
+            RangerServiceDef.RangerPolicyConditionDef embeddedActionMatchesCondition = null;
+
+            for (RangerServiceDef.RangerPolicyConditionDef policyCondition : embeddedPolicyConditions) {
+                if (POLICY_CONDITION_ACTION_MATCHES.equals(policyCondition.getName())) {
+                    embeddedActionMatchesCondition = policyCondition;
+                    break;
+                }
+            }
+
+            if (embeddedActionMatchesCondition == null) {
+                logger.error("Policy condition {} is missing from embedded Ozone service-definition.", POLICY_CONDITION_ACTION_MATCHES);
+                return;
+            }
+
             Map<String, String> serviceDefOptionsPreUpdate = null;
             final String        jsonStrPreUpdate           = xXServiceDefObj.getDefOptions();
 
@@ -131,13 +154,37 @@ public class PatchForOzoneServiceDefPolicyConditionUpdate_J10065 extends BaseLoa
                 return;
             }
 
-            dbOzoneServiceDef.setPolicyConditions(embeddedPolicyConditions);
+            List<RangerServiceDef.RangerPolicyConditionDef> updatedPolicyConditions = dbOzoneServiceDef.getPolicyConditions() == null
+                    ? new ArrayList<>()
+                    : new ArrayList<>(dbOzoneServiceDef.getPolicyConditions());
 
-            final RangerServiceDefValidator validator = validatorFactory.getServiceDefValidator(svcStore);
+            updatedPolicyConditions.removeIf(c -> POLICY_CONDITION_ACTION_MATCHES.equals(c.getName()));
+
+            RangerServiceDef.RangerPolicyConditionDef actionMatchesCondition = new RangerServiceDef.RangerPolicyConditionDef(
+                    embeddedActionMatchesCondition.getItemId(),
+                    embeddedActionMatchesCondition.getName(),
+                    embeddedActionMatchesCondition.getEvaluator(),
+                    embeddedActionMatchesCondition.getEvaluatorOptions(),
+                    embeddedActionMatchesCondition.getValidationRegEx(),
+                    embeddedActionMatchesCondition.getValidationMessage(),
+                    embeddedActionMatchesCondition.getUiHint(),
+                    embeddedActionMatchesCondition.getLabel(),
+                    embeddedActionMatchesCondition.getDescription(),
+                    embeddedActionMatchesCondition.getRbKeyLabel(),
+                    embeddedActionMatchesCondition.getRbKeyDescription(),
+                    embeddedActionMatchesCondition.getRbKeyValidationMessage());
+
+            actionMatchesCondition.setItemId(nextPolicyConditionItemId(updatedPolicyConditions));
+
+            updatedPolicyConditions.add(actionMatchesCondition);
+
+            dbOzoneServiceDef.setPolicyConditions(updatedPolicyConditions);
+
+            final RangerServiceDefValidator validator = validatorFactory.getServiceDefValidator(svcDBStore);
 
             validator.validate(dbOzoneServiceDef, Action.UPDATE);
 
-            svcStore.updateServiceDef(dbOzoneServiceDef);
+            svcDBStore.updateServiceDef(dbOzoneServiceDef);
 
             xXServiceDefObj = daoMgr.getXXServiceDef().findByName(ozoneServiceDefName);
 
@@ -163,5 +210,21 @@ public class PatchForOzoneServiceDefPolicyConditionUpdate_J10065 extends BaseLoa
             logger.error("Error while updating ozone service-def policy conditions", e);
             throw new RuntimeException("Failed to update ozone service-def policy conditions", e);
         }
+    }
+
+    private long nextPolicyConditionItemId(List<RangerServiceDef.RangerPolicyConditionDef> policyConditions) {
+        long maxItemId = 0L;
+
+        if (policyConditions != null) {
+            for (RangerServiceDef.RangerPolicyConditionDef policyCondition : policyConditions) {
+                Long itemId = policyCondition.getItemId();
+
+                if (itemId != null && itemId > maxItemId) {
+                    maxItemId = itemId;
+                }
+            }
+        }
+
+        return maxItemId + 1;
     }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
This patch introduces Java database patch to handle upgrade scenario. 
--PatchForOzoneServiceDefUpdate_J10066 to backfill missing Ozone service definition metadata (the role resource, assume_role access type, and resource access-type restrictions)
--added DB entry for previous java Patch :PatchForOzoneServiceDefPolicyConditionUpdate_J10065


## How was this patch tested?

The build passed successfully using the command below.
mvn clean install

Tested with upgrade scenario.
