### PR TITLE
RANGER-5760 : [UI] Handle duplicate additional service configurations keys in service definition

### DIFF
--- a/security-admin/src/main/webapp/react-webapp/src/views/ServiceManager/ServiceForm.jsx
+++ b/security-admin/src/main/webapp/react-webapp/src/views/ServiceManager/ServiceForm.jsx
@@ -63,7 +63,8 @@ import {
   cloneDeep,
   intersection,
   join,
-  sortBy
+  sortBy,
+  includes
 } from "lodash";
 import withRouter from "Hooks/withRouter";
 import { RangerPolicyType } from "Utils/XAEnums";
@@ -402,7 +403,13 @@ class ServiceForm extends Component {
 
     serviceJson["configs"] = {};
 
-    let serviceDefConfigs = map(this.state?.serviceDef?.configs, "name");
+    const excludedServiceConfig = map(additionalServiceConfigs, "name");
+    let serviceDefConfigs = map(
+      reject(this.state?.serviceDef?.configs, (config) =>
+        includes(excludedServiceConfig, config.name)
+      ),
+      "name"
+    );
     let serviceCustomConfigs = without(
       difference(keys(serviceResp?.data?.configs), serviceDefConfigs),
       "ranger.plugin.audit.filters"
@@ -726,9 +733,13 @@ class ServiceForm extends Component {
   getServiceConfigs = (serviceDef) => {
     if (serviceDef?.configs !== undefined) {
       let formField = [];
-      const filterServiceConfigs = reject(serviceDef.configs, {
-        name: "ranger.plugin.audit.filters"
-      });
+      const configNamesToExclude = [
+        "ranger.plugin.audit.filters",
+        ...map(additionalServiceConfigs, "name")
+      ];
+      const filterServiceConfigs = reject(serviceDef.configs, (config) =>
+        includes(configNamesToExclude, config.name)
+      );
       filterServiceConfigs.map((configParam) => {
         this.configsJson[configParam.name] = configParam.name
           .replaceAll(".", "_")

--- a/security-admin/src/main/webapp/react-webapp/src/views/ServiceManager/ServiceViewDetails.jsx
+++ b/security-admin/src/main/webapp/react-webapp/src/views/ServiceManager/ServiceViewDetails.jsx
@@ -29,7 +29,9 @@ import {
   pick,
   intersection,
   find,
-  sortBy
+  sortBy,
+  reject,
+  includes
 } from "lodash";
 import { ModalLoader } from "Components/CommonComponents";
 import { additionalServiceConfigs } from "Utils/XAEnums";
@@ -78,8 +80,13 @@ export const ServiceViewDetails = (props) => {
     let configs = {};
     let customConfigs = {};
 
-    let serviceDefConfigs = serviceDef?.configs?.filter(
-      (config) => config.name !== "ranger.plugin.audit.filters"
+    const excludedServiceConfig = [
+      "ranger.plugin.audit.filters",
+      ...map(additionalServiceConfigs, "name")
+    ];
+
+    let serviceDefConfigs = reject(serviceDef?.configs, (config) =>
+      includes(excludedServiceConfig, config.name)
     );
 
     serviceConfigs = omit(serviceConfigs, "ranger.plugin.audit.filters");


### PR DESCRIPTION
## What changes were proposed in this pull request?
This Jira was created to handle duplicate service configuration entries on the frontend. On the UI side, we will ensure duplicate entries are filtered out and not populated in the service configuration form.


## How was this patch tested?
1. Built and restarted Ranger Admin with the updated Trino service definition.
2. Verified on the UI that Trino service creation/edit forms render `Superusers`, `Superuser groups`, `Service admin users`, and `Service admin usergroups` only once.
3. Created and updated a Trino service instance and verified that the backend receives valid configuration payloads and persists correct values in the database.
