### PR TITLE
RANGER-5751 : service-config UI show duplicate entries for trino plugin

### DIFF
--- a/agents-common/src/main/resources/service-defs/ranger-servicedef-trino.json
+++ b/agents-common/src/main/resources/service-defs/ranger-servicedef-trino.json
@@ -226,11 +226,7 @@
     { "itemId": 2, "name": "password",                    "type": "password", "mandatory": false, "label": "Password" },
     { "itemId": 3, "name": "jdbc.driverClassName",        "type": "string",   "defaultValue": "io.trino.jdbc.TrinoDriver", "mandatory": true },
     { "itemId": 4, "name": "jdbc.url",                    "type": "string",   "defaultValue": "", "mandatory": true },
-    { "itemId": 5, "name": "ranger.plugin.audit.filters", "type": "string",   "defaultValue": "[{'accessResult':'DENIED','isAudited':true},{'isAudited':false,'resources':{'queryid':{'values':['*']}},'accessTypes':['execute']},{'isAudited':false,'resources':{'trinouser':{'values':['{USER}']}},'accessTypes':['impersonate']}]" },
-    { "itemId": 6, "name": "ranger.plugin.super.users",   "type": "string",   "defaultValue": "trino", "label": "Superusers",               "description":  "Superusers will have full access to all resources in this Trino instance" },
-    { "itemId": 7, "name": "ranger.plugin.super.groups",  "type": "string",   "defaultValue": "trino", "label": "Superuser groups",         "description":  "Users in superuser groups will have full access to all resources in this Trino instance" },
-    { "itemId": 8, "name": "service.admin.users",         "type": "string",   "defaultValue": "trino", "label": "Service admin users",      "description":  "Service admin users can create policies for any resource in this Trino instance" },
-    { "itemId": 9, "name": "service.admin.groups",        "type": "string",   "defaultValue": "trino", "label": "Service admin usergroups", "description":  "Users in service admin usergroups can create policies for any resource in this Trino instance" }
+    { "itemId": 5, "name": "ranger.plugin.audit.filters", "type": "string",   "defaultValue": "[{'accessResult':'DENIED','isAudited':true},{'isAudited':false,'resources':{'queryid':{'values':['*']}},'accessTypes':['execute']},{'isAudited':false,'resources':{'trinouser':{'values':['{USER}']}},'accessTypes':['impersonate']}]" }
   ],
   "dataMaskDef": {
     "accessTypes": [


### PR DESCRIPTION
## What changes were proposed in this pull request?
**Issue Summary**
Duplicate service configurations (Superusers/Service Admin) in Trino service definition.

**Problem Description**
In the Trino service definition, duplicate entries are currently appearing for the following service configuration options on the UI:
* Superusers ({{ranger.plugin.trino.superusers}})
* Superuser groups ({{ranger.plugin.trino.superuser.groups}})
* Service admin users ({{ranger.plugin.trino.service.admin.users}})
* Service admin usergroups ({{ranger.plugin.trino.service.admin.user.groups}})

**Root Cause**
The Trino service definition JSON already contains these management properties explicitly. However, following *RANGER-3643*, these properties were also added dynamically on the frontend across all service definitions. As a result, Trino inherits both sets of definitions, rendering duplicate inputs in the service creation/edit UI.

Due to this duplication, submitting the service configuration form constructs a malformed JSON payload, resulting in invalid/incorrect values being stored in the database and causing service creation to fail.

**Expected Behavior**
* The Trino service configuration page should render only a single instance for each administrative property.
* Creating or updating a Trino service should pass valid configuration values and persist properly to the database.

## How was this patch tested?
1. Built and restarted Ranger Admin with the updated Trino service definition.
2. Verified on the UI that Trino service creation/edit forms render `Superusers`, `Superuser groups`, `Service admin users`, and `Service admin usergroups` only once.
3. Created and updated a Trino service instance and verified that the backend receives valid configuration payloads and persists correct values in the database.
