### PR TITLE
RANGER-5764:Enhancing RangerUserStore to include or exclude user group mappings 

### DIFF
--- a/security-admin/src/main/java/org/apache/ranger/common/RangerUserStoreCache.java
+++ b/security-admin/src/main/java/org/apache/ranger/common/RangerUserStoreCache.java
@@ -27,6 +27,7 @@ import org.apache.ranger.plugin.util.RangerUserStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -42,6 +43,7 @@ public class RangerUserStoreCache {
 
     private final int             waitTimeInSeconds;
     private final boolean         dedupStrings;
+    private final boolean         includeUserGroupMappings;
     private final ReentrantLock   lock = new ReentrantLock();
     private       RangerUserStore rangerUserStore;
 
@@ -49,6 +51,7 @@ public class RangerUserStoreCache {
         RangerAdminConfig config = RangerAdminConfig.getInstance();
 
         this.waitTimeInSeconds = config.getInt("ranger.admin.userstore.download.cache.max.waittime.for.update", MAX_WAIT_TIME_FOR_UPDATE);
+        this.includeUserGroupMappings = config.getBoolean("ranger.admin.userstore.include.usergroups.mappings", false);
         this.dedupStrings      = config.getBoolean("ranger.admin.userstore.dedup.strings", Boolean.TRUE);
         this.rangerUserStore   = new RangerUserStore();
     }
@@ -93,7 +96,7 @@ public class RangerUserStoreCache {
                     final long                     startTimeMs      = System.currentTimeMillis();
                     final Set<UserInfo>            rangerUsersInDB  = xUserMgr.getUsers();
                     final Set<GroupInfo>           rangerGroupsInDB = xUserMgr.getGroups();
-                    final Map<String, Set<String>> userGroups       = xUserMgr.getUserGroups();
+                    final Map<String, Set<String>> userGroups       = includeUserGroupMappings ? xUserMgr.getUserGroups() : new HashMap<>();
                     final long                     dbLoadTime       = System.currentTimeMillis() - startTimeMs;
 
                     if (LOG.isDebugEnabled()) {

--- a/security-admin/src/main/resources/conf.dist/ranger-admin-site.xml
+++ b/security-admin/src/main/resources/conf.dist/ranger-admin-site.xml
@@ -379,6 +379,16 @@
 		<name>ranger.downloadpolicy.session.log.enabled</name>
 		<value>false</value>
 	</property>
+	<!-- User-store download Properties starts-->
+	<property>
+		<name>ranger.admin.userstore.include.usergroups.mappings</name>
+		<value>false</value>
+		<description>
+			When set to true, the user-store download API includes the user-to-group mappings (userGroupMapping) in the response payload,
+		</description>
+	</property>
+	<!-- User-store download Properties ends-->
+
 	<!-- Service user for KMS -->
     <property>
     	<name>ranger.kms.service.user.hdfs</name>


### PR DESCRIPTION


## What changes were proposed in this pull request?

1>Currently, when RangerUserStoreCache refreshes the user store from the database, it always attempts to load user-to-group mappings. In large deployments with a high number of users and groups, loading these mappings on every refresh can significantly increase  overhead . 

2>I have made it to flag based approach , if flag is set to true then the mappings to the plugins will be provided by the UserStore download apis else not . 

3>The major cause of performance bottleneck was final Map<String, Set<String>> userGroups    = xUserMgr.getUserGroups();
which has been changed to  
final Map<String, Set<String>> userGroups       = downloadUserGroupsEnabled ? xUserMgr.getUserGroups() : new HashMap<>();
so based on the requirements we can download or skip user-group mappings in UserStore for Plugins 


## How was this patch tested?

1>For performance testing this patch was tested for 1 million users and .5 million groups where every 2 user was mapped to one group creating .5 million mappings 
2>mvn clean test and mvn clean install were performed locally 
