### PR TITLE
RANGER-5698 : Disable Unix Authentication Service by default

### DIFF
--- a/dev-support/ranger-docker/scripts/admin/ranger-admin-install-mysql.properties
+++ b/dev-support/ranger-docker/scripts/admin/ranger-admin-install-mysql.properties
@@ -91,7 +91,7 @@ PATCH_RETRY_INTERVAL=120
 STALE_PATCH_ENTRY_HOLD_TIME=10
 
 hadoop_conf=
-authentication_method=UNIX
+authentication_method=PAM
 
 #------------ Kerberos Config -----------------
 spnego_principal=HTTP/ranger.rangernw@EXAMPLE.COM

--- a/dev-support/ranger-docker/scripts/admin/ranger-admin-install-oracle.properties
+++ b/dev-support/ranger-docker/scripts/admin/ranger-admin-install-oracle.properties
@@ -92,7 +92,7 @@ PATCH_RETRY_INTERVAL=120
 STALE_PATCH_ENTRY_HOLD_TIME=10
 
 hadoop_conf=
-authentication_method=UNIX
+authentication_method=PAM
 
 #------------ Kerberos Config -----------------
 spnego_principal=HTTP/ranger.rangernw@EXAMPLE.COM

--- a/dev-support/ranger-docker/scripts/admin/ranger-admin-install-postgres.properties
+++ b/dev-support/ranger-docker/scripts/admin/ranger-admin-install-postgres.properties
@@ -93,7 +93,7 @@ PATCH_RETRY_INTERVAL=120
 STALE_PATCH_ENTRY_HOLD_TIME=10
 
 hadoop_conf=
-authentication_method=UNIX
+authentication_method=PAM
 
 #------------ Kerberos Config -----------------
 spnego_principal=HTTP/ranger.rangernw@EXAMPLE.COM

--- a/dev-support/ranger-docker/scripts/admin/ranger-admin-install-sqlserver.properties
+++ b/dev-support/ranger-docker/scripts/admin/ranger-admin-install-sqlserver.properties
@@ -98,7 +98,7 @@ PATCH_RETRY_INTERVAL=120
 STALE_PATCH_ENTRY_HOLD_TIME=10
 
 hadoop_conf=
-authentication_method=UNIX
+authentication_method=PAM
 
 #------------ Kerberos Config -----------------
 spnego_principal=HTTP/ranger.rangernw@EXAMPLE.COM

--- a/dev-support/ranger-docker/scripts/usersync/ranger-usersync-install.properties
+++ b/dev-support/ranger-docker/scripts/usersync/ranger-usersync-install.properties
@@ -28,6 +28,11 @@ POLICY_MGR_URL = http://ranger.rangernw:6080
 # defaults to unix
 SYNC_SOURCE = unix
 
+# Enable unix auth service, only when sync source is set to unix along with unix backend is set to passwd.
+# Also, Unix authentication is enabled in Ranger Admin.
+# defaults to false
+ENABLE_UNIX_AUTH = false
+
 #
 # Minimum Unix User-id to start SYNC.
 # This should avoid creating UNIX system-level users in the Policy Manager
@@ -61,10 +66,12 @@ hadoop_conf=/home/ranger/scripts
 #
 CRED_KEYSTORE_FILENAME=/opt/ranger/usersync/conf/rangerusersync.jceks
 
-# SSL Authentication
-AUTH_SSL_ENABLED=true
+# SSL Authentication configuration to be enabled when unix authentication is enabled.
+AUTH_SSL_ENABLED=false
 AUTH_SSL_KEYSTORE_FILE=/opt/ranger/usersync/conf/cert/unixauthservice.jks
 AUTH_SSL_KEYSTORE_PASSWORD=UnIx529p
+
+# Usersync SSL Truststore configuration
 AUTH_SSL_TRUSTSTORE_FILE=
 AUTH_SSL_TRUSTSTORE_PASSWORD=
 

