### PR TITLE
RANGER-5763: Fix NPE in HBase plugin snapshot hooks when table descriptor is null

### DIFF
--- a/hbase-agent/src/main/java/org/apache/ranger/authorization/hbase/RangerAuthorizationCoprocessor.java
+++ b/hbase-agent/src/main/java/org/apache/ranger/authorization/hbase/RangerAuthorizationCoprocessor.java
@@ -319,16 +319,31 @@ public class RangerAuthorizationCoprocessor implements AccessControlService.Inte
 
     @Override
     public void preSnapshot(ObserverContext<MasterCoprocessorEnvironment> ctx, SnapshotDescription snapshot, TableDescriptor hTableDescriptor) throws IOException {
+        if (hTableDescriptor == null) {
+            // HBase can call this hook with a null table descriptor when the table does not exist (HBASE-29361); the operation fails in HBase anyway
+            return;
+        }
+
         requirePermission(ctx, "snapshot", hTableDescriptor.getTableName().getName(), Permission.Action.ADMIN);
     }
 
     @Override
     public void preCloneSnapshot(ObserverContext<MasterCoprocessorEnvironment> ctx, SnapshotDescription snapshot, TableDescriptor hTableDescriptor) throws IOException {
+        if (hTableDescriptor == null) {
+            // HBase can call this hook with a null table descriptor when the table does not exist (HBASE-29361); the operation fails in HBase anyway
+            return;
+        }
+
         requirePermission(ctx, "cloneSnapshot", hTableDescriptor.getTableName().getName(), Permission.Action.ADMIN);
     }
 
     @Override
     public void preRestoreSnapshot(ObserverContext<MasterCoprocessorEnvironment> ctx, SnapshotDescription snapshot, TableDescriptor hTableDescriptor) throws IOException {
+        if (hTableDescriptor == null) {
+            // HBase can call this hook with a null table descriptor when the table does not exist (HBASE-29361); the operation fails in HBase anyway
+            return;
+        }
+
         requirePermission(ctx, "restoreSnapshot", hTableDescriptor.getTableName().getName(), Permission.Action.ADMIN);
     }
 

--- a/hbase-agent/src/test/java/org/apache/ranger/authorization/hbase/RangerAuthorizationCoprocessorTest.java
+++ b/hbase-agent/src/test/java/org/apache/ranger/authorization/hbase/RangerAuthorizationCoprocessorTest.java
@@ -45,7 +45,9 @@ import org.apache.hadoop.hbase.client.RegionInfo;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.client.SnapshotDescription;
+import org.apache.hadoop.hbase.client.SnapshotType;
 import org.apache.hadoop.hbase.client.TableDescriptor;
+import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
 import org.apache.hadoop.hbase.coprocessor.MasterCoprocessorEnvironment;
 import org.apache.hadoop.hbase.coprocessor.ObserverContext;
 import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
@@ -127,6 +129,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -2877,5 +2880,31 @@ public class RangerAuthorizationCoprocessorTest {
 
         // cleanup
         pf.set(null, null);
+    }
+
+    @Test
+    public void test116_preSnapshotHooks_skipPermissionCheckWhenTableDescriptorNull() throws Exception {
+        RangerAuthorizationCoprocessor cp = spy(new RangerAuthorizationCoprocessor());
+        ObserverContext<MasterCoprocessorEnvironment> ctx = mock(ObserverContext.class);
+        SnapshotDescription snapshot = new SnapshotDescription("snap", TableName.valueOf("nonexistent"), SnapshotType.FLUSH);
+
+        cp.preSnapshot(ctx, snapshot, null);
+        cp.preCloneSnapshot(ctx, snapshot, null);
+        cp.preRestoreSnapshot(ctx, snapshot, null);
+
+        verify(cp, never()).requirePermission(any(ObserverContext.class), anyString(), any(byte[].class), any(Permission.Action.class));
+    }
+
+    @Test
+    public void test117_preSnapshotHooks_checkPermissionWhenTableDescriptorPresent() throws Exception {
+        RangerAuthorizationCoprocessor cp = spy(new RangerAuthorizationCoprocessor());
+        doNothing().when(cp).requirePermission(any(ObserverContext.class), anyString(), any(byte[].class), any(Permission.Action.class));
+        ObserverContext<MasterCoprocessorEnvironment> ctx = mock(ObserverContext.class);
+        SnapshotDescription snapshot = new SnapshotDescription("snap", TableName.valueOf("t"), SnapshotType.FLUSH);
+        TableDescriptor tableDescriptor = TableDescriptorBuilder.newBuilder(TableName.valueOf("t")).build();
+
+        cp.preSnapshot(ctx, snapshot, tableDescriptor);
+
+        verify(cp).requirePermission(any(ObserverContext.class), eq("snapshot"), any(byte[].class), any(Permission.Action.class));
     }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

HBase 2.6.3/2.6.4 call the preSnapshot coprocessor hook with a null TableDescriptor when the table does not exist: HBASE-29361 moved the snapshot hooks ahead of the table-existence check and passes the descriptor from getTableDescriptors().get() without a null check. RangerAuthorizationCoprocessor dereferences the descriptor in preSnapshot/preCloneSnapshot/preRestoreSnapshot, so taking a snapshot of a non-existent table throws an NPE inside the coprocessor, and with hbase.coprocessor.abortonerror defaulting to true the HMaster aborts.

HBase corrected the ordering in HBASE-29955 (2.6.5); this change makes the plugin tolerate a null descriptor: the permission check is skipped when the descriptor is null, and the operation is rejected by HBase itself.

## How was this patch tested?

Unit tests added to RangerAuthorizationCoprocessorTest: the snapshot hooks skip the permission check when the table descriptor is null and run it when the descriptor is present. The failure mode was observed on a cluster running HBase 2.6.3 with the ranger hbase plugin.