### PR TITLE
RANGER-5753: LDAP/Active Directory authentication does not validate local Ranger account status

### DIFF
--- a/security-admin/src/main/java/org/apache/ranger/biz/UserMgr.java
+++ b/security-admin/src/main/java/org/apache/ranger/biz/UserMgr.java
@@ -1177,7 +1177,7 @@ public class UserMgr {
         return roleList;
     }
 
-    public boolean isUserDisabled(String loginId) {
+    public boolean isUserNotActive(String loginId) {
         if (loginId == null || loginId.trim().isEmpty()) {
             return false;
         }

--- a/security-admin/src/main/java/org/apache/ranger/biz/UserMgr.java
+++ b/security-admin/src/main/java/org/apache/ranger/biz/UserMgr.java
@@ -1177,6 +1177,14 @@ public class UserMgr {
         return roleList;
     }
 
+    public boolean isUserDisabled(String loginId) {
+        if (loginId == null || loginId.trim().isEmpty()) {
+            return false;
+        }
+        XXPortalUser xXPortalUser = daoManager.getXXPortalUser().findByLoginId(loginId);
+        return xXPortalUser != null && xXPortalUser.getStatus() == RangerCommonEnums.STATUS_DISABLED;
+    }
+
     @Transactional(readOnly = false, propagation = Propagation.REQUIRED)
     public XXPortalUser updateOldUserName(String userLoginId, String newUserName, String currentPassword) {
         if (userLoginId == null || newUserName == null || userLoginId.trim().isEmpty() || newUserName.trim().isEmpty()) {

--- a/security-admin/src/main/java/org/apache/ranger/biz/UserMgr.java
+++ b/security-admin/src/main/java/org/apache/ranger/biz/UserMgr.java
@@ -1182,7 +1182,7 @@ public class UserMgr {
             return false;
         }
         XXPortalUser xXPortalUser = daoManager.getXXPortalUser().findByLoginId(loginId);
-        return xXPortalUser != null && xXPortalUser.getStatus() == RangerCommonEnums.STATUS_DISABLED;
+        return xXPortalUser != null && xXPortalUser.getStatus() != RangerCommonEnums.ACT_STATUS_ACTIVE;
     }
 
     @Transactional(readOnly = false, propagation = Propagation.REQUIRED)

--- a/security-admin/src/main/java/org/apache/ranger/security/handler/RangerAuthenticationProvider.java
+++ b/security-admin/src/main/java/org/apache/ranger/security/handler/RangerAuthenticationProvider.java
@@ -114,14 +114,14 @@ public class RangerAuthenticationProvider implements AuthenticationProvider {
                     authentication = getLdapAuthentication(authentication);
 
                     if (authentication != null && authentication.isAuthenticated()) {
-                        checkAccountNotDisabled(authentication.getName());
+                        blockNotActiveUser(authentication.getName());
 
                         return authentication;
                     } else {
                         authentication = getLdapBindAuthentication(authentication);
 
                         if (authentication != null && authentication.isAuthenticated()) {
-                            checkAccountNotDisabled(authentication.getName());
+                            blockNotActiveUser(authentication.getName());
 
                             return authentication;
                         }
@@ -130,14 +130,14 @@ public class RangerAuthenticationProvider implements AuthenticationProvider {
                     authentication = getADBindAuthentication(authentication);
 
                     if (authentication != null && authentication.isAuthenticated()) {
-                        checkAccountNotDisabled(authentication.getName());
+                        blockNotActiveUser(authentication.getName());
 
                         return authentication;
                     } else {
                         authentication = getADAuthentication(authentication);
 
                         if (authentication != null && authentication.isAuthenticated()) {
-                            checkAccountNotDisabled(authentication.getName());
+                            blockNotActiveUser(authentication.getName());
 
                             return authentication;
                         }
@@ -148,7 +148,7 @@ public class RangerAuthenticationProvider implements AuthenticationProvider {
                     authentication = (isPAMAuthEnabled ? getPamAuthentication(authentication) : getUnixAuthentication(authentication));
 
                     if (authentication != null && authentication.isAuthenticated()) {
-                        checkAccountNotDisabled(authentication.getName());
+                        blockNotActiveUser(authentication.getName());
 
                         return authentication;
                     }
@@ -156,7 +156,7 @@ public class RangerAuthenticationProvider implements AuthenticationProvider {
                     authentication = getPamAuthentication(authentication);
 
                     if (authentication != null && authentication.isAuthenticated()) {
-                        checkAccountNotDisabled(authentication.getName());
+                        blockNotActiveUser(authentication.getName());
 
                         return authentication;
                     }
@@ -714,8 +714,8 @@ public class RangerAuthenticationProvider implements AuthenticationProvider {
         return authentication;
     }
 
-    private void checkAccountNotDisabled(String userName) {
-        if (userName != null && userMgr.isUserDisabled(userName)) {
+    private void blockNotActiveUser(String userName) {
+        if (userName != null && userMgr.isUserNotActive(userName)) {
             logger.info("Authentication rejected - Ranger account for user [{}] is disabled", userName);
             throw new DisabledException(messages.getMessage("AbstractUserDetailsAuthenticationProvider.disabled", "User account is disabled"));
         }

--- a/security-admin/src/main/java/org/apache/ranger/security/handler/RangerAuthenticationProvider.java
+++ b/security-admin/src/main/java/org/apache/ranger/security/handler/RangerAuthenticationProvider.java
@@ -35,6 +35,7 @@ import org.springframework.ldap.core.support.DefaultTlsDirContextAuthenticationS
 import org.springframework.ldap.core.support.LdapContextSource;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.DisabledException;
 import org.springframework.security.authentication.LockedException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
@@ -113,11 +114,15 @@ public class RangerAuthenticationProvider implements AuthenticationProvider {
                     authentication = getLdapAuthentication(authentication);
 
                     if (authentication != null && authentication.isAuthenticated()) {
+                        checkAccountNotDisabled(authentication.getName());
+
                         return authentication;
                     } else {
                         authentication = getLdapBindAuthentication(authentication);
 
                         if (authentication != null && authentication.isAuthenticated()) {
+                            checkAccountNotDisabled(authentication.getName());
+
                             return authentication;
                         }
                     }
@@ -125,11 +130,15 @@ public class RangerAuthenticationProvider implements AuthenticationProvider {
                     authentication = getADBindAuthentication(authentication);
 
                     if (authentication != null && authentication.isAuthenticated()) {
+                        checkAccountNotDisabled(authentication.getName());
+
                         return authentication;
                     } else {
                         authentication = getADAuthentication(authentication);
 
                         if (authentication != null && authentication.isAuthenticated()) {
+                            checkAccountNotDisabled(authentication.getName());
+
                             return authentication;
                         }
                     }
@@ -139,12 +148,16 @@ public class RangerAuthenticationProvider implements AuthenticationProvider {
                     authentication = (isPAMAuthEnabled ? getPamAuthentication(authentication) : getUnixAuthentication(authentication));
 
                     if (authentication != null && authentication.isAuthenticated()) {
+                        checkAccountNotDisabled(authentication.getName());
+
                         return authentication;
                     }
                 } else if ("PAM".equalsIgnoreCase(rangerAuthenticationMethod)) {
                     authentication = getPamAuthentication(authentication);
 
                     if (authentication != null && authentication.isAuthenticated()) {
+                        checkAccountNotDisabled(authentication.getName());
+
                         return authentication;
                     }
                 }
@@ -699,6 +712,13 @@ public class RangerAuthenticationProvider implements AuthenticationProvider {
         }
 
         return authentication;
+    }
+
+    private void checkAccountNotDisabled(String userName) {
+        if (userName != null && userMgr.isUserDisabled(userName)) {
+            logger.info("Authentication rejected - Ranger account for user [{}] is disabled", userName);
+            throw new DisabledException(messages.getMessage("AbstractUserDetailsAuthenticationProvider.disabled", "User account is disabled"));
+        }
     }
 
     private List<GrantedAuthority> getAuthorities(String username) {

--- a/security-admin/src/test/java/org/apache/ranger/biz/TestUserMgr.java
+++ b/security-admin/src/test/java/org/apache/ranger/biz/TestUserMgr.java
@@ -2407,7 +2407,7 @@ public class TestUserMgr {
 
         XXPortalUser user = new XXPortalUser();
         user.setLoginId(userLoginID);
-        user.setStatus(RangerCommonEnums.STATUS_DISABLED);
+        user.setStatus(RangerCommonEnums.ACT_STATUS_DISABLED);
 
         Mockito.when(daoManager.getXXPortalUser()).thenReturn(userDao);
         Mockito.when(userDao.findByLoginId(userLoginID)).thenReturn(user);
@@ -2421,7 +2421,7 @@ public class TestUserMgr {
 
         XXPortalUser user = new XXPortalUser();
         user.setLoginId(userLoginID);
-        user.setStatus(RangerCommonEnums.STATUS_ENABLED);
+        user.setStatus(RangerCommonEnums.ACT_STATUS_ACTIVE);
 
         Mockito.when(daoManager.getXXPortalUser()).thenReturn(userDao);
         Mockito.when(userDao.findByLoginId(userLoginID)).thenReturn(user);
@@ -2443,6 +2443,40 @@ public class TestUserMgr {
     public void testIsUserDisabled_returnsFalseForBlankLoginId() {
         Assertions.assertFalse(userMgr.isUserDisabled(""));
         Assertions.assertFalse(userMgr.isUserDisabled(null));
+    }
+
+    @Test
+    public void testIsUserDisabled_returnsTrueForDeactivatedLocalAccount() {
+        XXPortalUserDao userDao = Mockito.mock(XXPortalUserDao.class);
+
+        XXPortalUser user = new XXPortalUser();
+        user.setLoginId(userLoginID);
+        user.setStatus(RangerCommonEnums.ACT_STATUS_DEACTIVATED);
+
+        Mockito.when(daoManager.getXXPortalUser()).thenReturn(userDao);
+        Mockito.when(userDao.findByLoginId(userLoginID)).thenReturn(user);
+
+        Assertions.assertTrue(userMgr.isUserDisabled(userLoginID));
+    }
+
+    @Test
+    public void testIsUserDisabled_returnsTrueForNonActiveLocalAccountStatuses() {
+        XXPortalUserDao userDao = Mockito.mock(XXPortalUserDao.class);
+        int[] nonActiveStatuses = {
+                RangerCommonEnums.ACT_STATUS_PENDING_APPROVAL,
+                RangerCommonEnums.ACT_STATUS_PENDING_ACTIVATION,
+                RangerCommonEnums.ACT_STATUS_REJECTED,
+                RangerCommonEnums.ACT_STATUS_PRE_REGISTRATION,
+                RangerCommonEnums.ACT_STATUS_NO_LOGIN
+        };
+        Mockito.when(daoManager.getXXPortalUser()).thenReturn(userDao);
+        for (int status : nonActiveStatuses) {
+            XXPortalUser user = new XXPortalUser();
+            user.setLoginId(userLoginID);
+            user.setStatus(status);
+            Mockito.when(userDao.findByLoginId(userLoginID)).thenReturn(user);
+            Assertions.assertTrue(userMgr.isUserDisabled(userLoginID), "status " + status + " should be treated as not able to log in");
+        }
     }
 
     private VXPortalUser userProfile() {

--- a/security-admin/src/test/java/org/apache/ranger/biz/TestUserMgr.java
+++ b/security-admin/src/test/java/org/apache/ranger/biz/TestUserMgr.java
@@ -2402,7 +2402,7 @@ public class TestUserMgr {
     }
 
     @Test
-    public void testIsUserDisabled_returnsTrueForDisabledLocalAccount() {
+    public void testIsUserDisabled_returnsTrueForNotActiveLocalAccount() {
         XXPortalUserDao userDao = Mockito.mock(XXPortalUserDao.class);
 
         XXPortalUser user = new XXPortalUser();
@@ -2412,11 +2412,11 @@ public class TestUserMgr {
         Mockito.when(daoManager.getXXPortalUser()).thenReturn(userDao);
         Mockito.when(userDao.findByLoginId(userLoginID)).thenReturn(user);
 
-        Assertions.assertTrue(userMgr.isUserDisabled(userLoginID));
+        Assertions.assertTrue(userMgr.isUserNotActive(userLoginID));
     }
 
     @Test
-    public void testIsUserDisabled_returnsFalseForEnabledLocalAccount() {
+    public void testIsUserNotActive_returnsFalseForEnabledLocalAccount() {
         XXPortalUserDao userDao = Mockito.mock(XXPortalUserDao.class);
 
         XXPortalUser user = new XXPortalUser();
@@ -2426,27 +2426,27 @@ public class TestUserMgr {
         Mockito.when(daoManager.getXXPortalUser()).thenReturn(userDao);
         Mockito.when(userDao.findByLoginId(userLoginID)).thenReturn(user);
 
-        Assertions.assertFalse(userMgr.isUserDisabled(userLoginID));
+        Assertions.assertFalse(userMgr.isUserNotActive(userLoginID));
     }
 
     @Test
-    public void testIsUserDisabled_returnsFalseWhenNoLocalAccountExists() {
+    public void testIsUserNotActive_returnsFalseWhenNoLocalAccountExists() {
         XXPortalUserDao userDao = Mockito.mock(XXPortalUserDao.class);
 
         Mockito.when(daoManager.getXXPortalUser()).thenReturn(userDao);
         Mockito.when(userDao.findByLoginId(userLoginID)).thenReturn(null);
 
-        Assertions.assertFalse(userMgr.isUserDisabled(userLoginID));
+        Assertions.assertFalse(userMgr.isUserNotActive(userLoginID));
     }
 
     @Test
-    public void testIsUserDisabled_returnsFalseForBlankLoginId() {
-        Assertions.assertFalse(userMgr.isUserDisabled(""));
-        Assertions.assertFalse(userMgr.isUserDisabled(null));
+    public void testIsUserNotActive_returnsFalseForBlankLoginId() {
+        Assertions.assertFalse(userMgr.isUserNotActive(""));
+        Assertions.assertFalse(userMgr.isUserNotActive(null));
     }
 
     @Test
-    public void testIsUserDisabled_returnsTrueForDeactivatedLocalAccount() {
+    public void testIsUserNotActive_returnsTrueForDeactivatedLocalAccount() {
         XXPortalUserDao userDao = Mockito.mock(XXPortalUserDao.class);
 
         XXPortalUser user = new XXPortalUser();
@@ -2456,11 +2456,11 @@ public class TestUserMgr {
         Mockito.when(daoManager.getXXPortalUser()).thenReturn(userDao);
         Mockito.when(userDao.findByLoginId(userLoginID)).thenReturn(user);
 
-        Assertions.assertTrue(userMgr.isUserDisabled(userLoginID));
+        Assertions.assertTrue(userMgr.isUserNotActive(userLoginID));
     }
 
     @Test
-    public void testIsUserDisabled_returnsTrueForNonActiveLocalAccountStatuses() {
+    public void testIsUserNotActive_returnsTrueForNonActiveLocalAccountStatuses() {
         XXPortalUserDao userDao = Mockito.mock(XXPortalUserDao.class);
         int[] nonActiveStatuses = {
                 RangerCommonEnums.ACT_STATUS_PENDING_APPROVAL,
@@ -2475,7 +2475,7 @@ public class TestUserMgr {
             user.setLoginId(userLoginID);
             user.setStatus(status);
             Mockito.when(userDao.findByLoginId(userLoginID)).thenReturn(user);
-            Assertions.assertTrue(userMgr.isUserDisabled(userLoginID), "status " + status + " should be treated as not able to log in");
+            Assertions.assertTrue(userMgr.isUserNotActive(userLoginID), "status " + status + " should be treated as not able to log in");
         }
     }
 

--- a/security-admin/src/test/java/org/apache/ranger/biz/TestUserMgr.java
+++ b/security-admin/src/test/java/org/apache/ranger/biz/TestUserMgr.java
@@ -2401,6 +2401,50 @@ public class TestUserMgr {
         });
     }
 
+    @Test
+    public void testIsUserDisabled_returnsTrueForDisabledLocalAccount() {
+        XXPortalUserDao userDao = Mockito.mock(XXPortalUserDao.class);
+
+        XXPortalUser user = new XXPortalUser();
+        user.setLoginId(userLoginID);
+        user.setStatus(RangerCommonEnums.STATUS_DISABLED);
+
+        Mockito.when(daoManager.getXXPortalUser()).thenReturn(userDao);
+        Mockito.when(userDao.findByLoginId(userLoginID)).thenReturn(user);
+
+        Assertions.assertTrue(userMgr.isUserDisabled(userLoginID));
+    }
+
+    @Test
+    public void testIsUserDisabled_returnsFalseForEnabledLocalAccount() {
+        XXPortalUserDao userDao = Mockito.mock(XXPortalUserDao.class);
+
+        XXPortalUser user = new XXPortalUser();
+        user.setLoginId(userLoginID);
+        user.setStatus(RangerCommonEnums.STATUS_ENABLED);
+
+        Mockito.when(daoManager.getXXPortalUser()).thenReturn(userDao);
+        Mockito.when(userDao.findByLoginId(userLoginID)).thenReturn(user);
+
+        Assertions.assertFalse(userMgr.isUserDisabled(userLoginID));
+    }
+
+    @Test
+    public void testIsUserDisabled_returnsFalseWhenNoLocalAccountExists() {
+        XXPortalUserDao userDao = Mockito.mock(XXPortalUserDao.class);
+
+        Mockito.when(daoManager.getXXPortalUser()).thenReturn(userDao);
+        Mockito.when(userDao.findByLoginId(userLoginID)).thenReturn(null);
+
+        Assertions.assertFalse(userMgr.isUserDisabled(userLoginID));
+    }
+
+    @Test
+    public void testIsUserDisabled_returnsFalseForBlankLoginId() {
+        Assertions.assertFalse(userMgr.isUserDisabled(""));
+        Assertions.assertFalse(userMgr.isUserDisabled(null));
+    }
+
     private VXPortalUser userProfile() {
         VXPortalUser userProfile = new VXPortalUser();
         userProfile.setEmailAddress("test@test.com");

--- a/security-admin/src/test/java/org/apache/ranger/security/handler/TestRangerAuthenticationProvider.java
+++ b/security-admin/src/test/java/org/apache/ranger/security/handler/TestRangerAuthenticationProvider.java
@@ -295,10 +295,10 @@ public class TestRangerAuthenticationProvider {
     }
 
     @Test
-    public void checkAccountNotDisabled_throwsDisabledException_whenLocalAccountDisabled() throws Exception {
+    public void blockActiveUser() throws Exception {
         String username = "erin";
-        when(userMgr.isUserDisabled(username)).thenReturn(true);
-        Method m = provider.getClass().getDeclaredMethod("checkAccountNotDisabled", String.class);
+        when(userMgr.isUserNotActive(username)).thenReturn(true);
+        Method m = provider.getClass().getDeclaredMethod("blockNotActiveUser", String.class);
         m.setAccessible(true);
         Exception thrown = null;
         try {
@@ -306,15 +306,15 @@ public class TestRangerAuthenticationProvider {
         } catch (java.lang.reflect.InvocationTargetException e) {
             thrown = (Exception) e.getCause();
         }
-        assertNotNull(thrown, "expected checkAccountNotDisabled to reject a disabled account");
+        assertNotNull(thrown, "expected blockNotActiveUser to reject a disabled account");
         assertTrue(thrown instanceof DisabledException);
     }
 
     @Test
-    public void checkAccountNotDisabled_allowsLogin_whenLocalAccountEnabledOrUnknown() throws Exception {
+    public void blockEnabledOrUnknown() throws Exception {
         String username = "frank";
-        when(userMgr.isUserDisabled(username)).thenReturn(false);
-        Method m = provider.getClass().getDeclaredMethod("checkAccountNotDisabled", String.class);
+        when(userMgr.isUserNotActive(username)).thenReturn(false);
+        Method m = provider.getClass().getDeclaredMethod("blockNotActiveUser", String.class);
         m.setAccessible(true);
         // should not throw
         m.invoke(provider, username);
@@ -333,7 +333,7 @@ public class TestRangerAuthenticationProvider {
         adProvider.userMgr    = userMgr;
         adProvider.sessionMgr = sessionMgr;
         adProvider.setRangerAuthenticationMethod("ACTIVE_DIRECTORY");
-        when(userMgr.isUserDisabled(username)).thenReturn(true);
+        when(userMgr.isUserNotActive(username)).thenReturn(true);
         UsernamePasswordAuthenticationToken input = new UsernamePasswordAuthenticationToken(username, "pw");
         DisabledException thrown = assertThrows(DisabledException.class, () -> adProvider.authenticate(input));
         assertNotNull(thrown);

--- a/security-admin/src/test/java/org/apache/ranger/security/handler/TestRangerAuthenticationProvider.java
+++ b/security-admin/src/test/java/org/apache/ranger/security/handler/TestRangerAuthenticationProvider.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.DisabledException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
@@ -40,11 +41,13 @@ import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
@@ -289,6 +292,51 @@ public class TestRangerAuthenticationProvider {
 
         assertNotNull(result);
         assertTrue(result.isAuthenticated());
+    }
+
+    @Test
+    public void checkAccountNotDisabled_throwsDisabledException_whenLocalAccountDisabled() throws Exception {
+        String username = "erin";
+        when(userMgr.isUserDisabled(username)).thenReturn(true);
+        Method m = provider.getClass().getDeclaredMethod("checkAccountNotDisabled", String.class);
+        m.setAccessible(true);
+        Exception thrown = null;
+        try {
+            m.invoke(provider, username);
+        } catch (java.lang.reflect.InvocationTargetException e) {
+            thrown = (Exception) e.getCause();
+        }
+        assertNotNull(thrown, "expected checkAccountNotDisabled to reject a disabled account");
+        assertTrue(thrown instanceof DisabledException);
+    }
+
+    @Test
+    public void checkAccountNotDisabled_allowsLogin_whenLocalAccountEnabledOrUnknown() throws Exception {
+        String username = "frank";
+        when(userMgr.isUserDisabled(username)).thenReturn(false);
+        Method m = provider.getClass().getDeclaredMethod("checkAccountNotDisabled", String.class);
+        m.setAccessible(true);
+        // should not throw
+        m.invoke(provider, username);
+    }
+
+    @Test
+    public void authenticate_activeDirectory_rejectsDisabledLocalAccount_evenWithValidDirectoryCredentials() {
+        String username = "gina";
+        RangerAuthenticationProvider adProvider = new RangerAuthenticationProvider() {
+            @Override
+            public Authentication getADAuthentication(Authentication authentication) {
+                List<GrantedAuthority> auths = Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"));
+                return new UsernamePasswordAuthenticationToken(new User(username, "pw", auths), "pw", auths);
+            }
+        };
+        adProvider.userMgr    = userMgr;
+        adProvider.sessionMgr = sessionMgr;
+        adProvider.setRangerAuthenticationMethod("ACTIVE_DIRECTORY");
+        when(userMgr.isUserDisabled(username)).thenReturn(true);
+        UsernamePasswordAuthenticationToken input = new UsernamePasswordAuthenticationToken(username, "pw");
+        DisabledException thrown = assertThrows(DisabledException.class, () -> adProvider.authenticate(input));
+        assertNotNull(thrown);
     }
 
     private static void setPrivateField(Object target, String fieldName, Object value) throws Exception {


### PR DESCRIPTION


## What changes were proposed in this pull request?
When Ranger Admin is configured for LDAP or Active Directory authentication
(`ranger.authentication.method=LDAP` or `ACTIVE_DIRECTORY`), `RangerAuthenticationProvider`
did not check the local Ranger account's status after a successful directory bind. This meant
a user's local account status could be out of sync with their actual ability to sign in when
directory-based authentication was used, unlike local/JDBC authentication, which already
respects account status via the `STATUS` column read by the JDBC user-details query.

This change adds a status check, `UserMgr#isUserDisabled`, and calls it from
`RangerAuthenticationProvider#authenticate` right after each successful LDAP, LDAP-bind,
AD-bind, AD, PAM, and UNIX authentication branch, before the method returns — so a disabled
local account is rejected consistently across all supported authentication methods.


## How was this patch tested?
added new unit tests.
