### PR TITLE
RANGER-5766: Add support for SPIFFE Ids as usernames in Ranger

### DIFF
--- a/common-utils/src/main/java/org/apache/ranger/plugin/util/SpiffeIdUtil.java
+++ b/common-utils/src/main/java/org/apache/ranger/plugin/util/SpiffeIdUtil.java
@@ -28,33 +28,34 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * Helper for validating a SPIFFE ID and extracting the service-account identity from it.
+ * Helper for validating a SPIFFE ID that is used as a service identity.
  *
- * <p>A SPIFFE ID is expected in the exact form {@code spiffe://<trust-domain>/ns/<namespace>/sa/<service-account>};
- * for service-to-service authentication the receiving server trusts the workload
- * identity carried in a header (e.g. {@code x-service-spiffe-id}) and uses
- * the trailing service-account segment as the authenticated principal.
+ * <p>A SPIFFE ID is expected in the general form defined by the SPIFFE-ID specification,
+ * {@code spiffe://<trust-domain>/<path>}, where {@code <path>} is one or more {@code /}-separated
+ * segments. For service-to-service authentication the receiving server trusts the workload identity
+ * carried in a header (e.g. {@code x-service-spiffe-id}) and uses the SPIFFE ID itself as the
+ * authenticated principal. No particular path layout (such as the SPIRE {@code /ns/<namespace>/sa/<service-account>}
+ * convention) is required.
  */
 public final class SpiffeIdUtil {
     private static final String  HEADER_NAMES_SEP  = ",";
 
     /**
-     * Matches {@code spiffe://<trust-domain>/ns/<namespace>/sa/<service-account>} using the character
-     * sets from the SPIFFE-ID specification:
+     * Matches {@code spiffe://<trust-domain>/<path>} using the character sets from the SPIFFE-ID
+     * specification:
      * <ul>
      *   <li>trust-domain: lowercase letters, digits, {@code .}, {@code -}, {@code _} (the spec requires
      *       the trust domain to be lowercase);
-     *   <li>namespace and service-account: ASCII letters (any case), digits, {@code .}, {@code -}, {@code _}
-     *       (SPIFFE path segments are case-sensitive).
+     *   <li>path: one or more {@code /}-separated segments of ASCII letters (any case), digits,
+     *       {@code .}, {@code -}, {@code _} (SPIFFE path segments are case-sensitive).
      * </ul>
-     * All segments must be non-empty. This is an allow-list of safe characters, so whitespace, control
-     * characters and {@code /} are excluded, keeping the extracted principal well-formed. Per the spec,
-     * the namespace and service-account path segments must not be the relative modifiers {@code .} or
-     * {@code ..} (enforced by the leading negative look-aheads). The service-account is exposed via the
-     * named group {@code sa}.
+     * At least one path segment is required and every segment must be non-empty. This is an allow-list
+     * of safe characters, so whitespace and control characters are excluded, keeping the principal
+     * well-formed. Per the spec, no path segment may be the relative modifier {@code .} or {@code ..}
+     * (enforced by the per-segment negative look-ahead).
      */
     private static final Pattern SPIFFE_ID_PATTERN = Pattern.compile(
-            "^spiffe://[a-z0-9._-]+/ns/(?!\\.{1,2}/)[A-Za-z0-9._-]+/sa/(?<sa>(?!\\.{1,2}$)[A-Za-z0-9._-]+)$");
+            "^spiffe://[a-z0-9._-]+(?:/(?!\\.{1,2}(?:/|$))[A-Za-z0-9._-]+)+$");
 
     private SpiffeIdUtil() {
         // to block instantiation
@@ -97,25 +98,10 @@ public final class SpiffeIdUtil {
     }
 
     /**
-     * Extracts the service-account name from a SPIFFE ID such as
-     * {@code spiffe://my-cluster/ns/service-namespace/sa/service-sa}. The value must match the exact
-     * SPIFFE ID format (see {@link #isValidSpiffeId(String)}); otherwise {@code null} is returned.
-     *
-     * @param spiffeId the raw SPIFFE ID value from the request header
-     * @return the service-account segment (e.g. {@code service-sa}), or
-     *         {@code null} if the input is blank or not a well-formed SPIFFE ID
-     */
-    public static String extractServiceAccount(String spiffeId) {
-        Matcher matcher = matchSpiffeId(spiffeId);
-
-        return matcher != null ? matcher.group("sa") : null;
-    }
-
-    /**
      * Matches the given value against the expected SPIFFE ID format, computing the {@link Matcher} once.
      *
      * @param spiffeId the raw SPIFFE ID value from the request header
-     * @return a matched {@link Matcher} (with groups available) if the value is a well-formed SPIFFE ID;
+     * @return a matched {@link Matcher} if the value is a well-formed SPIFFE ID;
      *         {@code null} if the value is blank or does not match
      */
     private static Matcher matchSpiffeId(String spiffeId) {

--- a/common-utils/src/test/java/org/apache/ranger/plugin/util/SpiffeIdUtilTest.java
+++ b/common-utils/src/test/java/org/apache/ranger/plugin/util/SpiffeIdUtilTest.java
@@ -25,7 +25,6 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class SpiffeIdUtilTest {
@@ -44,14 +43,12 @@ class SpiffeIdUtilTest {
         assertFalse(SpiffeIdUtil.isValidSpiffeId("   "));
         assertFalse(SpiffeIdUtil.isValidSpiffeId("not-a-spiffe-id"));
         assertFalse(SpiffeIdUtil.isValidSpiffeId("https://my-cluster/ns/n/sa/s"));   // wrong scheme
-        assertFalse(SpiffeIdUtil.isValidSpiffeId("spiffe://my-cluster/sa/service-sa")); // missing /ns/
-        assertFalse(SpiffeIdUtil.isValidSpiffeId("spiffe://my-cluster/ns/n"));       // missing /sa/
-        assertFalse(SpiffeIdUtil.isValidSpiffeId("spiffe://my-cluster/ns//sa/s"));   // empty namespace
+        assertFalse(SpiffeIdUtil.isValidSpiffeId("spiffe://my-cluster"));            // trust domain only, no path
+        assertFalse(SpiffeIdUtil.isValidSpiffeId("spiffe://my-cluster/"));           // trailing slash, empty path
+        assertFalse(SpiffeIdUtil.isValidSpiffeId("spiffe://my-cluster/ns//sa/s"));   // empty path segment
         assertFalse(SpiffeIdUtil.isValidSpiffeId("spiffe:///ns/n/sa/s"));            // empty trust domain
-        assertFalse(SpiffeIdUtil.isValidSpiffeId("spiffe://my-cluster/ns/n/sa/"));   // empty service account
+        assertFalse(SpiffeIdUtil.isValidSpiffeId("spiffe://my-cluster/ns/n/sa/"));   // empty trailing segment
         assertFalse(SpiffeIdUtil.isValidSpiffeId(VALID + "/"));                      // trailing slash
-        assertFalse(SpiffeIdUtil.isValidSpiffeId(VALID + "/extra"));                 // extra segment
-        assertFalse(SpiffeIdUtil.isValidSpiffeId("spiffe://my-cluster/sa/s/ns/n"));  // wrong order
     }
 
     @Test
@@ -61,9 +58,6 @@ class SpiffeIdUtilTest {
         assertFalse(SpiffeIdUtil.isValidSpiffeId("spiffe://my-cluster/ns/prod/sa/service\nsa"));  // embedded newline
         assertFalse(SpiffeIdUtil.isValidSpiffeId("spiffe://my-cluster/ns/prod/sa/svc@admin"));    // illegal char '@'
         assertFalse(SpiffeIdUtil.isValidSpiffeId("spiffe://My-Cluster/ns/prod/sa/service-sa"));   // trust domain must be lowercase per spec
-
-        assertNull(SpiffeIdUtil.extractServiceAccount("spiffe://my-cluster/ns/prod/sa/service sa"));
-        assertNull(SpiffeIdUtil.extractServiceAccount("spiffe://my-cluster/ns/prod/sa/service\nsa"));
     }
 
     @Test
@@ -74,73 +68,47 @@ class SpiffeIdUtilTest {
         assertFalse(SpiffeIdUtil.isValidSpiffeId("spiffe://my-cluster/ns/prod/sa/."));         // service-account '.'
         assertFalse(SpiffeIdUtil.isValidSpiffeId("spiffe://my-cluster/ns/prod/sa/.."));        // service-account '..'
 
-        assertNull(SpiffeIdUtil.extractServiceAccount("spiffe://my-cluster/ns/prod/sa/."));
-        assertNull(SpiffeIdUtil.extractServiceAccount("spiffe://my-cluster/ns/../sa/service-sa"));
-
         // Dots inside a segment (not a bare '.'/'..') remain valid.
         assertTrue(SpiffeIdUtil.isValidSpiffeId("spiffe://my-cluster/ns/prod/sa/svc.v1"));
-        assertEquals("svc.v1", SpiffeIdUtil.extractServiceAccount("spiffe://my-cluster/ns/..prod/sa/svc.v1"));
+        assertTrue(SpiffeIdUtil.isValidSpiffeId("spiffe://my-cluster/ns/..prod/sa/svc.v1"));
     }
 
     @Test
     void isValidSpiffeId_acceptsSpecAllowedCharacters() {
         // SPIFFE path segments are case-sensitive and allow letters (any case), digits, '.', '-', '_'.
         assertTrue(SpiffeIdUtil.isValidSpiffeId("spiffe://my-cluster.example.com/ns/service-namespace/sa/service-sa"));
-        assertEquals("Service-SA", SpiffeIdUtil.extractServiceAccount("spiffe://my-cluster/ns/Prod/sa/Service-SA")); // mixed case
-        assertEquals("svc_01", SpiffeIdUtil.extractServiceAccount("spiffe://cluster1/ns/ns_2/sa/svc_01"));           // underscore
-        assertEquals("svc-01", SpiffeIdUtil.extractServiceAccount("spiffe://cluster1/ns/ns-2/sa/svc-01"));           // hyphen/digits
+        assertTrue(SpiffeIdUtil.isValidSpiffeId("spiffe://my-cluster/ns/Prod/sa/Service-SA")); // mixed case
+        assertTrue(SpiffeIdUtil.isValidSpiffeId("spiffe://cluster1/ns/ns_2/sa/svc_01"));       // underscore
+        assertTrue(SpiffeIdUtil.isValidSpiffeId("spiffe://cluster1/ns/ns-2/sa/svc-01"));       // hyphen/digits
     }
 
     @Test
-    void extractServiceAccount_returnsSaOnlyForValidId() {
-        assertEquals("service-sa", SpiffeIdUtil.extractServiceAccount(VALID));
-        assertEquals("service-sa", SpiffeIdUtil.extractServiceAccount("  " + VALID + "  "));
-    }
-
-    @Test
-    void extractServiceAccount_returnsNullForMalformedId() {
-        assertNull(SpiffeIdUtil.extractServiceAccount(null));
-        assertNull(SpiffeIdUtil.extractServiceAccount(""));
-        assertNull(SpiffeIdUtil.extractServiceAccount("not-a-spiffe-id"));
-        assertNull(SpiffeIdUtil.extractServiceAccount("spiffe://my-cluster/sa/service-sa"));
-        assertNull(SpiffeIdUtil.extractServiceAccount("spiffe://my-cluster/ns/n/sa/"));
-        assertNull(SpiffeIdUtil.extractServiceAccount(VALID + "/extra"));
-    }
-
-    @Test
-    void extractServiceAccount_handlesRealisticProductionIds() {
+    void isValidSpiffeId_handlesRealisticProductionIds() {
         // Kubernetes trust domain with a DNS-style cluster name and typical namespace/service-account names.
-        assertEquals("nginx-ingress",
-                SpiffeIdUtil.extractServiceAccount("spiffe://prod-cluster.k8s.example.com/ns/ingress-nginx/sa/nginx-ingress"));
+        assertTrue(SpiffeIdUtil.isValidSpiffeId("spiffe://prod-cluster.k8s.example.com/ns/ingress-nginx/sa/nginx-ingress"));
 
         // Cloud/mesh style trust domain (e.g. the header value from the PR description).
-        assertEquals("service-sa",
-                SpiffeIdUtil.extractServiceAccount("spiffe://my-cluster/ns/service-namespace/sa/service-sa"));
+        assertTrue(SpiffeIdUtil.isValidSpiffeId("spiffe://my-cluster/ns/service-namespace/sa/service-sa"));
 
         // Istio-style default service account in an application namespace.
-        assertEquals("default",
-                SpiffeIdUtil.extractServiceAccount("spiffe://cluster.local/ns/payments/sa/default"));
+        assertTrue(SpiffeIdUtil.isValidSpiffeId("spiffe://cluster.local/ns/payments/sa/default"));
 
         // Namespace and service-account with digits and hyphens, as commonly generated by platforms.
-        assertEquals("spark-driver-01",
-                SpiffeIdUtil.extractServiceAccount("spiffe://data-plane.internal/ns/team-analytics-42/sa/spark-driver-01"));
-
-        assertTrue(SpiffeIdUtil.isValidSpiffeId("spiffe://prod-cluster.k8s.example.com/ns/ingress-nginx/sa/nginx-ingress"));
-        assertTrue(SpiffeIdUtil.isValidSpiffeId("spiffe://cluster.local/ns/payments/sa/default"));
+        assertTrue(SpiffeIdUtil.isValidSpiffeId("spiffe://data-plane.internal/ns/team-analytics-42/sa/spark-driver-01"));
     }
 
     @Test
-    void rejectsSpecValidButNonConformingSpiffeId() {
-        // These are well-formed SPIFFE IDs per the SPIFFE spec (valid scheme + trust domain + path),
-        // but they do not follow the expected spiffe://<trust-domain>/ns/<namespace>/sa/<service-account>
-        // layout, so Ranger must reject them.
-        String workloadPath = "spiffe://example.org/workload/frontend"; // arbitrary path, no /ns//sa/
-        String nsOnly       = "spiffe://example.org/ns/prod";           // has /ns/ but no /sa/ segment
-
-        assertFalse(SpiffeIdUtil.isValidSpiffeId(workloadPath));
-        assertFalse(SpiffeIdUtil.isValidSpiffeId(nsOnly));
-        assertNull(SpiffeIdUtil.extractServiceAccount(workloadPath));
-        assertNull(SpiffeIdUtil.extractServiceAccount(nsOnly));
+    void acceptsSpecValidNonSpireLayoutSpiffeId() {
+        // Well-formed SPIFFE IDs per the spec (valid scheme + trust domain + one or more path segments)
+        // that do not follow the SPIRE spiffe://<trust-domain>/ns/<namespace>/sa/<service-account>
+        // convention. Since the full SPIFFE ID is used as the principal, these must be accepted.
+        assertTrue(SpiffeIdUtil.isValidSpiffeId("spiffe://example.org/workload/frontend")); // arbitrary path
+        assertTrue(SpiffeIdUtil.isValidSpiffeId("spiffe://example.org/ns/prod"));           // /ns/ but no /sa/
+        assertTrue(SpiffeIdUtil.isValidSpiffeId("spiffe://my-cluster/sa/service-sa"));      // /sa/ but no /ns/
+        assertTrue(SpiffeIdUtil.isValidSpiffeId("spiffe://my-cluster/ns/n"));               // single-segment style
+        assertTrue(SpiffeIdUtil.isValidSpiffeId("spiffe://example.org/single"));            // single path segment
+        assertTrue(SpiffeIdUtil.isValidSpiffeId("spiffe://my-cluster/sa/s/ns/n"));          // segments in any order
+        assertTrue(SpiffeIdUtil.isValidSpiffeId(VALID + "/extra"));                         // additional trailing segment
     }
 
     @Test

--- a/pdp/conf.dist/ranger-pdp-site.xml
+++ b/pdp/conf.dist/ranger-pdp-site.xml
@@ -149,7 +149,7 @@
   <property>
     <name>ranger.pdp.authn.header.spiffe</name>
     <value></value>
-    <description>Comma-separated list of HTTP header name(s) carrying a SPIFFE ID (e.g. spiffe://cluster/ns/&lt;ns&gt;/sa/&lt;service-account&gt;). A single header name is also valid. The trailing service-account segment is used as the authenticated principal. When multiple headers are configured, the first one carrying a well-formed SPIFFE ID is used. Consulted only when the username header is absent.</description>
+    <description>Comma-separated list of HTTP header name(s) carrying a SPIFFE ID (e.g. spiffe://cluster/ns/&lt;ns&gt;/sa/&lt;service-account&gt;). A single header name is also valid. The full SPIFFE ID is used as the authenticated principal. When multiple headers are configured, the first one carrying a well-formed SPIFFE ID is used. Consulted only when the username header is absent.</description>
   </property>
 
   <!-- JWT bearer token authentication for incoming REST requests -->

--- a/pdp/src/main/java/org/apache/ranger/pdp/security/HttpHeaderAuthNHandler.java
+++ b/pdp/src/main/java/org/apache/ranger/pdp/security/HttpHeaderAuthNHandler.java
@@ -71,13 +71,12 @@ public class HttpHeaderAuthNHandler implements PdpAuthNHandler {
         }
 
         for (String spiffeHeader : spiffeHeaders) {
-            String spiffeId       = request.getHeader(spiffeHeader);
-            String serviceAccount = SpiffeIdUtil.extractServiceAccount(spiffeId);
+            String spiffeId = StringUtils.trimToNull(request.getHeader(spiffeHeader));
 
-            if (StringUtils.isNotBlank(serviceAccount)) {
-                LOG.debug("authenticate(): service-account={} (from SPIFFE header {})", serviceAccount, spiffeHeader);
+            if (SpiffeIdUtil.isValidSpiffeId(spiffeId)) {
+                LOG.debug("authenticate(): spiffeId={} (from SPIFFE header {})", spiffeId, spiffeHeader);
 
-                return Result.authenticated(serviceAccount, AUTH_TYPE_SPIFFE);
+                return Result.authenticated(spiffeId, AUTH_TYPE_SPIFFE);
             } else if (StringUtils.isNotBlank(spiffeId)) {
                 LOG.warn("SPIFFE header '{}' value is not a well-formed SPIFFE ID", spiffeHeader);
             }

--- a/pdp/src/main/resources/ranger-pdp-default.xml
+++ b/pdp/src/main/resources/ranger-pdp-default.xml
@@ -149,7 +149,7 @@
   <property>
     <name>ranger.pdp.authn.header.spiffe</name>
     <value></value>
-    <description>Comma-separated list of HTTP header name(s) carrying a SPIFFE ID (e.g. spiffe://cluster/ns/&lt;ns&gt;/sa/&lt;service-account&gt;). A single header name is also valid. The trailing service-account segment is used as the authenticated principal. When multiple headers are configured, the first one carrying a well-formed SPIFFE ID is used. Consulted only when the username header is absent.</description>
+    <description>Comma-separated list of HTTP header name(s) carrying a SPIFFE ID (e.g. spiffe://cluster/ns/&lt;ns&gt;/sa/&lt;service-account&gt;). A single header name is also valid. The full SPIFFE ID is used as the authenticated principal. When multiple headers are configured, the first one carrying a well-formed SPIFFE ID is used. Consulted only when the username header is absent.</description>
   </property>
 
   <!-- JWT bearer token authentication for incoming REST requests -->

--- a/pdp/src/test/java/org/apache/ranger/pdp/security/HttpHeaderAuthNHandlerTest.java
+++ b/pdp/src/test/java/org/apache/ranger/pdp/security/HttpHeaderAuthNHandlerTest.java
@@ -77,11 +77,12 @@ public class HttpHeaderAuthNHandlerTest {
         handler.init(config);
 
         // Realistic production SPIFFE ID: DNS-style Kubernetes cluster trust domain + namespace/service-account.
-        HttpServletRequest     request = requestWithHeader("X-Spiffe-Id", "spiffe://prod-cluster.k8s.example.com/ns/ingress-nginx/sa/nginx-ingress");
-        PdpAuthNHandler.Result result  = handler.authenticate(request, null);
+        String                 spiffeId = "spiffe://prod-cluster.k8s.example.com/ns/ingress-nginx/sa/nginx-ingress";
+        HttpServletRequest     request  = requestWithHeader("X-Spiffe-Id", spiffeId);
+        PdpAuthNHandler.Result result   = handler.authenticate(request, null);
 
         assertEquals(PdpAuthNHandler.Result.Status.AUTHENTICATED, result.getStatus());
-        assertEquals("nginx-ingress", result.getUserName());
+        assertEquals(spiffeId, result.getUserName());
         assertEquals(HttpHeaderAuthNHandler.AUTH_TYPE_SPIFFE, result.getAuthType());
     }
 
@@ -118,13 +119,15 @@ public class HttpHeaderAuthNHandlerTest {
 
         Map<String, String> headers = new HashMap<>();
 
+        String spiffeId = "spiffe://my-cluster/ns/service-namespace/sa/service-sa";
+
         headers.put("X-Spiffe-Id", "not-a-spiffe-id");
-        headers.put("X-Workload-Id", "spiffe://my-cluster/ns/service-namespace/sa/service-sa");
+        headers.put("X-Workload-Id", spiffeId);
 
         PdpAuthNHandler.Result result = handler.authenticate(requestWithHeaders(headers), null);
 
         assertEquals(PdpAuthNHandler.Result.Status.AUTHENTICATED, result.getStatus());
-        assertEquals("service-sa", result.getUserName());
+        assertEquals(spiffeId, result.getUserName());
         assertEquals(HttpHeaderAuthNHandler.AUTH_TYPE_SPIFFE, result.getAuthType());
     }
 
@@ -145,7 +148,7 @@ public class HttpHeaderAuthNHandlerTest {
     }
 
     @Test
-    void testAuthenticate_specValidButNonConformingSpiffeHeaderSkips() {
+    void testAuthenticate_specValidNonSpireLayoutSpiffeHeaderAuthenticatesFullId() {
         HttpHeaderAuthNHandler handler = new HttpHeaderAuthNHandler();
         Properties             config  = new Properties();
 
@@ -153,12 +156,15 @@ public class HttpHeaderAuthNHandlerTest {
 
         handler.init(config);
 
-        // Valid SPIFFE ID per the SPIFFE spec, but not in the expected /ns/<ns>/sa/<sa> layout.
-        HttpServletRequest     request = requestWithHeader("X-Spiffe-Id", "spiffe://example.org/workload/frontend");
-        PdpAuthNHandler.Result result  = handler.authenticate(request, null);
+        // Valid SPIFFE ID per the SPIFFE spec that does not use the SPIRE /ns/<ns>/sa/<sa> layout;
+        // the full SPIFFE ID is used as the authenticated principal.
+        String                 spiffeId = "spiffe://example.org/workload/frontend";
+        HttpServletRequest     request  = requestWithHeader("X-Spiffe-Id", spiffeId);
+        PdpAuthNHandler.Result result   = handler.authenticate(request, null);
 
-        assertEquals(PdpAuthNHandler.Result.Status.SKIP, result.getStatus());
-        assertNull(result.getUserName());
+        assertEquals(PdpAuthNHandler.Result.Status.AUTHENTICATED, result.getStatus());
+        assertEquals(spiffeId, result.getUserName());
+        assertEquals(HttpHeaderAuthNHandler.AUTH_TYPE_SPIFFE, result.getAuthType());
     }
 
     @Test

--- a/security-admin/src/main/java/org/apache/ranger/common/StringUtil.java
+++ b/security-admin/src/main/java/org/apache/ranger/common/StringUtil.java
@@ -46,6 +46,10 @@ public class StringUtil implements Serializable {
     public static final String VALIDATION_IP_ADDRESS = "[\\d\\.\\%\\:]*";
     public static final String WILDCARD_ASTERISK     = "*";
 
+    // When enabled, ':' is treated as a valid login-id character so that SPIFFE IDs (e.g. spiffe://spiffe.example.com/ns/sales/sa/trino) can be used as usernames.
+    public static final String PROP_SPIFFE_AS_USERNAME_ENABLED = "ranger.admin.spiffe.as.username.enabled";
+    public static final String VALIDATION_LOGINID_SPIFFE       = "^([A-Za-z0-9_]|[\u00C0-\u017F])([a-z0-9,._\\-+/@=: ]|[\u00C0-\u017F])+$";
+
     /**
      *
      */
@@ -269,5 +273,26 @@ public class StringUtil implements Serializable {
                 : str.contains("@") ?
                 str.substring(0, str.indexOf("@"))
                 : str;
+    }
+
+    /**
+     * Whether SPIFFE IDs are allowed as usernames. Controlled by the
+     * {@link #PROP_SPIFFE_AS_USERNAME_ENABLED} config (disabled by default). When enabled,
+     * the login-id validation allows the ':' character used in SPIFFE IDs.
+     *
+     * @return true if using SPIFFE IDs as usernames is enabled
+     */
+    public static boolean isSpiffeAsUsernameEnabled() {
+        return PropertiesUtil.getBooleanProperty(PROP_SPIFFE_AS_USERNAME_ENABLED, false);
+    }
+
+    /**
+     * Returns the login-id validation regex in effect. When using SPIFFE IDs as usernames
+     * is enabled, ':' is treated as a valid character (see {@link #VALIDATION_LOGINID_SPIFFE}).
+     *
+     * @return the login-id validation regex
+     */
+    public static String getLoginIdValidationRegEx() {
+        return isSpiffeAsUsernameEnabled() ? VALIDATION_LOGINID_SPIFFE : VALIDATION_LOGINID;
     }
 }

--- a/security-admin/src/main/java/org/apache/ranger/rest/UserREST.java
+++ b/security-admin/src/main/java/org/apache/ranger/rest/UserREST.java
@@ -274,6 +274,7 @@ public class UserREST {
             long                inactivityTimeout = PropertiesUtil.getLongProperty("ranger.service.inactivity.timeout", 15 * 60);
 
             configProperties.put("inactivityTimeout", Long.toString(inactivityTimeout));
+            configProperties.put("spiffeAsUsernameEnabled", Boolean.toString(StringUtil.isSpiffeAsUsernameEnabled()));
 
             VXPortalUser userProfile = userManager.getUserProfileByLoginId();
 

--- a/security-admin/src/main/java/org/apache/ranger/security/web/filter/RangerHeaderPreAuthFilter.java
+++ b/security-admin/src/main/java/org/apache/ranger/security/web/filter/RangerHeaderPreAuthFilter.java
@@ -110,8 +110,8 @@ public class RangerHeaderPreAuthFilter extends GenericFilterBean {
 
     /**
      * Resolves the principal from trusted headers. The username header (user identity) takes
-     * precedence; when it is absent, the SPIFFE header (service identity) is used and
-     * the trailing service-account segment of the SPIFFE ID becomes the principal.
+     * precedence; when it is absent, the SPIFFE header (service identity) is used and the
+     * full SPIFFE ID becomes the principal (SPIFFE IDs are used as usernames in Ranger).
      */
     private String resolvePrincipal(HttpServletRequest httpRequest) {
         String username = StringUtils.isNotBlank(userNameHeaderName) ? StringUtils.trimToNull(httpRequest.getHeader(userNameHeaderName)) : null;
@@ -121,13 +121,12 @@ public class RangerHeaderPreAuthFilter extends GenericFilterBean {
         }
 
         for (String spiffeHeaderName : spiffeHeaderNames) {
-            String spiffeId       = StringUtils.trimToNull(httpRequest.getHeader(spiffeHeaderName));
-            String serviceAccount = SpiffeIdUtil.extractServiceAccount(spiffeId);
+            String spiffeId = StringUtils.trimToNull(httpRequest.getHeader(spiffeHeaderName));
 
-            if (StringUtils.isNotBlank(serviceAccount)) {
-                LOG.debug("Resolved service-account '{}' from SPIFFE header '{}'", serviceAccount, spiffeHeaderName);
+            if (SpiffeIdUtil.isValidSpiffeId(spiffeId)) {
+                LOG.debug("Resolved SPIFFE ID '{}' from header '{}'", spiffeId, spiffeHeaderName);
 
-                return serviceAccount;
+                return spiffeId;
             } else if (StringUtils.isNotBlank(spiffeId)) {
                 LOG.warn("SPIFFE header '{}' value is not a well-formed SPIFFE ID", spiffeHeaderName);
             }

--- a/security-admin/src/main/resources/conf.dist/ranger-admin-site.xml
+++ b/security-admin/src/main/resources/conf.dist/ranger-admin-site.xml
@@ -326,11 +326,16 @@
 	<property>
 		<name>ranger.admin.authn.header.spiffe</name>
 		<value></value>
-		<description>Comma-separated list of HTTP header name(s) carrying a SPIFFE ID (e.g. spiffe://cluster/ns/&lt;ns&gt;/sa/&lt;service-account&gt;). A single header name is also valid. The trailing service-account segment is used as the authenticated principal. When multiple headers are configured, the first one carrying a well-formed SPIFFE ID is used. Consulted only when the username header is absent.</description>
+		<description>Comma-separated list of HTTP header name(s) carrying a SPIFFE ID (e.g. spiffe://cluster/ns/&lt;ns&gt;/sa/&lt;service-account&gt;). A single header name is also valid. The full SPIFFE ID is used as the authenticated principal. When multiple headers are configured, the first one carrying a well-formed SPIFFE ID is used. Consulted only when the username header is absent.</description>
 	</property>
 	<property>
 		<name>ranger.admin.authn.header.requestid</name>
 		<value></value>
+	</property>
+	<property>
+		<name>ranger.admin.spiffe.as.username.enabled</name>
+		<value>false</value>
+		<description>When enabled, ':' is accepted as a valid character in usernames so that SPIFFE IDs (e.g. spiffe://spiffe.example.com/ns/sales/sa/trino) can be used as service-account usernames. Disabled by default.</description>
 	</property>
 	<!-- Trusted header auth properties end -->
 	<!-- Kerberos Properties starts-->	

--- a/security-admin/src/main/webapp/login.jsp
+++ b/security-admin/src/main/webapp/login.jsp
@@ -14,6 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
+<%@ page import="org.apache.ranger.common.StringUtil" %>
 <!DOCTYPE html>
 <!--[if lt IE 7]><html class="no-js lt-ie9 lt-ie8 lt-ie7"><![endif]-->
 <!--[if IE 7]><html class="no-js lt-ie9 lt-ie8"><![endif]-->
@@ -32,6 +33,9 @@
         <link rel="stylesheet" href="styles/font-awesome.min.css">
         <link href="styles/xa.css" media="all" rel="stylesheet" type="text/css" >
         <script src="libs/bower/jquery/js/core-lib.js" ></script>
+        <script type="text/javascript">
+            window.rangerSpiffeAsUsernameEnabled = <%= StringUtil.isSpiffeAsUsernameEnabled() %>;
+        </script>
         <script src="scripts/prelogin/XAPrelogin.js" ></script>
         <script type="text/javascript">
             $(document).ready(function() {

--- a/security-admin/src/main/webapp/react-webapp/src/utils/XAEnums.js
+++ b/security-admin/src/main/webapp/react-webapp/src/utils/XAEnums.js
@@ -584,6 +584,8 @@ export const RegexValidation = {
   NAME_VALIDATION: {
     regexExpressionForName:
       /^([A-Za-z0-9_]|[\u00C0-\u017F])([a-z0-9,._\-+/@= ]|[\u00C0-\u017F])+$/i,
+    regexExpressionForUserName:
+      /^([A-Za-z0-9_]|[\u00C0-\u017F])([a-z0-9,._\-+/@=: ]|[\u00C0-\u017F])+$/i,
     regexExpressionForFirstAndLastName:
       /^([A-Za-z0-9_]|[\u00C0-\u017F])([a-zA-Z0-9\s_. -@]|[\u00C0-\u017F])+$/i,
     regexForNameValidation: /^[a-zA-Z0-9_-][a-zA-Z0-9\s_-]{0,254}$/,
@@ -598,6 +600,15 @@ export const RegexValidation = {
         characters.
         <br />
         2. Allowed special character ,._-+/@= and space. <br />
+        3. Name length should be greater than one.
+      </>
+    ),
+    userNameValidationMessage: (
+      <>
+        1. Name should be start with alphabet / numeric / underscore / non-us
+        characters.
+        <br />
+        2. Allowed special character ,._-+/@=: and space. <br />
         3. Name length should be greater than one.
       </>
     ),

--- a/security-admin/src/main/webapp/react-webapp/src/utils/XAMessages.js
+++ b/security-admin/src/main/webapp/react-webapp/src/utils/XAMessages.js
@@ -36,6 +36,18 @@ export const RegexMessage = {
         </p>
       </>
     ),
+    userNameValidationMsgWithSpiffe: (
+      <>
+        <p className="pd-10 mb-0" style={{ fontSize: "small" }}>
+          1. User name should be start with alphabet / numeric / underscore /
+          non-us characters.
+          <br />
+          2. Allowed special character ,._-+/@=: and space.
+          <br />
+          3. Name length should be greater than one.
+        </p>
+      </>
+    ),
     passwordValidationInfoMessage:
       "Password should be minimum 8 characters ,at least one uppercase letter, one lowercase letter and one numeric. For FIPS environment password should be minimum 14 characters with atleast one uppercase letter, one special characters, one lowercase letter and one numeric.",
     emailValidationInfoMessage: (

--- a/security-admin/src/main/webapp/react-webapp/src/views/UserGroupRoleListing/users_details/UserForm.jsx
+++ b/security-admin/src/main/webapp/react-webapp/src/views/UserGroupRoleListing/users_details/UserForm.jsx
@@ -50,6 +50,10 @@ const INITIAL_STATE = {
   preventUnBlock: false
 };
 
+// SPIFFE IDs (e.g. spiffe://spiffe.example.com/ns/sales/sa/trino) contain ':', which is only permitted in usernames when the admin config `ranger.admin.spiffe.as.username.enabled` is enabled.
+const isSpiffeAsUsernameEnabled = () =>
+  getUserProfile()?.configProperties?.spiffeAsUsernameEnabled === "true";
+
 const PromptDialog = (props) => {
   const { isDirtyField, isUnblock } = props;
   usePrompt("Are you sure you want to leave", isDirtyField && !isUnblock);
@@ -342,12 +346,14 @@ function UserForm(props) {
     if (!values.name) {
       errors.name = "Required";
     } else {
-      if (
-        !RegexValidation.NAME_VALIDATION.regexExpressionForName.test(
-          values.name
-        )
-      ) {
-        errors.name = RegexValidation.NAME_VALIDATION.nameValidationMessage;
+      const spiffeEnabled = isSpiffeAsUsernameEnabled();
+      const userNameRegex = spiffeEnabled
+        ? RegexValidation.NAME_VALIDATION.regexExpressionForUserName
+        : RegexValidation.NAME_VALIDATION.regexExpressionForName;
+      if (!userNameRegex.test(values.name)) {
+        errors.name = spiffeEnabled
+          ? RegexValidation.NAME_VALIDATION.userNameValidationMessage
+          : RegexValidation.NAME_VALIDATION.nameValidationMessage;
       }
     }
     if (!values.password && !isEditView) {
@@ -467,7 +473,11 @@ function UserForm(props) {
                       <InfoIcon
                         css="input-box-info-icon"
                         position="right"
-                        message={RegexMessage.MESSAGE.userNameValidationMsg}
+                        message={
+                          isSpiffeAsUsernameEnabled()
+                            ? RegexMessage.MESSAGE.userNameValidationMsgWithSpiffe
+                            : RegexMessage.MESSAGE.userNameValidationMsg
+                        }
                       />
 
                       {meta.error && meta.touched && (

--- a/security-admin/src/main/webapp/scripts/prelogin/XAPrelogin.js
+++ b/security-admin/src/main/webapp/scripts/prelogin/XAPrelogin.js
@@ -45,7 +45,11 @@ function doLogin() {
 	}
 
 	var regexEmail = /^([a-zA-Z0-9_\.\-\+])+\@(([a-zA-Z0-9\-])+\.)+([a-zA-Z0-9]{2,4})+$/;
-	var regexPlain = /^([A-Za-z0-9_]|[\u00C0-\u017F])([a-z0-9,._\-+/@= ]|[\u00C0-\u017F])+$/i;
+	// ':' is only accepted in usernames (for SPIFFE IDs) when the admin config ranger.admin.spiffe.as.username.enabled is turned on.
+	var spiffeAsUsername = (typeof window !== 'undefined' && window.rangerSpiffeAsUsernameEnabled === true);
+	var regexPlain = spiffeAsUsername
+		? /^([A-Za-z0-9_]|[\u00C0-\u017F])([a-z0-9,._\-+/@=: ]|[\u00C0-\u017F])+$/i
+		: /^([A-Za-z0-9_]|[\u00C0-\u017F])([a-z0-9,._\-+/@= ]|[\u00C0-\u017F])+$/i;
 	
 	if(!regexPlain.test(userName)){
 		if(!regexEmail.test(userName)){

--- a/security-admin/src/test/java/org/apache/ranger/common/TestStringUtil.java
+++ b/security-admin/src/test/java/org/apache/ranger/common/TestStringUtil.java
@@ -183,6 +183,35 @@ public class TestStringUtil {
     }
 
     @Test
+    public void testDefaultLoginIdRegExRejectsColon() {
+        // SPIFFE ID support is disabled by default, so ':' must not be a valid login-id character.
+        String spiffeId = "spiffe://spiffe.example.com/ns/sales/sa/trino";
+        assertFalse(stringUtil.validateString(StringUtil.VALIDATION_LOGINID, spiffeId));
+        assertFalse(stringUtil.validateString(StringUtil.VALIDATION_LOGINID, "user:name"));
+    }
+
+    @Test
+    public void testSpiffeLoginIdRegExAllowsSpiffeId() {
+        // SPIFFE IDs are used as service-account usernames in k8s deployments.
+        String spiffeId = "spiffe://spiffe.example.com/ns/sales/sa/trino";
+        assertTrue(stringUtil.validateString(StringUtil.VALIDATION_LOGINID_SPIFFE, spiffeId));
+        assertTrue(stringUtil.validateString(StringUtil.VALIDATION_LOGINID_SPIFFE, "user:name"));
+    }
+
+    @Test
+    public void testLoginIdRegExRejectsInvalidCharacter() {
+        assertFalse(stringUtil.validateString(StringUtil.VALIDATION_LOGINID, "user#name"));
+        assertFalse(stringUtil.validateString(StringUtil.VALIDATION_LOGINID_SPIFFE, "user#name"));
+    }
+
+    @Test
+    public void testGetLoginIdValidationRegExDefaultsToNonSpiffe() {
+        // With the config disabled (default), the effective regex is the non-SPIFFE one.
+        assertFalse(StringUtil.isSpiffeAsUsernameEnabled());
+        assertEquals(StringUtil.VALIDATION_LOGINID, StringUtil.getLoginIdValidationRegEx());
+    }
+
+    @Test
     public void testIsValidNameNull() {
         boolean value = stringUtil.isValidName(null);
         assertFalse(value);

--- a/security-admin/src/test/java/org/apache/ranger/security/web/filter/TestRangerHeaderPreAuthFilter.java
+++ b/security-admin/src/test/java/org/apache/ranger/security/web/filter/TestRangerHeaderPreAuthFilter.java
@@ -153,7 +153,7 @@ public class TestRangerHeaderPreAuthFilter {
     }
 
     @Test
-    public void testDoFilter_enabled_withSpiffeHeader_setsServiceAccountAuthentication() throws Exception {
+    public void testDoFilter_enabled_withSpiffeHeader_setsSpiffeIdAuthentication() throws Exception {
         PropertiesUtil.getPropertiesMap().put(RangerHeaderPreAuthFilter.PROP_HEADER_AUTH_ENABLED, "true");
         PropertiesUtil.getPropertiesMap().put(RangerHeaderPreAuthFilter.PROP_USERNAME_HEADER_NAME, "X-Forwarded-User");
         PropertiesUtil.getPropertiesMap().put(RangerHeaderPreAuthFilter.PROP_SPIFFE_HEADER_NAME, "X-Spiffe-Id");
@@ -164,14 +164,17 @@ public class TestRangerHeaderPreAuthFilter {
         filter.userMgr = userMgr;
         filter.initialize();
 
-        when(userMgr.getRolesByLoginId("nginx-ingress")).thenReturn(Collections.singletonList("ROLE_USER"));
+        // The full SPIFFE ID is the username in Ranger, so roles are looked up by the whole SPIFFE ID.
+        String spiffeId = "spiffe://prod-cluster.k8s.example.com/ns/ingress-nginx/sa/nginx-ingress";
+
+        when(userMgr.getRolesByLoginId(spiffeId)).thenReturn(Collections.singletonList("ROLE_USER"));
 
         HttpServletRequest  request  = mock(HttpServletRequest.class);
         HttpServletResponse response = mock(HttpServletResponse.class);
 
         when(request.getHeader("X-Forwarded-User")).thenReturn(null);
         // Realistic production SPIFFE ID: DNS-style Kubernetes cluster trust domain + namespace/service-account.
-        when(request.getHeader("X-Spiffe-Id")).thenReturn("spiffe://prod-cluster.k8s.example.com/ns/ingress-nginx/sa/nginx-ingress");
+        when(request.getHeader("X-Spiffe-Id")).thenReturn(spiffeId);
 
         FilterChain chain = new FilterChain() {
             @Override
@@ -182,7 +185,7 @@ public class TestRangerHeaderPreAuthFilter {
                 assertTrue(auth instanceof RangerAuthenticationToken);
                 RangerAuthenticationToken rangerAuth = (RangerAuthenticationToken) auth;
                 assertEquals(XXAuthSession.AUTH_TYPE_TRUSTED_PROXY, rangerAuth.getAuthType());
-                assertEquals("nginx-ingress", auth.getName());
+                assertEquals(spiffeId, auth.getName());
             }
         };
 
@@ -234,13 +237,15 @@ public class TestRangerHeaderPreAuthFilter {
         filter.userMgr = userMgr;
         filter.initialize();
 
-        when(userMgr.getRolesByLoginId("service-sa")).thenReturn(Collections.singletonList("ROLE_USER"));
+        String spiffeId = "spiffe://my-cluster/ns/service-namespace/sa/service-sa";
+
+        when(userMgr.getRolesByLoginId(spiffeId)).thenReturn(Collections.singletonList("ROLE_USER"));
 
         HttpServletRequest  request  = mock(HttpServletRequest.class);
         HttpServletResponse response = mock(HttpServletResponse.class);
 
         when(request.getHeader("X-Spiffe-Id")).thenReturn("not-a-spiffe-id");
-        when(request.getHeader("X-Workload-Id")).thenReturn("spiffe://my-cluster/ns/service-namespace/sa/service-sa");
+        when(request.getHeader("X-Workload-Id")).thenReturn(spiffeId);
 
         FilterChain chain = new FilterChain() {
             @Override
@@ -248,7 +253,7 @@ public class TestRangerHeaderPreAuthFilter {
                 org.springframework.security.core.Authentication auth = SecurityContextHolder.getContext().getAuthentication();
 
                 assertNotNull(auth);
-                assertEquals("service-sa", auth.getName());
+                assertEquals(spiffeId, auth.getName());
             }
         };
 
@@ -280,7 +285,7 @@ public class TestRangerHeaderPreAuthFilter {
     }
 
     @Test
-    public void testDoFilter_enabled_specValidButNonConformingSpiffeHeader_passesThrough() throws Exception {
+    public void testDoFilter_enabled_specValidNonSpireLayoutSpiffeHeader_authenticatesFullId() throws Exception {
         PropertiesUtil.getPropertiesMap().put(RangerHeaderPreAuthFilter.PROP_HEADER_AUTH_ENABLED, "true");
         PropertiesUtil.getPropertiesMap().put(RangerHeaderPreAuthFilter.PROP_SPIFFE_HEADER_NAME, "X-Spiffe-Id");
 
@@ -290,18 +295,31 @@ public class TestRangerHeaderPreAuthFilter {
         filter.userMgr = userMgr;
         filter.initialize();
 
+        // Valid SPIFFE ID per the SPIFFE spec that does not use the SPIRE /ns/<ns>/sa/<sa> layout.
+        // The full SPIFFE ID is used as the authenticated principal.
+        String spiffeId = "spiffe://example.org/workload/frontend";
+
+        when(userMgr.getRolesByLoginId(spiffeId)).thenReturn(Collections.singletonList("ROLE_USER"));
+
         HttpServletRequest  request  = mock(HttpServletRequest.class);
         HttpServletResponse response = mock(HttpServletResponse.class);
-        FilterChain         chain    = mock(FilterChain.class);
 
-        // Valid SPIFFE ID per the SPIFFE spec, but not in the expected /ns/<ns>/sa/<sa> layout.
-        when(request.getHeader("X-Spiffe-Id")).thenReturn("spiffe://example.org/workload/frontend");
+        when(request.getHeader("X-Spiffe-Id")).thenReturn(spiffeId);
+
+        FilterChain chain = new FilterChain() {
+            @Override
+            public void doFilter(ServletRequest req, ServletResponse res) {
+                org.springframework.security.core.Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+
+                assertNotNull(auth);
+                assertTrue(auth instanceof RangerAuthenticationToken);
+                RangerAuthenticationToken rangerAuth = (RangerAuthenticationToken) auth;
+                assertEquals(XXAuthSession.AUTH_TYPE_TRUSTED_PROXY, rangerAuth.getAuthType());
+                assertEquals(spiffeId, auth.getName());
+            }
+        };
 
         filter.doFilter(request, response, chain);
-
-        verify(chain).doFilter(request, response);
-        verify(userMgr, never()).getRolesByLoginId(anyString());
-        assertNull(SecurityContextHolder.getContext().getAuthentication());
     }
 
     @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

- SPIFFE IDs as usernames in Ranger. 
- `:` allowed in usernames (config driven), and 
- header/trusted-proxy authn resolves the full SPIFFE ID as the principal in both Ranger Admin and the PDP.


## How was this patch tested?

### Config prerequisites (Docker)
~~~
# Admin 
ranger.admin.authn.header.enabled=true
ranger.admin.authn.header.spiffe=X-Spiffe-Id
ranger.admin.spiffe.as.username.enabled=true
ranger.sso.enabled=true

# PDP 
ranger.pdp.authn.header.enabled=true
ranger.pdp.authn.header.spiffe=X-Spiffe-Id

~~~
- SPIFFE users are visible in Ranger UI:
<img width="2216" height="364" alt="image" src="https://github.com/user-attachments/assets/f6318e22-0de2-46c8-8e0f-9d43fc4e58d5" />

- SPIFFE users participate in policy creation/update.
<img width="2224" height="106" alt="image" src="https://github.com/user-attachments/assets/f4d3dbdd-56b1-4f67-9d3b-98c126992703" />

- PDP path
~~~
$ curl -sk -X POST http://localhost:6500/authz/v1/authorize \
  -H 'Content-Type: application/json' -H "X-Spiffe-Id: none" \
  -d "{\"requestId\":\"t6\",\"context\":{\"serviceName\":\"dev_hive\",\"serviceType\":\"hive\"},\"user\":{\"name\":\"$SID\"},\"access\":{\"resource\":{\"name\":\"database:default\"},\"action\":\"select\",\"permissions\":[\"select\"]}}" \
  -w '\nHTTP %{http_code}\n'
{"code":"UNAUTHORIZED","message":"Authentication required"}
HTTP 401

# Grant the full SPIFFE ID 'select' on database=default in dev_hive

$ SID='spiffe://spiffe.example.com/ns/sales/sa/trino'
$ curl -sk -X POST http://localhost:6500/authz/v1/authorize \
  -H 'Content-Type: application/json' -H "X-Spiffe-Id: $SID" \
  -d "{\"requestId\":\"t6\",\"context\":{\"serviceName\":\"dev_hive\",\"serviceType\":\"hive\"},\"user\":{\"name\":\"$SID\"},\"access\":{\"resource\":{\"name\":\"database:default\"},\"action\":\"select\",\"permissions\":[\"select\"]}}" \
  -w '\nHTTP %{http_code}\n'
{"requestId":"t6","decision":"ALLOW","permissions":{"select":{"permission":"select","access":{"decision":"ALLOW","policy":{"id":52,"version":1}}}}}
HTTP 200


$ SID='spiffe://spiffe.example.com/ns/sales/sa/ohau'
$ curl -sk -X POST http://localhost:6500/authz/v1/authorize \
  -H 'Content-Type: application/json' -H "X-Spiffe-Id: $SID" \
  -d '{"requestId":"t6","context":{"serviceName":"dev_hive","serviceType":"hive"},"user":{"name":"someoneelse"},"access":{"resource":{"name":"database:default"},"action":"select","permissions":["select"]}}' \
  -w '\nHTTP %{http_code}\n'
{"code":"FORBIDDEN","message":"spiffe://spiffe.example.com/ns/sales/sa/ohau is not authorized"}
HTTP 403
~~~
