### PR TITLE
RANGER-5786: Skip Kafka broker service user in default audit filters

### DIFF
--- a/dev-support/ranger-docker/scripts/admin/create-ranger-services.py
+++ b/dev-support/ranger-docker/scripts/admin/create-ranger-services.py
@@ -70,7 +70,7 @@ kafka = RangerService({'name': 'dev_kafka', 'type': 'kafka',
                                    'default-policy.5.resource.cluster': '*,dummy',
                                    'default-policy.5.policyItem.1.users': 'rangerauditserver',
                                    'default-policy.5.policyItem.1.accessTypes': 'configure,describe,alter,create,idempotent_write,describe_configs,alter_configs',
-                                   'ranger.plugin.audit.filters': "[{'accessResult': 'DENIED', 'isAudited': true},{'resources':{'topic':{'values':['ATLAS_ENTITIES']}},'users':['rangertagsync'],'actions':['create','consume','describe'],'isAudited':false},{'resources':{'consumergroup':{'values':['ranger_entities_consumer']}},'users':['rangertagsync'],'actions':['consume'],'isAudited':false},{'users':['rangerauditserver'],'isAudited':false}]",
+                                   'ranger.plugin.audit.filters': "[{'accessResult': 'DENIED', 'isAudited': true},{'resources':{'topic':{'values':['ATLAS_ENTITIES']}},'users':['rangertagsync'],'actions':['create','consume','describe'],'isAudited':false},{'resources':{'consumergroup':{'values':['ranger_entities_consumer']}},'users':['rangertagsync'],'actions':['consume'],'isAudited':false},{'users':['kafka'],'isAudited':false},{'users':['rangerauditserver'],'isAudited':false}]",
                                    'userstore.download.auth.users': 'kafka',
                                    'ranger.plugin.kafka.policy.refresh.synchronous':'true'}})
 


### PR DESCRIPTION
## Summary

[RANGER-5786](https://issues.apache.org/jira/browse/RANGER-5786) — Reduce noisy Kafka access audits from the broker service user `kafka` in the docker dev stack.

Docker `dev_kafka` bootstrap overrides the Kafka service-def default audit filters without a skip rule for user `kafka`. Broker internal describe traffic on topics such as `__consumer_offsets` and `ranger_audits` shows up in Admin audit views and adds noise.

Per review feedback, this PR keeps the fix minimal: **one change** in docker service bootstrap only.

## Changes

| File | Change |
|------|--------|
| `dev-support/ranger-docker/scripts/admin/create-ranger-services.py` | Add `{'users':['kafka'],'isAudited':false}` to `dev_kafka` `ranger.plugin.audit.filters` |

No service-def, DB patch, or unit-test changes in this PR.

## Testing

After docker stack bootstrap, confirm `dev_kafka` audit filters include the kafka user skip:

```bash
curl -sf -u admin:rangerR0cks! \
  http://localhost:6080/service/public/v2/api/service/name/dev_kafka \
  | python3 -c "import json,sys; f=json.load(sys.stdin)['configs']['ranger.plugin.audit.filters']; print(f); assert \"'users':['kafka']\" in f.replace(' ', '') or \"'users': ['kafka']\" in f"
```

## Test plan

- [ ] CI: `build-17`
- [ ] Docker bootstrap: `dev_kafka` audit filters include `{'users':['kafka'],'isAudited':false}`
