### PR TITLE
RANGER-5776: Prevent DB2HSM migration tool from overwriting existing keys in HSM

### DIFF
--- a/kms/src/main/java/org/apache/hadoop/crypto/key/RangerHSM.java
+++ b/kms/src/main/java/org/apache/hadoop/crypto/key/RangerHSM.java
@@ -162,11 +162,16 @@ public class RangerHSM implements RangerKMSMKI {
     public boolean setExternalKeyAsMK(String password, byte[] key) {
         if (myStore != null) {
             try {
-                Key aesKey = new SecretKeySpec(key, MK_CIPHER);
+                if (!myStore.containsAlias(mkAlias)) {
+                    Key aesKey = new SecretKeySpec(key, MK_CIPHER);
 
-                myStore.setKeyEntry(mkAlias, aesKey, password.toCharArray(), (java.security.cert.Certificate[]) null);
+                    myStore.setKeyEntry(mkAlias, aesKey, password.toCharArray(), (java.security.cert.Certificate[]) null);
 
-                return true;
+                    return true;
+                }
+                else {
+                    logger.warn("Master key with alias '{}' already exists in HSM, returning.", mkAlias);
+                }
             } catch (KeyStoreException e) {
                 logger.error("setMasterKey : Exception while setting Master Key, Error - {} ", e.getMessage());
             }

--- a/kms/src/main/java/org/apache/hadoop/crypto/key/RangerSafenetKeySecure.java
+++ b/kms/src/main/java/org/apache/hadoop/crypto/key/RangerSafenetKeySecure.java
@@ -169,11 +169,16 @@ public class RangerSafenetKeySecure implements RangerKMSMKI {
     public boolean setExternalKeyAsMK(String password, byte[] key) {
         if (myStore != null) {
             try {
-                Key aesKey = new SecretKeySpec(key, MK_ALGO);
+                if (!myStore.containsAlias(alias)) {
+                    Key aesKey = new SecretKeySpec(key, MK_ALGO);
 
-                myStore.setKeyEntry(alias, aesKey, password.toCharArray(), (java.security.cert.Certificate[]) null);
+                    myStore.setKeyEntry(alias, aesKey, password.toCharArray(), (java.security.cert.Certificate[]) null);
 
-                return true;
+                    return true;
+                }
+                else {
+                    logger.warn("Master key with alias '{}' already exists in Safenet, returning.", alias);
+                }
             } catch (Exception e) {
                 logger.error("setMasterKey : Exception while setting Master Key - {}", e.getMessage());
             }

--- a/kms/src/test/java/org/apache/hadoop/crypto/key/TestDB2HSMMKUtil.java
+++ b/kms/src/test/java/org/apache/hadoop/crypto/key/TestDB2HSMMKUtil.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.crypto.key;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(MockitoExtension.class)
+@TestMethodOrder(MethodOrderer.MethodName.class)
+@Disabled
+class TestDB2HSMMKUtil {
+    private final PrintStream     originalOut             = System.out;
+    private final PrintStream     originalErr             = System.err;
+    private final SecurityManager originalSecurityManager = System.getSecurityManager();
+
+    private ByteArrayOutputStream outContent;
+    private ByteArrayOutputStream errContent;
+
+    @BeforeEach
+    public void setUp() {
+        outContent = new ByteArrayOutputStream();
+        errContent = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(outContent));
+        System.setErr(new PrintStream(errContent));
+        System.setSecurityManager(new NoExitSecurityManager());
+    }
+
+    @AfterEach
+    public void tearDown() {
+        System.setOut(originalOut);
+        System.setErr(originalErr);
+        System.setSecurityManager(originalSecurityManager);
+    }
+
+    @Test
+    void testMain_WithLessThan2Args_ShouldExit1() {
+        String[]             args = {"onlyOneArg"};
+        ExitTrappedException ex   = assertThrows(ExitTrappedException.class, () -> DB2HSMMKUtil.main(args));
+        assertEquals(1, ex.status);
+        assertTrue(errContent.toString().contains("Invalid number of parameters"));
+    }
+
+    @Test
+    void testMain_WithEmptyHSMType_ShouldExit1() {
+        String[]             args = {"", "partition1"};
+        ExitTrappedException ex   = assertThrows(ExitTrappedException.class, () -> DB2HSMMKUtil.main(args));
+        assertEquals(1, ex.status);
+        assertTrue(errContent.toString().contains("HSM Type does not exists"));
+    }
+
+    @Test
+    void testMain_WithEmptyPartition_ShouldExit1() {
+        String[]             args = {"HSMType", ""};
+        ExitTrappedException ex   = assertThrows(ExitTrappedException.class, () -> DB2HSMMKUtil.main(args));
+        assertEquals(1, ex.status);
+        assertTrue(errContent.toString().contains("Partition name does not exists"));
+    }
+
+    @Test
+    void testShowUsage() {
+        DB2HSMMKUtil.showUsage();
+        String errOutput = errContent.toString();
+        assertTrue(errOutput.contains("USAGE:"));
+        assertTrue(errOutput.contains("HSMType"));
+        assertTrue(errOutput.contains("partitionName"));
+    }
+
+    static class ExitTrappedException extends SecurityException {
+        final int status;
+
+        ExitTrappedException(int status) {
+            super("System.exit(" + status + ") called");
+            this.status = status;
+        }
+    }
+
+    private static class NoExitSecurityManager extends SecurityManager {
+        @Override
+        public void checkPermission(java.security.Permission perm) {
+            // Allow all
+        }
+
+        @Override
+        public void checkExit(int status) {
+            throw new ExitTrappedException(status);
+        }
+    }
+}

--- a/kms/src/test/java/org/apache/hadoop/crypto/key/kms/TestRangerSafenetKeySecure.java
+++ b/kms/src/test/java/org/apache/hadoop/crypto/key/kms/TestRangerSafenetKeySecure.java
@@ -37,6 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Answers.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @TestMethodOrder(MethodOrderer.MethodName.class)
@@ -88,6 +89,27 @@ public class TestRangerSafenetKeySecure {
 
         boolean result = secure.setExternalKeyAsMK("pass", "mockKey".getBytes());
         assertFalse(result);
+    }
+
+    @Test
+    public void testSetMasterKey_WithAliasCheck() throws Exception {
+        RangerSafenetKeySecure secure = mock(RangerSafenetKeySecure.class, CALLS_REAL_METHODS);
+
+        KeyStore dummyKeystore = mock(KeyStore.class);
+
+        Field storeField = RangerSafenetKeySecure.class.getDeclaredField("myStore");
+        storeField.setAccessible(true);
+        storeField.set(secure, dummyKeystore);
+
+        Field aliasField = RangerSafenetKeySecure.class.getDeclaredField("alias");
+        aliasField.setAccessible(true);
+        aliasField.set(secure, "RANGERMK");
+
+        when(dummyKeystore.containsAlias("RANGERMK")).thenReturn(true);
+        assertFalse(secure.setExternalKeyAsMK("pass", "mockKey".getBytes()));
+
+        when(dummyKeystore.containsAlias("RANGERMK")).thenReturn(false);
+        assertTrue(secure.setExternalKeyAsMK("pass", "mockKey".getBytes()));
     }
 
     @Test


### PR DESCRIPTION
Currently, when the master key is migrated from the KMS DB to Luna HSM using the migration tool **(DB2HSMMKUtil)**, it silently overwrites any existing key present in the HSM. This overwrite should never happen, as it could lead to loss of data if the HSM already holds the active master key.

The fix is added to check the presence of alias in HSM before writing to the HSM. If the alias is already present, the write is skipped and a warning is logged.
This brings the behaviour in sync with how **HSM2DBMKUtil** works.
(Note: This is also missing in **RangerSafenetKeySecure** side so added fix here too)


