### PR TITLE
RANGER-5756: Make J10056 skip automatic reactivation of disabled external users

### DIFF
--- a/security-admin/src/main/java/org/apache/ranger/patch/PatchForExternalUserStatusUpdate_J10056.java
+++ b/security-admin/src/main/java/org/apache/ranger/patch/PatchForExternalUserStatusUpdate_J10056.java
@@ -26,21 +26,13 @@ import org.apache.ranger.util.CLIUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.PlatformTransactionManager;
-import org.springframework.transaction.TransactionDefinition;
-import org.springframework.transaction.support.TransactionTemplate;
 
 import java.util.List;
 
 @Component
 public class PatchForExternalUserStatusUpdate_J10056 extends BaseLoader {
     private static final Logger logger = LoggerFactory.getLogger(PatchForExternalUserStatusUpdate_J10056.class);
-
-    @Autowired
-    @Qualifier(value = "transactionManager")
-    PlatformTransactionManager txManager;
 
     @Autowired
     private RangerDaoManager daoManager;
@@ -84,26 +76,17 @@ public class PatchForExternalUserStatusUpdate_J10056 extends BaseLoader {
         XXPortalUserDao    dao           = this.daoManager.getXXPortalUser();
         List<XXPortalUser> xXPortalUsers = dao.findByUserSourceAndStatus(RangerCommonEnums.USER_EXTERNAL, RangerCommonEnums.ACT_STATUS_DISABLED);
 
-        if (CollectionUtils.isNotEmpty(xXPortalUsers)) {
-            for (XXPortalUser xxPortalUser : xXPortalUsers) {
-                if (xxPortalUser != null) {
-                    xxPortalUser.setStatus(RangerCommonEnums.ACT_STATUS_ACTIVE);
+        if (CollectionUtils.isEmpty(xXPortalUsers)) {
+            return;
+        }
 
-                    TransactionTemplate txTemplate = new TransactionTemplate(txManager);
+        // Do not bulk-reactivate external disabled users. Disabled is a valid administrative state (see XUserREST.modifyUserActiveStatus),
+        // and this patch cannot distinguish accounts left disabled by an old usersync bug from accounts disabled on purpose.
+        logger.warn("updateExternalUserStatus(): Skipping automatic reactivation of {} external disabled user(s). Re-enable affected accounts explicitly via Ranger Admin if required.", xXPortalUsers.size());
 
-                    txTemplate.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
-
-                    try {
-                        txTemplate.execute(status -> {
-                            dao.update(xxPortalUser, true);
-
-                            return null;
-                        });
-                    } catch (Throwable ex) {
-                        logger.error("updateExternalUserStatus(): Failed to update DB for user: {}", xxPortalUser.getLoginId(), ex);
-                        throw new RuntimeException(ex);
-                    }
-                }
+        for (XXPortalUser xxPortalUser : xXPortalUsers) {
+            if (xxPortalUser != null) {
+                logger.warn("updateExternalUserStatus(): Left unchanged (loginId={})", xxPortalUser.getLoginId());
             }
         }
     }

--- a/security-admin/src/test/java/org/apache/ranger/patch/TestPatchForExternalUserStatusUpdate_J10056.java
+++ b/security-admin/src/test/java/org/apache/ranger/patch/TestPatchForExternalUserStatusUpdate_J10056.java
@@ -35,9 +35,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.transaction.PlatformTransactionManager;
-import org.springframework.transaction.TransactionDefinition;
-import org.springframework.transaction.support.SimpleTransactionStatus;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
@@ -74,10 +71,8 @@ public class TestPatchForExternalUserStatusUpdate_J10056 {
             Mockito.when(daoMgr.getXXPortalUser()).thenReturn(xxPortalUserDao);
             Mockito.when(xxPortalUserDao.findByUserSourceAndStatus(Mockito.anyInt(), Mockito.anyInt()))
                     .thenReturn(Collections.emptyList());
-            PlatformTransactionManager txManager = Mockito.mock(PlatformTransactionManager.class);
 
             setIfPresent(patch, "daoManager", daoMgr);
-            setIfPresent(patch, "txManager", txManager);
             setIfPresent(patch, "svcDBStore", svcStore);
             setIfPresent(patch, "jsonUtil", new JSONUtil());
             setIfPresent(patch, "policyService", Mockito.mock(RangerPolicyService.class));
@@ -91,61 +86,25 @@ public class TestPatchForExternalUserStatusUpdate_J10056 {
     }
 
     @Test
-    public void testExecLoad_UpdatesUsersViaTransaction() {
+    public void testExecLoad_DoesNotReactivateDisabledExternalUsers() {
         PatchForExternalUserStatusUpdate_J10056 patch = new PatchForExternalUserStatusUpdate_J10056();
 
         RangerDaoManager daoMgr = Mockito.mock(RangerDaoManager.class);
         XXPortalUserDao xxPortalUserDao = Mockito.mock(XXPortalUserDao.class);
         Mockito.when(daoMgr.getXXPortalUser()).thenReturn(xxPortalUserDao);
 
-        // One disabled external user
         XXPortalUser user = new XXPortalUser();
         user.setLoginId("u1");
         user.setStatus(RangerCommonEnums.ACT_STATUS_DISABLED);
         Mockito.when(xxPortalUserDao.findByUserSourceAndStatus(Mockito.anyInt(), Mockito.anyInt()))
                 .thenReturn(Collections.singletonList(user));
 
-        // Mock tx template execute path via PlatformTransactionManager
-        PlatformTransactionManager txManager = Mockito.mock(PlatformTransactionManager.class);
         setIfPresent(patch, "daoManager", daoMgr);
-        setIfPresent(patch, "txManager", txManager);
-        Mockito.when(txManager.getTransaction(Mockito.any(TransactionDefinition.class)))
-                .thenReturn(new SimpleTransactionStatus());
-
-        // Capture update invocation executed inside lambda
-        Mockito.doAnswer(inv -> null).when(xxPortalUserDao).update(Mockito.any(XXPortalUser.class), Mockito.eq(true));
 
         patch.execLoad();
 
-        // status should be set to ACTIVE before dao.update
-        Assertions.assertEquals(RangerCommonEnums.ACT_STATUS_ACTIVE, user.getStatus());
-        Mockito.verify(xxPortalUserDao, Mockito.times(1)).update(Mockito.any(XXPortalUser.class), Mockito.eq(true));
-    }
-
-    @Test
-    public void testExecLoad_TransactionThrowsRuntime() {
-        PatchForExternalUserStatusUpdate_J10056 patch = new PatchForExternalUserStatusUpdate_J10056();
-
-        RangerDaoManager daoMgr = Mockito.mock(RangerDaoManager.class);
-        XXPortalUserDao xxPortalUserDao = Mockito.mock(XXPortalUserDao.class);
-        Mockito.when(daoMgr.getXXPortalUser()).thenReturn(xxPortalUserDao);
-        XXPortalUser user = new XXPortalUser();
-        user.setLoginId("u2");
-        user.setStatus(RangerCommonEnums.ACT_STATUS_DISABLED);
-        Mockito.when(xxPortalUserDao.findByUserSourceAndStatus(Mockito.anyInt(), Mockito.anyInt()))
-                .thenReturn(Collections.singletonList(user));
-
-        PlatformTransactionManager txManager = Mockito.mock(PlatformTransactionManager.class);
-        setIfPresent(patch, "daoManager", daoMgr);
-        setIfPresent(patch, "txManager", txManager);
-        Mockito.when(txManager.getTransaction(Mockito.any(TransactionDefinition.class)))
-                .thenReturn(new SimpleTransactionStatus());
-
-        // Simulate dao.update throwing
-        Mockito.doThrow(new RuntimeException("db fail")).when(xxPortalUserDao).update(Mockito.any(XXPortalUser.class),
-                Mockito.eq(true));
-
-        Assertions.assertThrows(RuntimeException.class, patch::execLoad);
+        Assertions.assertEquals(RangerCommonEnums.ACT_STATUS_DISABLED, user.getStatus());
+        Mockito.verify(xxPortalUserDao, Mockito.never()).update(Mockito.any(XXPortalUser.class), Mockito.eq(true));
     }
 
     @Test
@@ -157,7 +116,6 @@ public class TestPatchForExternalUserStatusUpdate_J10056 {
         Mockito.when(xxPortalUserDao.findByUserSourceAndStatus(Mockito.anyInt(), Mockito.anyInt()))
                 .thenReturn(Collections.emptyList());
         setIfPresent(patch, "daoManager", daoMgr);
-        setIfPresent(patch, "txManager", Mockito.mock(PlatformTransactionManager.class));
 
         patch.execLoad();
 
@@ -177,7 +135,6 @@ public class TestPatchForExternalUserStatusUpdate_J10056 {
                     }
                 });
         setIfPresent(patch, "daoManager", daoMgr);
-        setIfPresent(patch, "txManager", Mockito.mock(PlatformTransactionManager.class));
 
         patch.execLoad();
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

J10056 previously set all external users in ACT_STATUS_DISABLED to active during upgrade. 
Disabled is a valid administrative state, and the patch cannot reliably tell which rows should be changed. 
Leave matching accounts unchanged and log them for operator review instead.


## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)
