### PR TITLE
RANGER-5762: Add `execute` access type to Trino service definition

### DIFF
--- a/agents-common/src/main/resources/service-defs/ranger-servicedef-trino.json
+++ b/agents-common/src/main/resources/service-defs/ranger-servicedef-trino.json
@@ -153,7 +153,7 @@
       "label":          "Schema Function",
       "description":    "Schema Function",
       "accessTypeRestrictions": [
-        "create", "drop", "show"
+        "create", "drop", "execute", "show"
       ]
     },
     {


### PR DESCRIPTION
## What changes were proposed in this pull request?
In Trino, the `EXECUTE` access type is checked when validating the permission for Schema Function, but that permission is not available via the service definition.

```
@Override
public boolean canExecuteFunction(SystemSecurityContext context, CatalogSchemaRoutineName functionName)
{
    return hasPermission(
        RangerTrinoResource.forSchemaFunction(
            functionName.getCatalogName(),
            functionName.getSchemaRoutineName().getSchemaName(),
            functionName.getSchemaRoutineName().getRoutineName()),
        context,
        EXECUTE,
        "ExecuteFunction");
}
```
_Source: https://github.com/trinodb/trino/blob/master/plugin/trino-ranger/src/main/java/io/trino/plugin/ranger/RangerSystemAccessControl.java#L791_

This PR adds the `execute` access type to fix this.

## How was this patch tested?
* Running Trino, executing a schema function (in my case any ai function: https://trino.io/docs/current/functions/ai.html)
* The function invocation in Trino throws a PERMISSION DENIED
* Delete the service definition for Trino in Ranger
* Upload the new service definition in Ranger
* Restart Ranger
* Add new Trino service to Ranger
* Add new policy for Catalog, Schema, Schema Function with `execute` permission
* The function invocation in Trino returns the right result 