### PR TITLE
RANGER-5754: Fix timezone-sensitive test failures in MiscUtilTest

### DIFF
--- a/agents-audit/core/src/main/java/org/apache/ranger/audit/provider/MiscUtil.java
+++ b/agents-audit/core/src/main/java/org/apache/ranger/audit/provider/MiscUtil.java
@@ -843,7 +843,7 @@ public class MiscUtil {
     public static Date getUTCDateForLocalDate(Date date) {
         TimeZone          gmtTimeZone = TimeZone.getTimeZone("GMT+0");
         Calendar          local       = Calendar.getInstance();
-        int               offset      = local.getTimeZone().getOffset(local.getTimeInMillis());
+        int               offset      = local.getTimeZone().getOffset(date.getTime());
         GregorianCalendar utc         = new GregorianCalendar(gmtTimeZone);
 
         utc.setTimeInMillis(date.getTime());

--- a/agents-audit/core/src/test/java/org/apache/ranger/audit/provider/MiscUtilTest.java
+++ b/agents-audit/core/src/test/java/org/apache/ranger/audit/provider/MiscUtilTest.java
@@ -29,6 +29,7 @@ import java.lang.reflect.Field;
 import java.nio.file.Path;
 import java.security.PrivilegedAction;
 import java.security.PrivilegedExceptionAction;
+import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
@@ -125,8 +126,9 @@ class MiscUtilTest {
     void testGetFormattedTime() {
         long timestamp = 1609459200000L; // 2021-01-01 00:00:00 UTC
 
-        // Test with valid format
-        assertEquals("2021-01-01", MiscUtil.getFormattedTime(timestamp, "yyyy-MM-dd"));
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
+        String expected = sdf.format(timestamp);
+        assertEquals(expected, MiscUtil.getFormattedTime(timestamp, "yyyy-MM-dd"));
 
         // Test with invalid format
         assertNull(MiscUtil.getFormattedTime(timestamp, "invalid"));

--- a/agents-common/src/main/java/org/apache/ranger/authorization/utils/StringUtil.java
+++ b/agents-common/src/main/java/org/apache/ranger/authorization/utils/StringUtil.java
@@ -259,7 +259,7 @@ public class StringUtil {
 
     public static Date getUTCDateForLocalDate(Date date) {
         Calendar          local  = Calendar.getInstance();
-        int               offset = local.getTimeZone().getOffset(local.getTimeInMillis());
+        int               offset = local.getTimeZone().getOffset(date.getTime());
         GregorianCalendar utc    = new GregorianCalendar(gmtTimeZone);
 
         utc.setTimeInMillis(date.getTime());


### PR DESCRIPTION
**Description:**
Timezone-dependent unit test failures found in MiscUtilTest (failure outside UTC)
mainly in testGetFormattedTime and testGetUTCDateForLocalDate.

**Fix**
`testGetFormattedTime`: Replaced hardcoded "2021-01-01" with an expected value generated by the same SimpleDateFormat logic as production, so the test uses JVM local timezone and stays timezone-agnostic.

`testGetUTCDateForLocalDate`: Fixed incorrect DST offset in MiscUtil.getUTCDateForLocalDate and StringUtil.getUTCDateForLocalDate causing test failure outside UTC timezones

**Test:** 
Successful build
Successful run with both 
> mvn clean -Duser.timezone=America/New_York test  &
> mvn clean -Duser.timezone=UTC test