--- a/security-admin/scripts/setup.sh
+++ b/security-admin/scripts/setup.sh
@@ -1514,6 +1514,17 @@ do_authentication_setup(){
                         updatePropertyToFilePy $propertyName "${newPropertyValue}" $ldap_file
                 fi
         fi
+
+		if [ $authentication_method = "PAM" ] ; then
+			newPropertyValue='PAM'
+			pam_service="login"
+			config_file=$app_home/WEB-INF/classes/conf/ranger-admin-site.xml
+			if test -f $config_file; then
+				propertyName=ranger.authentication.method
+				newPropertyValue="${authentication_method}"
+				updatePropertyToFilePy $propertyName $newPropertyValue $config_file
+			fi
+		fi
 	
         log "[I] Finished setup based on user authentication method=$authentication_method";
 }

--- a/security-admin/scripts/setup_authentication.sh
+++ b/security-admin/scripts/setup_authentication.sh
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 
-USAGE="Usage: setup_authentication.sh [UNIX|LDAP|AD|NONE] <path>"
+USAGE="Usage: setup_authentication.sh [UNIX|LDAP|AD|PAM|NONE] <path>"
 
 if [ $# -ne 2 ]
   then
@@ -92,6 +92,9 @@ elif [ $authentication_method = "ACTIVE_DIRECTORY" ]; then
 	/AD_SEC_SETTINGS_END/{f=0}!f' $path/META-INF/contextXML/ad_security_settings.xml $CONFIG_FILE  > tmp
 	mv tmp $CONFIG_FILE
 
+    exit 0;
+elif [ $authentication_method = "PAM" ]; then
+echo $path;
     exit 0;
 elif [ $authentication_method = "NONE" ]; then
 echo $path;

--- a/security-admin/src/bin/ranger_usersync.py
+++ b/security-admin/src/bin/ranger_usersync.py
@@ -120,7 +120,7 @@ if service_entry:
 		jdk_options = get_jdk_options()
 		class_path = get_ranger_classpath()
 		java_class = 'org.apache.ranger.authentication.server.RangerUserSyncServer'
-		class_arguments = '-enableUnixAuth'
+		class_arguments = ''
 
 		dom = getDOMImplementation()
 		xmlDoc = dom.createDocument(None, 'service', None)

--- a/security-admin/src/main/resources/conf.dist/ranger-admin-default-site.xml
+++ b/security-admin/src/main/resources/conf.dist/ranger-admin-default-site.xml
@@ -711,4 +711,8 @@
 		<name>ranger.allow.kerberos.auth.login.browser</name>
 		<value>false</value>
 	</property>
+	<property>
+		<name>ranger.pam.service</name>
+		<value>login</value>
+	</property>
 </configuration>

--- a/ugsync/src/main/java/org/apache/ranger/unixusersync/config/UserGroupSyncConfig.java
+++ b/ugsync/src/main/java/org/apache/ranger/unixusersync/config/UserGroupSyncConfig.java
@@ -195,12 +195,14 @@ public class UserGroupSyncConfig {
     /* SSL Configs */
     private static final String SSL_KEYSTORE_FILE_TYPE_PARAM       = "ranger.keystore.file.type";
     private static final String SSL_TRUSTSTORE_FILE_TYPE_PARAM     = "ranger.truststore.file.type";
-    private static final String SSL_KEYSTORE_PATH_PARAM            = "ranger.usersync.keystore.file";
-    private static final String SSL_KEYSTORE_PATH_PASSWORD_PARAM   = "ranger.usersync.keystore.password";
+    private static final String SSL_KEYSTORE_PATH_PARAM            = "ranger.usersync.service.https.attrib.keystore.file";
+    private static final String SSL_KEYSTORE_PATH_PASSWORD_PARAM   = "ranger.usersync.service.https.attrib.keystore.pass";
     private static final String SSL_TRUSTSTORE_PATH_PARAM          = "ranger.usersync.truststore.file";
     private static final String SSL_TRUSTSTORE_PATH_PASSWORD_PARAM = "ranger.usersync.truststore.password";
-    private static final String SSL_KEYSTORE_PATH_PASSWORD_ALIAS   = "usersync.ssl.key.password";
+    private static final String SSL_KEYSTORE_PATH_PASSWORD_ALIAS   = "ranger.usersync.service.https.attrib.keystore.pass";
     private static final String SSL_TRUSTSTORE_PATH_PASSWORD_ALIAS = "usersync.ssl.truststore.password";
+
+    private static final String UGSYNC_UNIX_AUTH_ENABLED = "ranger.usersync.unix.auth.enabled";
 
     private static volatile UserGroupSyncConfig me;
     private final           Properties          prop = new Properties();
@@ -409,6 +411,14 @@ public class UserGroupSyncConfig {
         }
 
         return prop.getProperty(SSL_TRUSTSTORE_PATH_PASSWORD_PARAM);
+    }
+
+    public boolean getUserSyncUnixAuth() {
+        boolean enableUnixAuth = false;
+        if (prop.containsKey(UGSYNC_UNIX_AUTH_ENABLED)) {
+            enableUnixAuth = Boolean.parseBoolean(prop.getProperty(UGSYNC_UNIX_AUTH_ENABLED));
+        }
+        return enableUnixAuth;
     }
 
     public long getUpdateMillisMin() {

--- a/ugsync/src/test/java/org/apache/ranger/unixusersync/config/TestUserGroupSyncConfig.java
+++ b/ugsync/src/test/java/org/apache/ranger/unixusersync/config/TestUserGroupSyncConfig.java
@@ -86,7 +86,7 @@ public class TestUserGroupSyncConfig {
         cfg.setProperty("ranger.usersync.ssl.keystore.type", "jks");
 
         // Touch properties using correct parameter keys and ensure returned
-        cfg.setProperty("ranger.usersync.keystore.password", "ksp");
+        cfg.setProperty("ranger.usersync.service.https.attrib.keystore.pass", "ksp");
         cfg.setProperty("ranger.usersync.truststore.password", "tsp");
         assertEquals("ksp", cfg.getSSLKeyStorePathPassword());
         assertEquals("tsp", cfg.getSSLTrustStorePathPassword());

--- a/unixauthservice/conf.dist/ranger-ugsync-default.xml
+++ b/unixauthservice/conf.dist/ranger-ugsync-default.xml
@@ -19,7 +19,7 @@
 <configuration>
 	<property>
 		<name>ranger.usersync.port</name>
-                <value>5151</value>
+		<value>5151</value>
 	</property>
 	<property>
 		<name>ranger.usersync.ssl</name>

--- a/unixauthservice/scripts/install.properties
+++ b/unixauthservice/scripts/install.properties
@@ -28,6 +28,11 @@ POLICY_MGR_URL =
 # defaults to unix
 SYNC_SOURCE = unix
 
+# Enable unix auth service, only when sync source is set to unix along with unix backend is set to passwd.
+# Also, Unix authentication is enabled in Ranger Admin.
+# defaults to false
+ENABLE_UNIX_AUTH = false
+
 #
 # Minimum Unix User-id to start SYNC.
 # This should avoid creating UNIX system-level users in the Policy Manager
@@ -61,10 +66,12 @@ hadoop_conf=/etc/hadoop/conf
 #
 CRED_KEYSTORE_FILENAME=/etc/ranger/usersync/conf/rangerusersync.jceks
 
-# SSL Authentication
+# SSL Authentication configuration to be enabled when unix authentication is enabled.
 AUTH_SSL_ENABLED=false
 AUTH_SSL_KEYSTORE_FILE=/etc/ranger/usersync/conf/cert/unixauthservice.jks
 AUTH_SSL_KEYSTORE_PASSWORD=UnIx529p
+
+# Usersync SSL Truststore configuration
 AUTH_SSL_TRUSTSTORE_FILE=
 AUTH_SSL_TRUSTSTORE_PASSWORD=
 

--- a/unixauthservice/scripts/ranger-usersync-services.sh
+++ b/unixauthservice/scripts/ranger-usersync-services.sh
@@ -127,7 +127,7 @@ if [ "${action}" == "START" ]; then
         fi
     fi
 	SLEEP_TIME_AFTER_START=5
-	nohup java -Dproc_rangerusersync ${JAVA_OPTS} -Duser=rangerusersync -Dhostname=${HOSTNAME} -Dservername=rangerusersync -Dranger.usersync.home=`pwd` -Dlogdir="${logdir}" -Dranger.usersync.log.dir="${RANGER_USERSYNC_LOG_DIR}" -Dlogback.configurationFile=file:${USERSYNC_CONF_DIR}/logback.xml -Djdk.tls.ephemeralDHKeySize=2048 -Dranger.usersync.webapp.dir="${RANGER_USERSYNC_WEBAPP}" -Dranger.usersync.service.host="${HOSTNAME}" -Dcatalina.base=${cdir}/ews -cp "${cp}" org.apache.ranger.authentication.server.RangerUserSyncServer -enableUnixAuth > ${RANGER_USERSYNC_LOG_DIR}/catalina.out 2>&1 &
+	nohup java -Dproc_rangerusersync ${JAVA_OPTS} -Duser=rangerusersync -Dhostname=${HOSTNAME} -Dservername=rangerusersync -Dranger.usersync.home=`pwd` -Dlogdir="${logdir}" -Dranger.usersync.log.dir="${RANGER_USERSYNC_LOG_DIR}" -Dlogback.configurationFile=file:${USERSYNC_CONF_DIR}/logback.xml -Djdk.tls.ephemeralDHKeySize=2048 -Dranger.usersync.webapp.dir="${RANGER_USERSYNC_WEBAPP}" -Dranger.usersync.service.host="${HOSTNAME}" -Dcatalina.base=${cdir}/ews -cp "${cp}" org.apache.ranger.authentication.server.RangerUserSyncServer > ${RANGER_USERSYNC_LOG_DIR}/catalina.out 2>&1 &
 	VALUE_OF_PID=$!
     echo "Starting Ranger Usersync Service"
     sleep $SLEEP_TIME_AFTER_START

--- a/unixauthservice/scripts/setup.py
+++ b/unixauthservice/scripts/setup.py
@@ -70,7 +70,7 @@ nativeAuthProgramName = join(nativeAuthFolderName, 'credValidator.uexe')
 pamAuthProgramName = join(nativeAuthFolderName, 'pamCredValidator.uexe')
 
 defaultKSPassword = 'UnIx529p'
-defaultDNAME = 'cn=unixauthservice,ou=authenticator,o=mycompany,c=US'
+defaultDNAME = 'cn=Ranger Usersync Unixauthservice, ST=CA, C=US'
 
 unixUserProp = 'unix_user'
 unixGroupProp = 'unix_group'
@@ -438,17 +438,22 @@ def main():
         if (localLogFolderName != ugsyncLogFolderName):
             os.symlink(ugsyncLogFolderName, localLogFolderName)
 
-    if (not 'ranger.usersync.keystore.file' in mergeProps):
-        mergeProps['ranger.usersync.keystore.file'] = defaultKSFileName
+    enableUnixAuth = globalDict.get('ENABLE_UNIX_AUTH', 'false').lower() == 'true'
+    if enableUnixAuth:
+        mergeProps['ranger.usersync.unix.backend'] = 'passwd'
+        if (not 'ranger.usersync.keystore.file' in mergeProps):
+            mergeProps['ranger.usersync.keystore.file'] = defaultKSFileName
 
-    ksFileName = mergeProps['ranger.usersync.keystore.file']
+        ksFileName = mergeProps['ranger.usersync.keystore.file']
 
-    if (not isfile(ksFileName)):
-        mergeProps['ranger.usersync.keystore.password'] = defaultKSPassword
-        createJavaKeystoreForSSL(ksFileName, defaultKSPassword)
+        if (not isfile(ksFileName)):
+            mergeProps['ranger.usersync.keystore.password'] = defaultKSPassword
+            createJavaKeystoreForSSL(ksFileName, defaultKSPassword)
 
-    if ('ranger.usersync.keystore.password' not in mergeProps):
-        mergeProps['ranger.usersync.keystore.password'] = defaultKSPassword
+        if ('ranger.usersync.keystore.password' not in mergeProps):
+            mergeProps['ranger.usersync.keystore.password'] = defaultKSPassword
+    else:
+        mergeProps['ranger.usersync.unix.backend'] = 'nss'
 
     fn = join(installTemplateDirName, templateFileName)
     outfn = join(confFolderName, outputFileName)

--- a/unixauthservice/scripts/templates/installprop2xml.properties
+++ b/unixauthservice/scripts/templates/installprop2xml.properties
@@ -55,7 +55,8 @@ AUTH_SSL_TRUSTSTORE_PASSWORD = ranger.usersync.truststore.password
 AUTH_SSL_ENABLED = ranger.usersync.ssl
 SYNC_LDAP_REFERRAL = ranger.usersync.ldap.referral
 usersync_principal= ranger.usersync.kerberos.principal
-usersync_keytab= ranger.usersync.kerberos.keytab
+usersync_keytab = ranger.usersync.kerberos.keytab
+ENABLE_UNIX_AUTH = ranger.usersync.unix.auth.enabled
 #JVM metrics related property
 JVM_METRICS_ENABLED=ranger.usersync.metrics.enabled
 JVM_METRICS_FILENAME=ranger.usersync.metrics.filename

--- a/unixauthservice/scripts/templates/ranger-ugsync-template.xml
+++ b/unixauthservice/scripts/templates/ranger-ugsync-template.xml
@@ -74,9 +74,9 @@
 		<value></value>
 	</property>
 	<property>
-                <name>ranger.usersync.ldap.deltasync</name>
-                <value></value>
-        </property>
+		<name>ranger.usersync.ldap.deltasync</name>
+		<value></value>
+	</property>
 	<property>
 		<name>ranger.usersync.ldap.user.groupnameattribute</name>
 		<value></value>
@@ -198,49 +198,49 @@
 		<value></value>
 	</property>
 	<property>
-      <name>ranger.usersync.keystore.password</name>
-      <value></value>
-    </property>
-    <property>
-      <name>ranger.usersync.truststore.password</name>
-      <value></value>
-    </property>
-    <property>
-      <name>ranger.usersync.role.assignment.list.delimiter</name>
-          <value></value>
-        </property>
-        <property>
-      <name>ranger.usersync.users.groups.assignment.list.delimiter</name>
-      <value></value>
-        </property>
-        <property>
-      <name>ranger.usersync.username.groupname.assignment.list.delimiter</name>
-      <value></value>
-        </property>
-    <property>
-          <name>ranger.usersync.group.based.role.assignment.rules</name>
-      <value></value>
-    </property>
-    <property>
+		<name>ranger.usersync.keystore.password</name>
+		<value></value>
+	</property>
+	<property>
+		<name>ranger.usersync.truststore.password</name>
+		<value></value>
+	</property>
+	<property>
+		<name>ranger.usersync.role.assignment.list.delimiter</name>
+		<value></value>
+	</property>
+	<property>
+		<name>ranger.usersync.users.groups.assignment.list.delimiter</name>
+		<value></value>
+	</property>
+	<property>
+		<name>ranger.usersync.username.groupname.assignment.list.delimiter</name>
+		<value></value>
+	</property>
+	<property>
+		<name>ranger.usersync.group.based.role.assignment.rules</name>
+		<value></value>
+	</property>
+	<property>
 		<name>ranger.usersync.dest.ranger.session.cookie.name</name>
 		<value>RANGERADMINSESSIONID</value>
 	</property>
-    <property>
+	<property>
 		<name>ranger.usersync.metrics.enabled</name>
 		<value>false</value>
-    </property>
-    <property>
+	</property>
+	<property>
 		<name>ranger.usersync.metrics.filepath</name>
 		<value></value>
-    </property>
-    <property>
+	</property>
+	<property>
 		<name>ranger.usersync.metrics.frequencytimeinmillis</name>
 		<value></value>
-    </property>
-    <property>
+	</property>
+	<property>
 		<name>ranger.usersync.metrics.filename</name>
 		<value></value>
-    </property>
+	</property>
 
 	<!-- HA property -->
 	<property>
@@ -299,24 +299,32 @@
 		<name>ranger-ugsync.server.ha.https.port</name>
 		<value></value>
 	</property>
-    <property>
-        <name>ranger.usersync.service.http.port</name>
-        <value></value>
-    </property>
-    <property>
-        <name>ranger.usersync.service.https.port</name>
-        <value></value>
-    </property>
-    <property>
-        <name>ranger.usersync.service.https.attrib.keystore.keyalias</name>
-        <value></value>
-    </property>
-    <property>
-        <name>ranger.usersync.service.https.attrib.keystore.credential.alias</name>
-        <value></value>
-    </property>
-    <property>
-        <name>ranger.usersync.service.host</name>
-        <value></value>
-    </property>
+	<property>
+		<name>ranger.usersync.service.http.port</name>
+		<value></value>
+	</property>
+	<property>
+		<name>ranger.usersync.service.https.port</name>
+		<value></value>
+	</property>
+	<property>
+		<name>ranger.usersync.service.https.attrib.keystore.keyalias</name>
+		<value></value>
+	</property>
+	<property>
+		<name>ranger.usersync.service.https.attrib.keystore.credential.alias</name>
+		<value></value>
+	</property>
+	<property>
+		<name>ranger.usersync.service.host</name>
+		<value></value>
+	</property>
+	<property>
+		<name>ranger.usersync.unix.auth.enabled</name>
+		<value></value>
+	</property>
+	<property>
+		<name>ranger.usersync.unix.backend</name>
+		<value></value>
+	</property>
 </configuration>

--- a/unixauthservice/src/main/java/org/apache/ranger/authentication/UnixAuthenticationService.java
+++ b/unixauthservice/src/main/java/org/apache/ranger/authentication/UnixAuthenticationService.java
@@ -112,6 +112,7 @@ public class UnixAuthenticationService {
     }
 
     public void run() {
+        boolean unixAuthServiceStarted = false;
         try {
             UserGroupSyncConfig config = UserGroupSyncConfig.getInstance();
             enableUnixAuth = config.getUserSyncUnixAuth();
@@ -123,6 +124,7 @@ public class UnixAuthenticationService {
             if (enableUnixAuth && "passwd".equalsIgnoreCase(unixBackend)) {
                 LOG.info("Enabling Unix Auth Service!");
                 init();
+                unixAuthServiceStarted = true;
                 startService();
             } else {
                 LOG.info("Unix Auth Service Disabled!");
@@ -130,10 +132,17 @@ public class UnixAuthenticationService {
         } catch (Throwable t) {
             LOG.error("ERROR: Service: {}", serviceName, t);
         } finally {
-            LOG.info("Service: {} - STOPPED", serviceName);
-            if (this.userSyncHAInitializerImpl != null) {
-                LOG.info("Stopping curator leader latch service as main thread is closing");
-                this.userSyncHAInitializerImpl.stop();
+            /*
+             * Stop Curator leader election only when the Unix Auth listener is shutting down.
+             * When Unix Auth is disabled, this main thread returns but UserGroupSync keeps running
+             * and still depends on HA; stopping the leader latch here would mark every node active.
+             */
+            if (unixAuthServiceStarted) {
+                LOG.info("Service: {} - STOPPED", serviceName);
+                if (this.userSyncHAInitializerImpl != null) {
+                    LOG.info("Stopping curator leader latch service as Unix Auth service is closing");
+                    this.userSyncHAInitializerImpl.stop();
+                }
             }
         }
     }

--- a/unixauthservice/src/main/java/org/apache/ranger/authentication/UnixAuthenticationService.java
+++ b/unixauthservice/src/main/java/org/apache/ranger/authentication/UnixAuthenticationService.java
@@ -82,6 +82,7 @@ public class UnixAuthenticationService {
     private static final String UNIXAUTH_ACCOUNT_MAX_DELAY_MS_PARAM          = "ranger.usersync.unixauth.account.max.delay.ms";
 
     private static boolean enableUnixAuth;
+    private static String unixBackend;
 
     private final List<String> adminUserList = new ArrayList<>();
 
@@ -105,7 +106,6 @@ public class UnixAuthenticationService {
     }
 
     public static void main(String[] args) {
-        enableUnixAuth = Arrays.stream(args).anyMatch("-enableUnixAuth"::equalsIgnoreCase);
         UnixAuthenticationService service = new UnixAuthenticationService();
         service.userSyncHAInitializerImpl = UserSyncHAInitializerImpl.getInstance(UserGroupSyncConfig.getInstance().getUserGroupConfig());
         service.run();
@@ -113,10 +113,14 @@ public class UnixAuthenticationService {
 
     public void run() {
         try {
+            UserGroupSyncConfig config = UserGroupSyncConfig.getInstance();
+            enableUnixAuth = config.getUserSyncUnixAuth();
+            unixBackend = config.getUnixBackend();
+
             LOG.info("Starting User Sync Service!");
             startUnixUserGroupSyncProcess();
             Thread.sleep(5000);
-            if (enableUnixAuth) {
+            if (enableUnixAuth && "passwd".equalsIgnoreCase(unixBackend)) {
                 LOG.info("Enabling Unix Auth Service!");
                 init();
                 startService();

--- a/unixauthservice/src/main/java/org/apache/ranger/authentication/server/RangerUserSyncStarter.java
+++ b/unixauthservice/src/main/java/org/apache/ranger/authentication/server/RangerUserSyncStarter.java
@@ -43,8 +43,7 @@ public class RangerUserSyncStarter {
     static class UnixAuthenticationServiceThread extends Thread {
         @Override
         public void run() {
-            String[] params = {"-enableUnixAuth"};
-            UnixAuthenticationService.main(params);
+            UnixAuthenticationService.main(new String[] {});
         }
     }
 }

--- a/unixauthservice/src/test/java/org/apache/ranger/authentication/TestUnixAuthenticationService.java
+++ b/unixauthservice/src/test/java/org/apache/ranger/authentication/TestUnixAuthenticationService.java
@@ -255,7 +255,7 @@ public class TestUnixAuthenticationService {
         try (MockedStatic<UserGroupSyncConfig> ugscStatic = mockStatic(UserGroupSyncConfig.class);
                 MockedStatic<UserSyncHAInitializerImpl> haStatic = mockStatic(UserSyncHAInitializerImpl.class);
                 MockedConstruction<UnixAuthenticationService> serviceConstruction = mockConstruction(UnixAuthenticationService.class, (mock, ctx) -> {
-                    // service.run() will be called by main; make it a no-op
+                    doNothing().when(mock).run();
                 })) {
             UserGroupSyncConfig ugsc = mock(UserGroupSyncConfig.class);
             ugscStatic.when(UserGroupSyncConfig::getInstance).thenReturn(ugsc);
@@ -264,7 +264,10 @@ public class TestUnixAuthenticationService {
             UserSyncHAInitializerImpl ha = mock(UserSyncHAInitializerImpl.class);
             haStatic.when(() -> UserSyncHAInitializerImpl.getInstance(any())).thenReturn(ha);
 
-            UnixAuthenticationService.main(new String[] {"-enableUnixAuth"});
+            UnixAuthenticationService.main(new String[] {});
+
+            assertEquals(1, serviceConstruction.constructed().size());
+            verify(serviceConstruction.constructed().get(0)).run();
         }
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The Unix Authentication service is rarely utilized for Ranger authentication, as the vast majority of deployments have migrated to modern alternatives like PAM or LDAP.

To optimize default startup behavior, we are removing the Unix Authentication service from the Ranger Usersync default startup sequence.

Moving forward, this service will run only if explicitly enabled via the `ranger.usersync.unix.auth.enabled` property within the `ranger-ugsync-site.xml` configuration file.


## How was this patch tested?

1. Brought up ranger core services: ranger, usersync, tagsync, pdp and kms in containers.
2. Created a user on ranger & usersync containers.
3. Set the password for the user.
4. User got synced successfully on Ranger Admin.
5. Login was successfully with the user password on Ranger Admin with PAM authentication.