### PR TITLE
RANGER-4692: Sorting on the Ranger Admin - Plugin Status page by event(Download,Activation)

### DIFF
--- a/agents-common/src/main/java/org/apache/ranger/plugin/model/RangerPluginInfo.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/model/RangerPluginInfo.java
@@ -62,12 +62,15 @@ public class RangerPluginInfo implements Serializable {
     public static final String PLUGIN_INFO_GDS_DOWNLOADED_VERSION       = "gdsDownloadedVersion";
     public static final String PLUGIN_INFO_GDS_ACTIVATION_TIME          = "gdsActivationTime";
     public static final String PLUGIN_INFO_GDS_ACTIVE_VERSION           = "gdsActiveVersion";
+    public static final String PLUGIN_INFO_CLUSTER_NAME                 = "clusterName";
     public static final String RANGER_ADMIN_LAST_POLICY_UPDATE_TIME     = "lastPolicyUpdateTime";
     public static final String RANGER_ADMIN_LATEST_POLICY_VERSION       = "latestPolicyVersion";
     public static final String RANGER_ADMIN_LAST_TAG_UPDATE_TIME        = "lastTagUpdateTime";
     public static final String RANGER_ADMIN_LATEST_TAG_VERSION          = "latestTagVersion";
     public static final String RANGER_ADMIN_LAST_GDS_UPDATE_TIME        = "lastGdsUpdateTime";
     public static final String RANGER_ADMIN_LATEST_GDS_VERSION          = "latestGdsVersion";
+    public static final String RANGER_ADMIN_LAST_ROLE_UPDATE_TIME       = "lastRoleUpdateTime";
+    public static final String RANGER_ADMIN_LATEST_ROLE_VERSION         = "latestRoleVersion";
     public static final String RANGER_ADMIN_CAPABILITIES                = "adminCapabilities";
     public static final String PLUGIN_INFO_CAPABILITIES                 = "pluginCapabilities";
 
@@ -459,6 +462,20 @@ public class RangerPluginInfo implements Serializable {
     }
 
     @JsonIgnore
+    public Long getLatestRoleVersion() {
+        String latestRoleVersionString = getInfo().get(RANGER_ADMIN_LATEST_ROLE_VERSION);
+
+        return StringUtils.isNotBlank(latestRoleVersionString) ? Long.valueOf(latestRoleVersionString) : null;
+    }
+
+    @JsonIgnore
+    public Long getLastRoleUpdateTime() {
+        String updateTimeString = getInfo().get(RANGER_ADMIN_LAST_ROLE_UPDATE_TIME);
+
+        return StringUtils.isNotBlank(updateTimeString) ? Long.valueOf(updateTimeString) : null;
+    }
+
+    @JsonIgnore
     public String getPluginCapabilities() {
         return getCapabilities(PLUGIN_INFO_CAPABILITIES);
     }
@@ -476,6 +493,16 @@ public class RangerPluginInfo implements Serializable {
     @JsonIgnore
     public void setAdminCapabilities(String capabilities) {
         setCapabilities(RANGER_ADMIN_CAPABILITIES, capabilities);
+    }
+
+    @JsonIgnore
+    public void setClusterName(String clusterName) {
+        setCapabilities(PLUGIN_INFO_CLUSTER_NAME, clusterName);
+    }
+
+    @JsonIgnore
+    public String getClusterName() {
+        return getCapabilities(PLUGIN_INFO_CLUSTER_NAME);
     }
 
     @Override

--- a/dev-support/checkstyle-suppressions.xml
+++ b/dev-support/checkstyle-suppressions.xml
@@ -93,4 +93,5 @@
   <suppress files="PatchForAtlasPolicyUpdateForEntityRead_J10064" checks="TypeName"/>
   <suppress files="PatchForOzoneServiceDefPolicyConditionUpdate_J10066" checks="TypeName"/>
   <suppress files="PatchForOzoneServiceDefAssumeRoleUpdate_J10065" checks="TypeName"/>
+  <suppress files="PatchForPluginStatusEventSorting_J10067" checks="TypeName"/>
 </suppressions>

--- a/security-admin/db/mysql/optimized/current/ranger_core_db_mysql.sql
+++ b/security-admin/db/mysql/optimized/current/ranger_core_db_mysql.sql
@@ -14,6 +14,7 @@
 -- limitations under the License.
 
 DROP VIEW IF EXISTS `vx_principal`;
+DROP VIEW IF EXISTS `vx_plugin_info`;
 DROP TABLE IF EXISTS `x_rms_mapping_provider`;
 DROP TABLE IF EXISTS `x_rms_resource_mapping`;
 DROP TABLE IF EXISTS `x_rms_notification`;
@@ -1236,6 +1237,17 @@ CREATE TABLE IF NOT EXISTS `x_plugin_info`(
 `host_name` varchar(255) NOT NULL,
 `ip_address` varchar(64) NOT NULL,
 `info` varchar(1024) NOT NULL,
+`policy_download_time` bigint(20) DEFAULT NULL,
+`policy_activation_time` bigint(20) DEFAULT NULL,
+`tag_download_time` bigint(20) DEFAULT NULL,
+`tag_activation_time` bigint(20) DEFAULT NULL,
+`gds_download_time` bigint(20) DEFAULT NULL,
+`gds_activation_time` bigint(20) DEFAULT NULL,
+`role_download_time` bigint(20) DEFAULT NULL,
+`role_activation_time` bigint(20) DEFAULT NULL,
+`userstore_download_time` bigint(20) DEFAULT NULL,
+`userstore_activation_time` bigint(20) DEFAULT NULL,
+`cluster_name` varchar(255) DEFAULT NULL,
  PRIMARY KEY (`id`),
  UNIQUE KEY `x_plugin_info_UK`(`service_name`, `host_name`, `app_type`),
  KEY `x_plugin_info_IDX_service_name`(`service_name`),
@@ -1516,7 +1528,42 @@ CREATE INDEX x_policy_label_label_id ON x_policy_label(id);
 CREATE INDEX x_policy_label_label_name ON x_policy_label(label_name);
 CREATE INDEX x_policy_label_label_map_id ON x_policy_label_map(id);
 
+CREATE INDEX x_plugin_info_IDX_policy_download_time ON x_plugin_info(policy_download_time);
+CREATE INDEX x_plugin_info_IDX_policy_activation_time ON x_plugin_info(policy_activation_time);
+CREATE INDEX x_plugin_info_IDX_tag_download_time ON x_plugin_info(tag_download_time);
+CREATE INDEX x_plugin_info_IDX_tag_activation_time ON x_plugin_info(tag_activation_time);
+CREATE INDEX x_plugin_info_IDX_gds_download_time ON x_plugin_info(gds_download_time);
+CREATE INDEX x_plugin_info_IDX_gds_activation_time ON x_plugin_info(gds_activation_time);
+CREATE INDEX x_plugin_info_IDX_role_download_time ON x_plugin_info(role_download_time);
+CREATE INDEX x_plugin_info_IDX_role_activation_time ON x_plugin_info(role_activation_time);
+CREATE INDEX x_plugin_info_IDX_userstore_download_time ON x_plugin_info(userstore_download_time);
+CREATE INDEX x_plugin_info_IDX_userstore_activation_time ON x_plugin_info(userstore_activation_time);
+CREATE INDEX x_plugin_info_IDX_cluster_name ON x_plugin_info(cluster_name);
+CREATE INDEX x_service_version_info_IDX_policy_update_time ON x_service_version_info(policy_update_time);
+CREATE INDEX x_service_version_info_IDX_tag_update_time ON x_service_version_info(tag_update_time);
+CREATE INDEX x_service_version_info_IDX_role_update_time ON x_service_version_info(role_update_time);
+CREATE INDEX x_service_version_info_IDX_gds_update_time ON x_service_version_info(gds_update_time);
+
 CREATE VIEW vx_principal as (SELECT u.user_name AS principal_name, 0 AS principal_type, u.status status, u.is_visible is_visible, u.other_attributes other_attributes, u.create_time create_time, u.update_time update_time, u.added_by_id added_by_id, u.upd_by_id upd_by_id FROM x_user u) UNION (SELECT g.group_name principal_name, 1 AS principal_type, g.status status, g.is_visible is_visible, g.other_attributes other_attributes, g.create_time create_time, g.update_time update_time, g.added_by_id added_by_id, g.upd_by_id upd_by_id FROM x_group g) UNION (SELECT r.name principal_name, 2 AS principal_name, 1 status, 1 is_visible, null other_attributes, r.create_time create_time, r.update_time update_time, r.added_by_id added_by_id, r.upd_by_id upd_by_id FROM x_role r);
+
+CREATE VIEW vx_plugin_info AS (
+    SELECT
+        xpi.id, xpi.create_time, xpi.update_time, xpi.service_name,
+        xsd.name AS service_type, xpi.app_type, xpi.host_name, xpi.ip_address, xpi.info, x_ts.is_enabled AS is_tag_service_enable,
+        xpi.policy_download_time, xpi.policy_activation_time, xpi.tag_download_time, xpi.tag_activation_time,
+        xpi.gds_download_time, xpi.gds_activation_time, xpi.role_download_time, xpi.role_activation_time,
+        xpi.userstore_download_time, xpi.userstore_activation_time, xpi.cluster_name,
+        xsvi.policy_update_time AS last_policy_update_time, xsvi.policy_version AS latest_policy_version,
+        xsvi.tag_update_time AS last_tag_update_time, xsvi.tag_version AS latest_tag_version,
+        xsvi.gds_update_time AS last_gds_update_time, xsvi.gds_version AS latest_gds_version,
+        xsvi.role_update_time AS last_role_update_time, xsvi.role_version AS latest_role_version
+    FROM
+        x_plugin_info xpi
+        LEFT OUTER JOIN x_service xs ON xs.name = xpi.service_name
+        LEFT OUTER JOIN x_service_version_info xsvi ON xsvi.service_id = xs.id
+        LEFT OUTER JOIN x_service_def xsd ON xsd.id = xs.`type`
+        LEFT OUTER JOIN x_service x_ts ON x_ts.id = xs.tag_service
+);
 
 DELIMITER $$
 DROP PROCEDURE if exists getXportalUIdByLoginId$$
@@ -1953,6 +2000,7 @@ INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active
 INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('075',UTC_TIMESTAMP(),'Ranger 3.0.0',UTC_TIMESTAMP(),'localhost','Y');
 INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('076',UTC_TIMESTAMP(),'Ranger 3.0.0',UTC_TIMESTAMP(),'localhost','Y');
 INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('077',UTC_TIMESTAMP(),'Ranger 3.0.0',UTC_TIMESTAMP(),'localhost','Y');
+INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('078',UTC_TIMESTAMP(),'Ranger 3.0.0',UTC_TIMESTAMP(),'localhost','Y');
 INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('DB_PATCHES',UTC_TIMESTAMP(),'Ranger 1.0.0',UTC_TIMESTAMP(),'localhost','Y');
 
 INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('J10001',UTC_TIMESTAMP(),'Ranger 1.0.0',UTC_TIMESTAMP(),'localhost','Y');
@@ -2007,4 +2055,5 @@ INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active
 INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('J10064',UTC_TIMESTAMP(),'Ranger 3.0.0',UTC_TIMESTAMP(),'localhost','Y');
 INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('J10065',UTC_TIMESTAMP(),'Ranger 3.0.0',UTC_TIMESTAMP(),'localhost','Y');
 INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('J10066',UTC_TIMESTAMP(),'Ranger 3.0.0',UTC_TIMESTAMP(),'localhost','Y');
+INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('J10067',UTC_TIMESTAMP(),'Ranger 3.0.0',UTC_TIMESTAMP(),'localhost','Y');
 INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('JAVA_PATCHES',UTC_TIMESTAMP(),'Ranger 1.0.0',UTC_TIMESTAMP(),'localhost','Y');

--- a/security-admin/db/mysql/patches/078-add-columns-in-x_plugin_info.sql
+++ b/security-admin/db/mysql/patches/078-add-columns-in-x_plugin_info.sql
@@ -1,0 +1,150 @@
+-- Licensed to the Apache Software Foundation (ASF) under one or more
+-- contributor license agreements.  See the NOTICE file distributed with
+-- this work for additional information regarding copyright ownership.
+-- The ASF licenses this file to You under the Apache License, Version 2.0
+-- (the "License"); you may not use this file except in compliance with
+-- the License.  You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+DROP PROCEDURE IF EXISTS add_columns_and_indexes_for_plugin_info;
+
+DELIMITER ;;
+CREATE PROCEDURE add_columns_and_indexes_for_plugin_info()
+BEGIN
+    IF EXISTS (SELECT * FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'x_plugin_info') THEN
+        IF NOT EXISTS (SELECT * FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'x_plugin_info' AND column_name = 'policy_download_time') THEN
+            ALTER TABLE x_plugin_info ADD policy_download_time BIGINT(20) NULL DEFAULT NULL;
+        END IF;
+
+        IF NOT EXISTS (SELECT * FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'x_plugin_info' AND column_name = 'policy_activation_time') THEN
+            ALTER TABLE x_plugin_info ADD policy_activation_time BIGINT(20) NULL DEFAULT NULL;
+        END IF;
+
+        IF NOT EXISTS (SELECT * FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'x_plugin_info' AND column_name = 'tag_download_time') THEN
+            ALTER TABLE x_plugin_info ADD tag_download_time BIGINT(20) NULL DEFAULT NULL;
+        END IF;
+
+        IF NOT EXISTS (SELECT * FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'x_plugin_info' AND column_name = 'tag_activation_time') THEN
+            ALTER TABLE x_plugin_info ADD tag_activation_time BIGINT(20) NULL DEFAULT NULL;
+        END IF;
+
+        IF NOT EXISTS (SELECT * FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'x_plugin_info' AND column_name = 'gds_download_time') THEN
+            ALTER TABLE x_plugin_info ADD gds_download_time BIGINT(20) NULL DEFAULT NULL;
+        END IF;
+
+        IF NOT EXISTS (SELECT * FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'x_plugin_info' AND column_name = 'gds_activation_time') THEN
+            ALTER TABLE x_plugin_info ADD gds_activation_time BIGINT(20) NULL DEFAULT NULL;
+        END IF;
+
+        IF NOT EXISTS (SELECT * FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'x_plugin_info' AND column_name = 'role_download_time') THEN
+            ALTER TABLE x_plugin_info ADD role_download_time BIGINT(20) NULL DEFAULT NULL;
+        END IF;
+
+        IF NOT EXISTS (SELECT * FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'x_plugin_info' AND column_name = 'role_activation_time') THEN
+            ALTER TABLE x_plugin_info ADD role_activation_time BIGINT(20) NULL DEFAULT NULL;
+        END IF;
+
+        IF NOT EXISTS (SELECT * FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'x_plugin_info' AND column_name = 'userstore_download_time') THEN
+            ALTER TABLE x_plugin_info ADD userstore_download_time BIGINT(20) NULL DEFAULT NULL;
+        END IF;
+
+        IF NOT EXISTS (SELECT * FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'x_plugin_info' AND column_name = 'userstore_activation_time') THEN
+            ALTER TABLE x_plugin_info ADD userstore_activation_time BIGINT(20) NULL DEFAULT NULL;
+        END IF;
+
+        IF NOT EXISTS (SELECT * FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'x_plugin_info' AND column_name = 'cluster_name') THEN
+            ALTER TABLE x_plugin_info ADD cluster_name VARCHAR(255) NULL DEFAULT NULL;
+        END IF;
+
+        IF NOT EXISTS (SELECT * FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'x_plugin_info' AND index_name = 'x_plugin_info_IDX_policy_download_time') THEN
+            CREATE INDEX x_plugin_info_IDX_policy_download_time ON x_plugin_info(policy_download_time);
+        END IF;
+
+        IF NOT EXISTS (SELECT * FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'x_plugin_info' AND index_name = 'x_plugin_info_IDX_policy_activation_time') THEN
+            CREATE INDEX x_plugin_info_IDX_policy_activation_time ON x_plugin_info(policy_activation_time);
+        END IF;
+
+        IF NOT EXISTS (SELECT * FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'x_plugin_info' AND index_name = 'x_plugin_info_IDX_tag_download_time') THEN
+            CREATE INDEX x_plugin_info_IDX_tag_download_time ON x_plugin_info(tag_download_time);
+        END IF;
+
+        IF NOT EXISTS (SELECT * FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'x_plugin_info' AND index_name = 'x_plugin_info_IDX_tag_activation_time') THEN
+            CREATE INDEX x_plugin_info_IDX_tag_activation_time ON x_plugin_info(tag_activation_time);
+        END IF;
+
+        IF NOT EXISTS (SELECT * FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'x_plugin_info' AND index_name = 'x_plugin_info_IDX_gds_download_time') THEN
+            CREATE INDEX x_plugin_info_IDX_gds_download_time ON x_plugin_info(gds_download_time);
+        END IF;
+
+        IF NOT EXISTS (SELECT * FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'x_plugin_info' AND index_name = 'x_plugin_info_IDX_gds_activation_time') THEN
+            CREATE INDEX x_plugin_info_IDX_gds_activation_time ON x_plugin_info(gds_activation_time);
+        END IF;
+
+        IF NOT EXISTS (SELECT * FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'x_plugin_info' AND index_name = 'x_plugin_info_IDX_role_download_time') THEN
+            CREATE INDEX x_plugin_info_IDX_role_download_time ON x_plugin_info(role_download_time);
+        END IF;
+
+        IF NOT EXISTS (SELECT * FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'x_plugin_info' AND index_name = 'x_plugin_info_IDX_role_activation_time') THEN
+            CREATE INDEX x_plugin_info_IDX_role_activation_time ON x_plugin_info(role_activation_time);
+        END IF;
+
+        IF NOT EXISTS (SELECT * FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'x_plugin_info' AND index_name = 'x_plugin_info_IDX_userstore_download_time') THEN
+            CREATE INDEX x_plugin_info_IDX_userstore_download_time ON x_plugin_info(userstore_download_time);
+        END IF;
+
+        IF NOT EXISTS (SELECT * FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'x_plugin_info' AND index_name = 'x_plugin_info_IDX_userstore_activation_time') THEN
+            CREATE INDEX x_plugin_info_IDX_userstore_activation_time ON x_plugin_info(userstore_activation_time);
+        END IF;
+
+        IF NOT EXISTS (SELECT * FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'x_plugin_info' AND index_name = 'x_plugin_info_IDX_cluster_name') THEN
+            CREATE INDEX x_plugin_info_IDX_cluster_name ON x_plugin_info(cluster_name);
+        END IF;
+
+        IF NOT EXISTS (SELECT * FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'x_service_version_info' AND index_name = 'x_service_version_info_IDX_policy_update_time') THEN
+            CREATE INDEX x_service_version_info_IDX_policy_update_time ON x_service_version_info(policy_update_time);
+        END IF;
+
+        IF NOT EXISTS (SELECT * FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'x_service_version_info' AND index_name = 'x_service_version_info_IDX_tag_update_time') THEN
+            CREATE INDEX x_service_version_info_IDX_tag_update_time ON x_service_version_info(tag_update_time);
+        END IF;
+
+        IF NOT EXISTS (SELECT * FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'x_service_version_info' AND index_name = 'x_service_version_info_IDX_role_update_time') THEN
+            CREATE INDEX x_service_version_info_IDX_role_update_time ON x_service_version_info(role_update_time);
+        END IF;
+
+        IF NOT EXISTS (SELECT * FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'x_service_version_info' AND index_name = 'x_service_version_info_IDX_gds_update_time') THEN
+            CREATE INDEX x_service_version_info_IDX_gds_update_time ON x_service_version_info(gds_update_time);
+        END IF;
+    END IF;
+END;;
+
+DELIMITER ;
+CALL add_columns_and_indexes_for_plugin_info();
+DROP PROCEDURE IF EXISTS add_columns_and_indexes_for_plugin_info;
+
+DROP VIEW IF EXISTS vx_plugin_info;
+CREATE VIEW vx_plugin_info AS (
+    SELECT
+        xpi.id, xpi.create_time, xpi.update_time, xpi.service_name,
+        xsd.name AS service_type, xpi.app_type, xpi.host_name, xpi.ip_address, xpi.info, x_ts.is_enabled AS is_tag_service_enable,
+        xpi.policy_download_time, xpi.policy_activation_time, xpi.tag_download_time, xpi.tag_activation_time,
+        xpi.gds_download_time, xpi.gds_activation_time, xpi.role_download_time, xpi.role_activation_time,
+        xpi.userstore_download_time, xpi.userstore_activation_time, xpi.cluster_name,
+        xsvi.policy_update_time AS last_policy_update_time, xsvi.policy_version AS latest_policy_version,
+        xsvi.tag_update_time AS last_tag_update_time, xsvi.tag_version AS latest_tag_version,
+        xsvi.gds_update_time AS last_gds_update_time, xsvi.gds_version AS latest_gds_version,
+        xsvi.role_update_time AS last_role_update_time, xsvi.role_version AS latest_role_version
+    FROM
+        x_plugin_info xpi
+        LEFT OUTER JOIN x_service xs ON xs.name = xpi.service_name
+        LEFT OUTER JOIN x_service_version_info xsvi ON xsvi.service_id = xs.id
+        LEFT OUTER JOIN x_service_def xsd ON xsd.id = xs.`type`
+        LEFT OUTER JOIN x_service x_ts ON x_ts.id = xs.tag_service
+);

--- a/security-admin/db/oracle/optimized/current/ranger_core_db_oracle.sql
+++ b/security-admin/db/oracle/optimized/current/ranger_core_db_oracle.sql
@@ -223,6 +223,7 @@ BEGIN
 END;/
 /
 
+call spdropview('vx_plugin_info');
 call spdroptable('X_RMS_MAPPING_PROVIDER');
 call spdroptable('X_RMS_RESOURCE_MAPPING');
 call spdroptable('X_RMS_NOTIFICATION');
@@ -1342,6 +1343,17 @@ app_type VARCHAR(128) NOT NULL,
 host_name VARCHAR(255) NOT NULL,
 ip_address VARCHAR(64) NOT NULL,
 info VARCHAR(1024) NOT NULL,
+policy_download_time NUMBER(20) DEFAULT NULL NULL,
+policy_activation_time NUMBER(20) DEFAULT NULL NULL,
+tag_download_time NUMBER(20) DEFAULT NULL NULL,
+tag_activation_time NUMBER(20) DEFAULT NULL NULL,
+gds_download_time NUMBER(20) DEFAULT NULL NULL,
+gds_activation_time NUMBER(20) DEFAULT NULL NULL,
+role_download_time NUMBER(20) DEFAULT NULL NULL,
+role_activation_time NUMBER(20) DEFAULT NULL NULL,
+userstore_download_time NUMBER(20) DEFAULT NULL NULL,
+userstore_activation_time NUMBER(20) DEFAULT NULL NULL,
+cluster_name VARCHAR(255) DEFAULT NULL,
 PRIMARY KEY (id),
 CONSTRAINT x_plugin_info_UK UNIQUE (service_name, host_name, app_type)
 );
@@ -1590,6 +1602,25 @@ CONSTRAINT x_sz_ref_role_FK_role_id FOREIGN KEY (role_id) REFERENCES x_role (id)
 );
 commit;
 
+CREATE VIEW vx_plugin_info AS
+    SELECT
+        xpi.id, xpi.create_time, xpi.update_time, xpi.service_name,
+        xsd.name AS service_type, xpi.app_type, xpi.host_name, xpi.ip_address, xpi.info, x_ts.is_enabled AS is_tag_service_enable,
+        xpi.policy_download_time, xpi.policy_activation_time, xpi.tag_download_time, xpi.tag_activation_time,
+        xpi.gds_download_time, xpi.gds_activation_time, xpi.role_download_time, xpi.role_activation_time,
+        xpi.userstore_download_time, xpi.userstore_activation_time, xpi.cluster_name,
+        xsvi.policy_update_time AS last_policy_update_time, xsvi.policy_version AS latest_policy_version,
+        xsvi.tag_update_time AS last_tag_update_time, xsvi.tag_version AS latest_tag_version,
+        xsvi.gds_update_time AS last_gds_update_time, xsvi.gds_version AS latest_gds_version,
+        xsvi.role_update_time AS last_role_update_time, xsvi.role_version AS latest_role_version
+    FROM
+        x_plugin_info xpi
+        LEFT OUTER JOIN x_service xs ON xs.name = xpi.service_name
+        LEFT OUTER JOIN x_service_version_info xsvi ON xsvi.service_id = xs.id
+        LEFT OUTER JOIN x_service_def xsd ON xsd.id = xs.type
+        LEFT OUTER JOIN x_service x_ts ON x_ts.id = xs.tag_service;
+commit;
+
 CREATE INDEX xa_access_audit_added_by_id ON  xa_access_audit(added_by_id);
 CREATE INDEX xa_access_audit_upd_by_id ON  xa_access_audit(upd_by_id);
 CREATE INDEX xa_access_audit_cr_time ON  xa_access_audit(create_time);
@@ -1734,6 +1765,22 @@ CREATE INDEX x_ugsync_audit_info_etime ON x_ugsync_audit_info(event_time);
 CREATE INDEX x_ugsync_audit_info_sync_src ON x_ugsync_audit_info(sync_source);
 CREATE INDEX x_ugsync_audit_info_uname ON x_ugsync_audit_info(user_name);
 CREATE INDEX x_data_hist_idx_objid_clstype ON x_data_hist(obj_id,obj_class_type);
+
+CREATE INDEX x_plugin_info_IDX_policy_download_time ON x_plugin_info(policy_download_time);
+CREATE INDEX x_plugin_info_IDX_policy_activation_time ON x_plugin_info(policy_activation_time);
+CREATE INDEX x_plugin_info_IDX_tag_download_time ON x_plugin_info(tag_download_time);
+CREATE INDEX x_plugin_info_IDX_tag_activation_time ON x_plugin_info(tag_activation_time);
+CREATE INDEX x_plugin_info_IDX_gds_download_time ON x_plugin_info(gds_download_time);
+CREATE INDEX x_plugin_info_IDX_gds_activation_time ON x_plugin_info(gds_activation_time);
+CREATE INDEX x_plugin_info_IDX_role_download_time ON x_plugin_info(role_download_time);
+CREATE INDEX x_plugin_info_IDX_role_activation_time ON x_plugin_info(role_activation_time);
+CREATE INDEX x_plugin_info_IDX_userstore_download_time ON x_plugin_info(userstore_download_time);
+CREATE INDEX x_plugin_info_IDX_userstore_activation_time ON x_plugin_info(userstore_activation_time);
+CREATE INDEX x_plugin_info_IDX_cluster_name ON x_plugin_info(cluster_name);
+CREATE INDEX x_service_version_info_IDX_policy_update_time ON x_service_version_info(policy_update_time);
+CREATE INDEX x_service_version_info_IDX_tag_update_time ON x_service_version_info(tag_update_time);
+CREATE INDEX x_service_version_info_IDX_role_update_time ON x_service_version_info(role_update_time);
+CREATE INDEX x_service_version_info_IDX_gds_update_time ON x_service_version_info(gds_update_time);
 commit;
 
 CREATE OR REPLACE FUNCTION getModulesIdByName(inputval IN VARCHAR2)
@@ -2145,6 +2192,7 @@ INSERT INTO x_db_version_h (id,version,inst_at,inst_by,updated_at,updated_by,act
 INSERT INTO x_db_version_h (id,version,inst_at,inst_by,updated_at,updated_by,active) VALUES (X_DB_VERSION_H_SEQ.nextval, '075',sys_extract_utc(systimestamp),'Ranger 3.0.0',sys_extract_utc(systimestamp),'localhost','Y');
 INSERT INTO x_db_version_h (id,version,inst_at,inst_by,updated_at,updated_by,active) VALUES (X_DB_VERSION_H_SEQ.nextval, '076',sys_extract_utc(systimestamp),'Ranger 3.0.0',sys_extract_utc(systimestamp),'localhost','Y');
 INSERT INTO x_db_version_h (id,version,inst_at,inst_by,updated_at,updated_by,active) VALUES (X_DB_VERSION_H_SEQ.nextval, '077',sys_extract_utc(systimestamp),'Ranger 3.0.0',sys_extract_utc(systimestamp),'localhost','Y');
+INSERT INTO x_db_version_h (id,version,inst_at,inst_by,updated_at,updated_by,active) VALUES (X_DB_VERSION_H_SEQ.nextval, '078',sys_extract_utc(systimestamp),'Ranger 3.0.0',sys_extract_utc(systimestamp),'localhost','Y');
 INSERT INTO x_db_version_h (id,version,inst_at,inst_by,updated_at,updated_by,active) VALUES (X_DB_VERSION_H_SEQ.nextval, 'DB_PATCHES',sys_extract_utc(systimestamp),'Ranger 1.0.0',sys_extract_utc(systimestamp),'localhost','Y');
 
 INSERT INTO x_user_module_perm (id,user_id,module_id,create_time,update_time,added_by_id,upd_by_id,is_allowed) VALUES (X_USER_MODULE_PERM_SEQ.nextval,getXportalUIdByLoginId('admin'),getModulesIdByName('Reports'),sys_extract_utc(systimestamp),sys_extract_utc(systimestamp),getXportalUIdByLoginId('admin'),getXportalUIdByLoginId('admin'),1);
@@ -2230,5 +2278,6 @@ INSERT INTO x_db_version_h (id,version,inst_at,inst_by,updated_at,updated_by,act
 INSERT INTO x_db_version_h (id,version,inst_at,inst_by,updated_at,updated_by,active) VALUES (X_DB_VERSION_H_SEQ.nextval,'J10064',sys_extract_utc(systimestamp),'Ranger 3.0.0',sys_extract_utc(systimestamp),'localhost','Y');
 INSERT INTO x_db_version_h (id,version,inst_at,inst_by,updated_at,updated_by,active) VALUES (X_DB_VERSION_H_SEQ.nextval,'J10065',sys_extract_utc(systimestamp),'Ranger 3.0.0',sys_extract_utc(systimestamp),'localhost','Y');
 INSERT INTO x_db_version_h (id,version,inst_at,inst_by,updated_at,updated_by,active) VALUES (X_DB_VERSION_H_SEQ.nextval,'J10066',sys_extract_utc(systimestamp),'Ranger 3.0.0',sys_extract_utc(systimestamp),'localhost','Y');
+INSERT INTO x_db_version_h (id,version,inst_at,inst_by,updated_at,updated_by,active) VALUES (X_DB_VERSION_H_SEQ.nextval,'J10067',sys_extract_utc(systimestamp),'Ranger 3.0.0',sys_extract_utc(systimestamp),'localhost','Y');
 INSERT INTO x_db_version_h (id,version,inst_at,inst_by,updated_at,updated_by,active) VALUES (X_DB_VERSION_H_SEQ.nextval,'JAVA_PATCHES',sys_extract_utc(systimestamp),'Ranger 1.0.0',sys_extract_utc(systimestamp),'localhost','Y');
 commit;

--- a/security-admin/db/oracle/patches/078-add-columns-in-x_plugin_info.sql
+++ b/security-admin/db/oracle/patches/078-add-columns-in-x_plugin_info.sql
@@ -1,0 +1,205 @@
+-- Licensed to the Apache Software Foundation (ASF) under one or more
+-- contributor license agreements.  See the NOTICE file distributed with
+-- this work for additional information regarding copyright ownership.
+-- The ASF licenses this file to You under the Apache License, Version 2.0
+-- (the "License"); you may not use this file except in compliance with
+-- the License.  You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- sync_source_info CLOB NOT NULL,
+
+DECLARE
+    v_count NUMBER := 0;
+    v_table_exists NUMBER := 0;
+BEGIN
+    SELECT COUNT(*) INTO v_table_exists FROM user_tables WHERE table_name = 'X_PLUGIN_INFO';
+    IF v_table_exists > 0 THEN
+
+        SELECT COUNT(*) INTO v_count FROM user_tab_cols
+        WHERE table_name = 'X_PLUGIN_INFO' AND column_name = 'POLICY_DOWNLOAD_TIME';
+        IF v_count = 0 THEN
+            EXECUTE IMMEDIATE 'ALTER TABLE x_plugin_info ADD policy_download_time NUMBER(20) DEFAULT NULL';
+        END IF;
+
+        SELECT COUNT(*) INTO v_count FROM user_tab_cols
+        WHERE table_name = 'X_PLUGIN_INFO' AND column_name = 'POLICY_ACTIVATION_TIME';
+        IF v_count = 0 THEN
+            EXECUTE IMMEDIATE 'ALTER TABLE x_plugin_info ADD policy_activation_time NUMBER(20) DEFAULT NULL';
+        END IF;
+
+        SELECT COUNT(*) INTO v_count FROM user_tab_cols
+        WHERE table_name = 'X_PLUGIN_INFO' AND column_name = 'TAG_DOWNLOAD_TIME';
+        IF v_count = 0 THEN
+            EXECUTE IMMEDIATE 'ALTER TABLE x_plugin_info ADD tag_download_time NUMBER(20) DEFAULT NULL';
+        END IF;
+
+        SELECT COUNT(*) INTO v_count FROM user_tab_cols
+        WHERE table_name = 'X_PLUGIN_INFO' AND column_name = 'TAG_ACTIVATION_TIME';
+        IF v_count = 0 THEN
+            EXECUTE IMMEDIATE 'ALTER TABLE x_plugin_info ADD tag_activation_time NUMBER(20) DEFAULT NULL';
+        END IF;
+
+        SELECT COUNT(*) INTO v_count FROM user_tab_cols
+        WHERE table_name = 'X_PLUGIN_INFO' AND column_name = 'GDS_DOWNLOAD_TIME';
+        IF v_count = 0 THEN
+            EXECUTE IMMEDIATE 'ALTER TABLE x_plugin_info ADD gds_download_time NUMBER(20) DEFAULT NULL';
+        END IF;
+
+        SELECT COUNT(*) INTO v_count FROM user_tab_cols
+        WHERE table_name = 'X_PLUGIN_INFO' AND column_name = 'GDS_ACTIVATION_TIME';
+        IF v_count = 0 THEN
+            EXECUTE IMMEDIATE 'ALTER TABLE x_plugin_info ADD gds_activation_time NUMBER(20) DEFAULT NULL';
+        END IF;
+
+        SELECT COUNT(*) INTO v_count FROM user_tab_cols
+        WHERE table_name = 'X_PLUGIN_INFO' AND column_name = 'ROLE_DOWNLOAD_TIME';
+        IF v_count = 0 THEN
+            EXECUTE IMMEDIATE 'ALTER TABLE x_plugin_info ADD role_download_time NUMBER(20) DEFAULT NULL';
+        END IF;
+
+        SELECT COUNT(*) INTO v_count FROM user_tab_cols
+        WHERE table_name = 'X_PLUGIN_INFO' AND column_name = 'ROLE_ACTIVATION_TIME';
+        IF v_count = 0 THEN
+            EXECUTE IMMEDIATE 'ALTER TABLE x_plugin_info ADD role_activation_time NUMBER(20) DEFAULT NULL';
+        END IF;
+
+        SELECT COUNT(*) INTO v_count FROM user_tab_cols
+        WHERE table_name = 'X_PLUGIN_INFO' AND column_name = 'USERSTORE_DOWNLOAD_TIME';
+        IF v_count = 0 THEN
+            EXECUTE IMMEDIATE 'ALTER TABLE x_plugin_info ADD userstore_download_time NUMBER(20) DEFAULT NULL';
+        END IF;
+
+        SELECT COUNT(*) INTO v_count FROM user_tab_cols
+        WHERE table_name = 'X_PLUGIN_INFO' AND column_name = 'USERSTORE_ACTIVATION_TIME';
+        IF v_count = 0 THEN
+            EXECUTE IMMEDIATE 'ALTER TABLE x_plugin_info ADD userstore_activation_time NUMBER(20) DEFAULT NULL';
+        END IF;
+
+        SELECT COUNT(*) INTO v_count FROM user_tab_cols
+        WHERE table_name = 'X_PLUGIN_INFO' AND column_name = 'CLUSTER_NAME';
+        IF v_count = 0 THEN
+            EXECUTE IMMEDIATE 'ALTER TABLE x_plugin_info ADD cluster_name VARCHAR2(255) DEFAULT NULL';
+        END IF;
+
+        SELECT COUNT(*) INTO v_index_exists FROM USER_INDEXES WHERE INDEX_NAME = upper('x_plugin_info_IDX_policy_download_time') AND TABLE_NAME= upper('x_plugin_info');
+        IF (v_index_exists = 0) THEN
+            execute IMMEDIATE 'CREATE INDEX x_plugin_info_IDX_policy_download_time ON x_plugin_info(policy_download_time)';
+            commit;
+        END IF;
+
+        SELECT COUNT(*) INTO v_index_exists FROM USER_INDEXES WHERE INDEX_NAME = upper('x_plugin_info_IDX_policy_activation_time') AND TABLE_NAME= upper('x_plugin_info');
+        IF (v_index_exists = 0) THEN
+            execute IMMEDIATE 'CREATE INDEX x_plugin_info_IDX_policy_activation_time ON x_plugin_info(policy_activation_time)';
+            commit;
+        END IF;
+
+        SELECT COUNT(*) INTO v_index_exists FROM USER_INDEXES WHERE INDEX_NAME = upper('x_plugin_info_IDX_tag_download_time') AND TABLE_NAME= upper('x_plugin_info');
+        IF (v_index_exists = 0) THEN
+            execute IMMEDIATE 'CREATE INDEX x_plugin_info_IDX_tag_download_time ON x_plugin_info(tag_download_time)';
+            commit;
+        END IF;
+
+        SELECT COUNT(*) INTO v_index_exists FROM USER_INDEXES WHERE INDEX_NAME = upper('x_plugin_info_IDX_tag_activation_time') AND TABLE_NAME= upper('x_plugin_info');
+        IF (v_index_exists = 0) THEN
+            execute IMMEDIATE 'CREATE INDEX x_plugin_info_IDX_tag_activation_time ON x_plugin_info(tag_activation_time)';
+            commit;
+        END IF;
+
+        SELECT COUNT(*) INTO v_index_exists FROM USER_INDEXES WHERE INDEX_NAME = upper('x_plugin_info_IDX_gds_download_time') AND TABLE_NAME= upper('x_plugin_info');
+        IF (v_index_exists = 0) THEN
+            execute IMMEDIATE 'CREATE INDEX x_plugin_info_IDX_gds_download_time ON x_plugin_info(gds_download_time)';
+            commit;
+        END IF;
+
+        SELECT COUNT(*) INTO v_index_exists FROM USER_INDEXES WHERE INDEX_NAME = upper('x_plugin_info_IDX_gds_activation_time') AND TABLE_NAME= upper('x_plugin_info');
+        IF (v_index_exists = 0) THEN
+            execute IMMEDIATE 'CREATE INDEX x_plugin_info_IDX_gds_activation_time ON x_plugin_info(gds_activation_time)';
+            commit;
+        END IF;
+
+        SELECT COUNT(*) INTO v_index_exists FROM USER_INDEXES WHERE INDEX_NAME = upper('x_plugin_info_IDX_role_download_time') AND TABLE_NAME= upper('x_plugin_info');
+        IF (v_index_exists = 0) THEN
+            execute IMMEDIATE 'CREATE INDEX x_plugin_info_IDX_role_download_time ON x_plugin_info(role_download_time)';
+            commit;
+        END IF;
+
+        SELECT COUNT(*) INTO v_index_exists FROM USER_INDEXES WHERE INDEX_NAME = upper('x_plugin_info_IDX_role_activation_time') AND TABLE_NAME= upper('x_plugin_info');
+        IF (v_index_exists = 0) THEN
+            execute IMMEDIATE 'CREATE INDEX x_plugin_info_IDX_role_activation_time ON x_plugin_info(role_activation_time)';
+            commit;
+        END IF;
+
+        SELECT COUNT(*) INTO v_index_exists FROM USER_INDEXES WHERE INDEX_NAME = upper('x_plugin_info_IDX_userstore_download_time') AND TABLE_NAME= upper('x_plugin_info');
+        IF (v_index_exists = 0) THEN
+            execute IMMEDIATE 'CREATE INDEX x_plugin_info_IDX_userstore_download_time ON x_plugin_info(userstore_download_time)';
+            commit;
+        END IF;
+
+        SELECT COUNT(*) INTO v_index_exists FROM USER_INDEXES WHERE INDEX_NAME = upper('x_plugin_info_IDX_userstore_activation_time') AND TABLE_NAME= upper('x_plugin_info');
+        IF (v_index_exists = 0) THEN
+            execute IMMEDIATE 'CREATE INDEX x_plugin_info_IDX_userstore_activation_time ON x_plugin_info(userstore_activation_time)';
+            commit;
+        END IF;
+
+        SELECT COUNT(*) INTO v_index_exists FROM USER_INDEXES WHERE INDEX_NAME = upper('x_plugin_info_IDX_cluster_name') AND TABLE_NAME= upper('x_plugin_info');
+        IF (v_index_exists = 0) THEN
+            execute IMMEDIATE 'CREATE INDEX x_plugin_info_IDX_cluster_name ON x_plugin_info(cluster_name)';
+            commit;
+        END IF;
+
+        SELECT COUNT(*) INTO v_index_exists FROM USER_INDEXES WHERE INDEX_NAME = upper('x_service_version_info_IDX_policy_update_time') AND TABLE_NAME= upper('x_service_version_info');
+        IF (v_index_exists = 0) THEN
+            execute IMMEDIATE 'CREATE INDEX x_service_version_info_IDX_policy_update_time ON x_service_version_info(policy_update_time)';
+            commit;
+        END IF;
+
+        SELECT COUNT(*) INTO v_index_exists FROM USER_INDEXES WHERE INDEX_NAME = upper('x_service_version_info_IDX_tag_update_time') AND TABLE_NAME= upper('x_service_version_info');
+        IF (v_index_exists = 0) THEN
+            execute IMMEDIATE 'CREATE INDEX x_service_version_info_IDX_tag_update_time ON x_service_version_info(tag_update_time)';
+            commit;
+        END IF;
+
+        SELECT COUNT(*) INTO v_index_exists FROM USER_INDEXES WHERE INDEX_NAME = upper('x_service_version_info_IDX_role_update_time') AND TABLE_NAME= upper('x_service_version_info');
+        IF (v_index_exists = 0) THEN
+            execute IMMEDIATE 'CREATE INDEX x_service_version_info_IDX_role_update_time ON x_service_version_info(role_update_time)';
+            commit;
+        END IF;
+
+        SELECT COUNT(*) INTO v_index_exists FROM USER_INDEXES WHERE INDEX_NAME = upper('x_service_version_info_IDX_gds_update_time') AND TABLE_NAME= upper('x_service_version_info');
+        IF (v_index_exists = 0) THEN
+            execute IMMEDIATE 'CREATE INDEX x_service_version_info_IDX_gds_update_time ON x_service_version_info(gds_update_time)';
+            commit;
+        END IF;
+    END IF;
+
+COMMIT;
+
+call spdropview('vx_plugin_info');
+COMMIT;
+
+CREATE VIEW vx_plugin_info AS
+    SELECT
+        xpi.id, xpi.create_time, xpi.update_time, xpi.service_name,
+        xsd.name AS service_type, xpi.app_type, xpi.host_name, xpi.ip_address, xpi.info, x_ts.is_enabled AS is_tag_service_enable,
+        xpi.policy_download_time, xpi.policy_activation_time, xpi.tag_download_time, xpi.tag_activation_time,
+        xpi.gds_download_time, xpi.gds_activation_time, xpi.role_download_time, xpi.role_activation_time,
+        xpi.userstore_download_time, xpi.userstore_activation_time, xpi.cluster_name,
+        xsvi.policy_update_time AS last_policy_update_time, xsvi.policy_version AS latest_policy_version,
+        xsvi.tag_update_time AS last_tag_update_time, xsvi.tag_version AS latest_tag_version,
+        xsvi.gds_update_time AS last_gds_update_time, xsvi.gds_version AS latest_gds_version,
+        xsvi.role_update_time AS last_role_update_time, xsvi.role_version AS latest_role_version
+    FROM
+        x_plugin_info xpi
+        LEFT OUTER JOIN x_service xs ON xs.name = xpi.service_name
+        LEFT OUTER JOIN x_service_version_info xsvi ON xsvi.service_id = xs.id
+        LEFT OUTER JOIN x_service_def xsd ON xsd.id = xs.type
+        LEFT OUTER JOIN x_service x_ts ON x_ts.id = xs.tag_service;
+commit;
+
+END;/

--- a/security-admin/db/postgres/optimized/current/ranger_core_db_postgres.sql
+++ b/security-admin/db/postgres/optimized/current/ranger_core_db_postgres.sql
@@ -1209,6 +1209,17 @@ app_type varchar(128) NOT NULL,
 host_name varchar(255) NOT NULL,
 ip_address varchar(64) NOT NULL,
 info varchar(1024) NOT NULL,
+policy_download_time BIGINT DEFAULT NULL NULL,
+policy_activation_time BIGINT DEFAULT NULL NULL,
+tag_download_time BIGINT DEFAULT NULL NULL,
+tag_activation_time BIGINT DEFAULT NULL NULL,
+gds_download_time BIGINT DEFAULT NULL NULL,
+gds_activation_time BIGINT DEFAULT NULL NULL,
+role_download_time BIGINT DEFAULT NULL NULL,
+role_activation_time BIGINT DEFAULT NULL NULL,
+userstore_download_time BIGINT DEFAULT NULL NULL,
+userstore_activation_time BIGINT DEFAULT NULL NULL,
+cluster_name varchar(255) DEFAULT NULL,
 primary key (id),
 CONSTRAINT x_plugin_info_UK UNIQUE (service_name, host_name, app_type)
 );
@@ -1966,6 +1977,22 @@ CREATE INDEX x_rms_notification_IDX_ll_service_id ON x_rms_notification(ll_servi
 CREATE INDEX x_rms_resource_mapping_IDX_hl_resource_id ON x_rms_resource_mapping(hl_resource_id);
 CREATE INDEX x_rms_resource_mapping_IDX_ll_resource_id ON x_rms_resource_mapping(ll_resource_id);
 
+CREATE INDEX x_plugin_info_IDX_policy_download_time ON x_plugin_info(policy_download_time);
+CREATE INDEX x_plugin_info_IDX_policy_activation_time ON x_plugin_info(policy_activation_time);
+CREATE INDEX x_plugin_info_IDX_tag_download_time ON x_plugin_info(tag_download_time);
+CREATE INDEX x_plugin_info_IDX_tag_activation_time ON x_plugin_info(tag_activation_time);
+CREATE INDEX x_plugin_info_IDX_gds_download_time ON x_plugin_info(gds_download_time);
+CREATE INDEX x_plugin_info_IDX_gds_activation_time ON x_plugin_info(gds_activation_time);
+CREATE INDEX x_plugin_info_IDX_role_download_time ON x_plugin_info(role_download_time);
+CREATE INDEX x_plugin_info_IDX_role_activation_time ON x_plugin_info(role_activation_time);
+CREATE INDEX x_plugin_info_IDX_userstore_download_time ON x_plugin_info(userstore_download_time);
+CREATE INDEX x_plugin_info_IDX_userstore_activation_time ON x_plugin_info(userstore_activation_time);
+CREATE INDEX x_plugin_info_IDX_cluster_name ON x_plugin_info(cluster_name);
+CREATE INDEX x_service_version_info_IDX_policy_update_time ON x_service_version_info(policy_update_time);
+CREATE INDEX x_service_version_info_IDX_tag_update_time ON x_service_version_info(tag_update_time);
+CREATE INDEX x_service_version_info_IDX_role_update_time ON x_service_version_info(role_update_time);
+CREATE INDEX x_service_version_info_IDX_gds_update_time ON x_service_version_info(gds_update_time);
+
 CREATE OR REPLACE FUNCTION getXportalUIdByLoginId(input_val varchar(100))
 RETURNS bigint LANGUAGE SQL AS $$ SELECT x_portal_user.id FROM x_portal_user
 WHERE x_portal_user.login_id = $1; $$;
@@ -2059,6 +2086,7 @@ INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active
 INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('075',current_timestamp,'Ranger 3.0.0',current_timestamp,'localhost','Y');
 INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('076',current_timestamp,'Ranger 3.0.0',current_timestamp,'localhost','Y');
 INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('077',current_timestamp,'Ranger 3.0.0',current_timestamp,'localhost','Y');
+INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('078',current_timestamp,'Ranger 3.0.0',current_timestamp,'localhost','Y');
 INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('DB_PATCHES',current_timestamp,'Ranger 1.0.0',current_timestamp,'localhost','Y');
 
 INSERT INTO x_user_module_perm (user_id,module_id,create_time,update_time,added_by_id,upd_by_id,is_allowed) VALUES
@@ -2163,7 +2191,27 @@ INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active
 INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('J10064',current_timestamp,'Ranger 3.0.0',current_timestamp,'localhost','Y');
 INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('J10065',current_timestamp,'Ranger 3.0.0',current_timestamp,'localhost','Y');
 INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('J10066',current_timestamp,'Ranger 3.0.0',current_timestamp,'localhost','Y');
+INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('J10067',current_timestamp,'Ranger 3.0.0',current_timestamp,'localhost','Y');
 INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('JAVA_PATCHES',current_timestamp,'Ranger 1.0.0',current_timestamp,'localhost','Y');
 
 DROP VIEW IF EXISTS vx_principal;
 CREATE VIEW vx_principal as (SELECT u.user_name AS principal_name, 0 AS principal_type, u.status status, u.is_visible is_visible, u.other_attributes other_attributes, u.create_time create_time, u.update_time update_time, u.added_by_id added_by_id, u.upd_by_id upd_by_id FROM x_user u) UNION (SELECT g.group_name principal_name, 1 AS principal_type, g.status status, g.is_visible is_visible, g.other_attributes other_attributes, g.create_time create_time, g.update_time update_time, g.added_by_id added_by_id, g.upd_by_id upd_by_id FROM x_group g) UNION (SELECT r.name principal_name, 2 AS principal_name, 1 status, 1 is_visible, null other_attributes, r.create_time create_time, r.update_time update_time, r.added_by_id added_by_id, r.upd_by_id upd_by_id FROM x_role r);
+
+DROP VIEW IF EXISTS vx_plugin_info;
+CREATE VIEW vx_plugin_info AS
+    SELECT
+        xpi.id, xpi.create_time, xpi.update_time, xpi.service_name,
+        xsd.name AS service_type, xpi.app_type, xpi.host_name, xpi.ip_address, xpi.info, x_ts.is_enabled AS is_tag_service_enable,
+        xpi.policy_download_time, xpi.policy_activation_time, xpi.tag_download_time, xpi.tag_activation_time,
+        xpi.gds_download_time, xpi.gds_activation_time, xpi.role_download_time, xpi.role_activation_time,
+        xpi.userstore_download_time, xpi.userstore_activation_time, xpi.cluster_name,
+        xsvi.policy_update_time AS last_policy_update_time, xsvi.policy_version AS latest_policy_version,
+        xsvi.tag_update_time AS last_tag_update_time, xsvi.tag_version AS latest_tag_version,
+        xsvi.gds_update_time AS last_gds_update_time, xsvi.gds_version AS latest_gds_version,
+        xsvi.role_update_time AS last_role_update_time, xsvi.role_version AS latest_role_version
+    FROM
+        x_plugin_info xpi
+        LEFT OUTER JOIN x_service xs ON xs.name = xpi.service_name
+        LEFT OUTER JOIN x_service_version_info xsvi ON xsvi.service_id = xs.id
+        LEFT OUTER JOIN x_service_def xsd ON xsd.id = xs."type"
+        LEFT OUTER JOIN x_service x_ts ON x_ts.id = xs.tag_service;

--- a/security-admin/db/postgres/patches/078-add-columns-in-x_plugin_info.sql
+++ b/security-admin/db/postgres/patches/078-add-columns-in-x_plugin_info.sql
@@ -1,0 +1,220 @@
+-- Licensed to the Apache Software Foundation (ASF) under one or more
+-- contributor license agreements.  See the NOTICE file distributed with
+-- this work for additional information regarding copyright ownership.
+-- The ASF licenses this file to You under the Apache License, Version 2.0
+-- (the "License"); you may not use this file except in compliance with
+-- the License.  You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+SELECT 'delimiter start';
+
+CREATE OR REPLACE FUNCTION add_columns_and_indexes_for_plugin_info()
+RETURNS void AS $$
+DECLARE
+    v_column_exists integer := 0;
+    v_attnum1 integer := 0;
+BEGIN
+    SELECT COUNT(*) INTO v_column_exists FROM pg_attribute
+    WHERE attrelid = (SELECT oid FROM pg_class WHERE relname = 'x_plugin_info') AND attname = 'policy_download_time';
+    IF v_column_exists = 0 THEN
+        ALTER TABLE x_plugin_info ADD COLUMN policy_download_time BIGINT DEFAULT NULL;
+    END IF;
+
+    SELECT COUNT(*) INTO v_column_exists FROM pg_attribute
+    WHERE attrelid = (SELECT oid FROM pg_class WHERE relname = 'x_plugin_info') AND attname = 'policy_activation_time';
+    IF v_column_exists = 0 THEN
+        ALTER TABLE x_plugin_info ADD COLUMN policy_activation_time BIGINT DEFAULT NULL;
+    END IF;
+
+    SELECT COUNT(*) INTO v_column_exists FROM pg_attribute
+    WHERE attrelid = (SELECT oid FROM pg_class WHERE relname = 'x_plugin_info') AND attname = 'tag_download_time';
+    IF v_column_exists = 0 THEN
+        ALTER TABLE x_plugin_info ADD COLUMN tag_download_time BIGINT DEFAULT NULL;
+    END IF;
+
+    SELECT COUNT(*) INTO v_column_exists FROM pg_attribute
+    WHERE attrelid = (SELECT oid FROM pg_class WHERE relname = 'x_plugin_info') AND attname = 'tag_activation_time';
+    IF v_column_exists = 0 THEN
+        ALTER TABLE x_plugin_info ADD COLUMN tag_activation_time BIGINT DEFAULT NULL;
+    END IF;
+
+    SELECT COUNT(*) INTO v_column_exists FROM pg_attribute
+    WHERE attrelid = (SELECT oid FROM pg_class WHERE relname = 'x_plugin_info') AND attname = 'gds_download_time';
+    IF v_column_exists = 0 THEN
+        ALTER TABLE x_plugin_info ADD COLUMN gds_download_time BIGINT DEFAULT NULL;
+    END IF;
+
+    SELECT COUNT(*) INTO v_column_exists FROM pg_attribute
+    WHERE attrelid = (SELECT oid FROM pg_class WHERE relname = 'x_plugin_info') AND attname = 'gds_activation_time';
+    IF v_column_exists = 0 THEN
+        ALTER TABLE x_plugin_info ADD COLUMN gds_activation_time BIGINT DEFAULT NULL;
+    END IF;
+
+    SELECT COUNT(*) INTO v_column_exists FROM pg_attribute
+    WHERE attrelid = (SELECT oid FROM pg_class WHERE relname = 'x_plugin_info') AND attname = 'role_download_time';
+    IF v_column_exists = 0 THEN
+        ALTER TABLE x_plugin_info ADD COLUMN role_download_time BIGINT DEFAULT NULL;
+    END IF;
+
+    SELECT COUNT(*) INTO v_column_exists FROM pg_attribute
+    WHERE attrelid = (SELECT oid FROM pg_class WHERE relname = 'x_plugin_info') AND attname = 'role_activation_time';
+    IF v_column_exists = 0 THEN
+        ALTER TABLE x_plugin_info ADD COLUMN role_activation_time BIGINT DEFAULT NULL;
+    END IF;
+
+    SELECT COUNT(*) INTO v_column_exists FROM pg_attribute
+    WHERE attrelid = (SELECT oid FROM pg_class WHERE relname = 'x_plugin_info') AND attname = 'userstore_download_time';
+    IF v_column_exists = 0 THEN
+        ALTER TABLE x_plugin_info ADD COLUMN userstore_download_time BIGINT DEFAULT NULL;
+    END IF;
+
+    SELECT COUNT(*) INTO v_column_exists FROM pg_attribute
+    WHERE attrelid = (SELECT oid FROM pg_class WHERE relname = 'x_plugin_info') AND attname = 'userstore_activation_time';
+    IF v_column_exists = 0 THEN
+        ALTER TABLE x_plugin_info ADD COLUMN userstore_activation_time BIGINT DEFAULT NULL;
+    END IF;
+
+    SELECT COUNT(*) INTO v_column_exists FROM pg_attribute
+    WHERE attrelid = (SELECT oid FROM pg_class WHERE relname = 'x_plugin_info') AND attname = 'cluster_name';
+    IF v_column_exists = 0 THEN
+        ALTER TABLE x_plugin_info ADD COLUMN cluster_name VARCHAR(255) DEFAULT NULL;
+    END IF;
+
+    select attnum into v_attnum1 from pg_attribute where attrelid in(select oid from pg_class where relname='x_plugin_info') and attname in('policy_download_time');
+    IF v_attnum1 > 0 THEN
+        IF not exists (select * from pg_index where indrelid in(select oid from pg_class where relname='x_plugin_info') and indkey[0]=v_attnum1) THEN
+            CREATE INDEX x_plugin_info_IDX_policy_download_time ON x_plugin_info(policy_download_time);
+        END IF;
+    END IF;
+
+    select attnum into v_attnum1 from pg_attribute where attrelid in(select oid from pg_class where relname='x_plugin_info') and attname in('policy_activation_time');
+    IF v_attnum1 > 0 THEN
+        IF not exists (select * from pg_index where indrelid in(select oid from pg_class where relname='x_plugin_info') and indkey[0]=v_attnum1) THEN
+            CREATE INDEX x_plugin_info_IDX_policy_activation_time ON x_plugin_info(policy_activation_time);
+        END IF;
+    END IF;
+
+    select attnum into v_attnum1 from pg_attribute where attrelid in(select oid from pg_class where relname='x_plugin_info') and attname in('tag_download_time');
+    IF v_attnum1 > 0 THEN
+        IF not exists (select * from pg_index where indrelid in(select oid from pg_class where relname='x_plugin_info') and indkey[0]=v_attnum1) THEN
+            CREATE INDEX x_plugin_info_IDX_tag_download_time ON x_plugin_info(tag_download_time);
+        END IF;
+    END IF;
+
+    select attnum into v_attnum1 from pg_attribute where attrelid in(select oid from pg_class where relname='x_plugin_info') and attname in('tag_activation_time');
+    IF v_attnum1 > 0 THEN
+        IF not exists (select * from pg_index where indrelid in(select oid from pg_class where relname='x_plugin_info') and indkey[0]=v_attnum1) THEN
+            CREATE INDEX x_plugin_info_IDX_tag_activation_time ON x_plugin_info(tag_activation_time);
+        END IF;
+    END IF;
+
+    select attnum into v_attnum1 from pg_attribute where attrelid in(select oid from pg_class where relname='x_plugin_info') and attname in('gds_download_time');
+    IF v_attnum1 > 0 THEN
+        IF not exists (select * from pg_index where indrelid in(select oid from pg_class where relname='x_plugin_info') and indkey[0]=v_attnum1) THEN
+            CREATE INDEX x_plugin_info_IDX_gds_download_time ON x_plugin_info(gds_download_time);
+        END IF;
+    END IF;
+
+
+    select attnum into v_attnum1 from pg_attribute where attrelid in(select oid from pg_class where relname='x_plugin_info') and attname in('gds_activation_time');
+    IF v_attnum1 > 0 THEN
+        IF not exists (select * from pg_index where indrelid in(select oid from pg_class where relname='x_plugin_info') and indkey[0]=v_attnum1) THEN
+            CREATE INDEX x_plugin_info_IDX_gds_activation_time ON x_plugin_info(gds_activation_time);
+        END IF;
+    END IF;
+
+    select attnum into v_attnum1 from pg_attribute where attrelid in(select oid from pg_class where relname='x_plugin_info') and attname in('role_download_time');
+    IF v_attnum1 > 0 THEN
+        IF not exists (select * from pg_index where indrelid in(select oid from pg_class where relname='x_plugin_info') and indkey[0]=v_attnum1) THEN
+            CREATE INDEX x_plugin_info_IDX_role_download_time ON x_plugin_info(role_download_time);
+        END IF;
+    END IF;
+
+    select attnum into v_attnum1 from pg_attribute where attrelid in(select oid from pg_class where relname='x_plugin_info') and attname in('role_activation_time');
+    IF v_attnum1 > 0 THEN
+        IF not exists (select * from pg_index where indrelid in(select oid from pg_class where relname='x_plugin_info') and indkey[0]=v_attnum1) THEN
+            CREATE INDEX x_plugin_info_IDX_role_activation_time ON x_plugin_info(role_activation_time);
+        END IF;
+    END IF;
+
+    select attnum into v_attnum1 from pg_attribute where attrelid in(select oid from pg_class where relname='x_plugin_info') and attname in('userstore_download_time');
+    IF v_attnum1 > 0 THEN
+        IF not exists (select * from pg_index where indrelid in(select oid from pg_class where relname='x_plugin_info') and indkey[0]=v_attnum1) THEN
+            CREATE INDEX x_plugin_info_IDX_userstore_download_time ON x_plugin_info(userstore_download_time);
+        END IF;
+    END IF;
+
+    select attnum into v_attnum1 from pg_attribute where attrelid in(select oid from pg_class where relname='x_plugin_info') and attname in('userstore_activation_time');
+    IF v_attnum1 > 0 THEN
+        IF not exists (select * from pg_index where indrelid in(select oid from pg_class where relname='x_plugin_info') and indkey[0]=v_attnum1) THEN
+            CREATE INDEX x_plugin_info_IDX_userstore_activation_time ON x_plugin_info(userstore_activation_time);
+        END IF;
+    END IF;
+
+    select attnum into v_attnum1 from pg_attribute where attrelid in(select oid from pg_class where relname='x_plugin_info') and attname in('cluster_name');
+    IF v_attnum1 > 0 THEN
+        IF not exists (select * from pg_index where indrelid in(select oid from pg_class where relname='x_plugin_info') and indkey[0]=v_attnum1) THEN
+            CREATE INDEX x_plugin_info_IDX_cluster_name ON x_plugin_info(cluster_name);
+        END IF;
+    END IF;
+
+    select attnum into v_attnum1 from pg_attribute where attrelid in(select oid from pg_class where relname='x_service_version_info') and attname in('policy_update_time');
+    IF v_attnum1 > 0 THEN
+        IF not exists (select * from pg_index where indrelid in(select oid from pg_class where relname='x_service_version_info') and indkey[0]=v_attnum1) THEN
+            CREATE INDEX x_service_version_info_IDX_policy_update_time ON x_service_version_info(policy_update_time);
+        END IF;
+    END IF;
+
+    select attnum into v_attnum1 from pg_attribute where attrelid in(select oid from pg_class where relname='x_service_version_info') and attname in('tag_update_time');
+    IF v_attnum1 > 0 THEN
+        IF not exists (select * from pg_index where indrelid in(select oid from pg_class where relname='x_service_version_info') and indkey[0]=v_attnum1) THEN
+            CREATE INDEX x_service_version_info_IDX_tag_update_time ON x_service_version_info(tag_update_time);
+        END IF;
+    END IF;
+
+    select attnum into v_attnum1 from pg_attribute where attrelid in(select oid from pg_class where relname='x_service_version_info') and attname in('role_update_time');
+    IF v_attnum1 > 0 THEN
+        IF not exists (select * from pg_index where indrelid in(select oid from pg_class where relname='x_service_version_info') and indkey[0]=v_attnum1) THEN
+            CREATE INDEX x_service_version_info_IDX_role_update_time ON x_service_version_info(role_update_time);
+        END IF;
+    END IF;
+
+    select attnum into v_attnum1 from pg_attribute where attrelid in(select oid from pg_class where relname='x_service_version_info') and attname in('gds_update_time');
+    IF v_attnum1 > 0 THEN
+        IF not exists (select * from pg_index where indrelid in(select oid from pg_class where relname='x_service_version_info') and indkey[0]=v_attnum1) THEN
+            CREATE INDEX x_service_version_info_IDX_gds_update_time ON x_service_version_info(gds_update_time);
+        END IF;
+    END IF;
+
+DROP VIEW IF EXISTS vx_plugin_info;
+CREATE VIEW vx_plugin_info AS
+    SELECT
+        xpi.id, xpi.create_time, xpi.update_time, xpi.service_name,
+        xsd.name AS service_type, xpi.app_type, xpi.host_name, xpi.ip_address, xpi.info, x_ts.is_enabled AS is_tag_service_enable,
+        xpi.policy_download_time, xpi.policy_activation_time, xpi.tag_download_time, xpi.tag_activation_time,
+        xpi.gds_download_time, xpi.gds_activation_time, xpi.role_download_time, xpi.role_activation_time,
+        xpi.userstore_download_time, xpi.userstore_activation_time, xpi.cluster_name,
+        xsvi.policy_update_time AS last_policy_update_time, xsvi.policy_version AS latest_policy_version,
+        xsvi.tag_update_time AS last_tag_update_time, xsvi.tag_version AS latest_tag_version,
+        xsvi.gds_update_time AS last_gds_update_time, xsvi.gds_version AS latest_gds_version,
+        xsvi.role_update_time AS last_role_update_time, xsvi.role_version AS latest_role_version
+    FROM
+        x_plugin_info xpi
+        LEFT OUTER JOIN x_service xs ON xs.name = xpi.service_name
+        LEFT OUTER JOIN x_service_version_info xsvi ON xsvi.service_id = xs.id
+        LEFT OUTER JOIN x_service_def xsd ON xsd.id = xs."type"
+        LEFT OUTER JOIN x_service x_ts ON x_ts.id = xs.tag_service;
+
+END;
+$$ LANGUAGE plpgsql;
+SELECT 'delimiter end';
+
+SELECT add_columns_and_indexes_for_plugin_info();
+SELECT 'delimiter end';

--- a/security-admin/db/sqlanywhere/optimized/current/ranger_core_db_sqlanywhere.sql
+++ b/security-admin/db/sqlanywhere/optimized/current/ranger_core_db_sqlanywhere.sql
@@ -36,6 +36,8 @@ BEGIN
 END
 
 GO
+DROP VIEW IF EXISTS dbo.vx_plugin_info
+GO
 call dbo.removeForeignKeysAndTable('x_rms_mapping_provider')
 GO
 call dbo.removeForeignKeysAndTable('x_rms_resource_mapping')
@@ -1029,9 +1031,38 @@ CREATE TABLE dbo.x_plugin_info(
 		host_name varchar(255) NOT NULL,
 		ip_address varchar(64) NOT NULL,
 		info varchar(1024) NOT NULL,
+		policy_download_time bigint DEFAULT NULL NULL,
+		policy_activation_time bigint DEFAULT NULL NULL,
+		tag_download_time bigint DEFAULT NULL NULL,
+		tag_activation_time bigint DEFAULT NULL NULL,
+		gds_download_time bigint DEFAULT NULL NULL,
+		gds_activation_time bigint DEFAULT NULL NULL,
+		role_download_time bigint DEFAULT NULL NULL,
+		role_activation_time bigint DEFAULT NULL NULL,
+		userstore_download_time bigint DEFAULT NULL NULL,
+		userstore_activation_time bigint DEFAULT NULL NULL,
+		cluster_name varchar(255) DEFAULT NULL,
 		CONSTRAINT x_plugin_info_PK_id PRIMARY KEY CLUSTERED(id),
 		CONSTRAINT x_plugin_info_UK UNIQUE NONCLUSTERED (service_name, host_name, app_type)
 )
+GO
+CREATE VIEW dbo.vx_plugin_info AS
+    SELECT
+        xpi.id, xpi.create_time, xpi.update_time, xpi.service_name,
+        xsd.name AS service_type, xpi.app_type, xpi.host_name, xpi.ip_address, xpi.info, x_ts.is_enabled AS is_tag_service_enable,
+        xpi.policy_download_time, xpi.policy_activation_time, xpi.tag_download_time, xpi.tag_activation_time,
+        xpi.gds_download_time, xpi.gds_activation_time, xpi.role_download_time, xpi.role_activation_time,
+        xpi.userstore_download_time, xpi.userstore_activation_time, xpi.cluster_name,
+        xsvi.policy_update_time AS last_policy_update_time, xsvi.policy_version AS latest_policy_version,
+        xsvi.tag_update_time AS last_tag_update_time, xsvi.tag_version AS latest_tag_version,
+        xsvi.gds_update_time AS last_gds_update_time, xsvi.gds_version AS latest_gds_version,
+        xsvi.role_update_time AS last_role_update_time, xsvi.role_version AS latest_role_version
+    FROM
+        x_plugin_info xpi
+        LEFT OUTER JOIN x_service xs ON xs.name = xpi.service_name
+        LEFT OUTER JOIN x_service_version_info xsvi ON xsvi.service_id = xs.id
+        LEFT OUTER JOIN x_service_def xsd ON xsd.id = xs."type"
+        LEFT OUTER JOIN x_service x_ts ON x_ts.id = xs.tag_service
 GO
 CREATE TABLE dbo.x_policy_label (
 		id bigint IDENTITY NOT NULL,
@@ -1997,6 +2028,37 @@ GO
 CREATE NONCLUSTERED INDEX x_data_hist_idx_objid_objclstype ON dbo.x_data_hist(obj_id ASC, obj_class_type ASC)
 GO
 
+CREATE NONCLUSTERED INDEX x_plugin_info_IDX_policy_download_time ON dbo.x_plugin_info(policy_download_time ASC)
+GO
+CREATE NONCLUSTERED INDEX x_plugin_info_IDX_policy_activation_time ON dbo.x_plugin_info(policy_activation_time ASC)
+GO
+CREATE NONCLUSTERED INDEX x_plugin_info_IDX_tag_download_time ON dbo.x_plugin_info(tag_download_time ASC)
+GO
+CREATE NONCLUSTERED INDEX x_plugin_info_IDX_tag_activation_time ON dbo.x_plugin_info(tag_activation_time ASC)
+GO
+CREATE NONCLUSTERED INDEX x_plugin_info_IDX_gds_download_time ON dbo.x_plugin_info(gds_download_time ASC)
+GO
+CREATE NONCLUSTERED INDEX x_plugin_info_IDX_gds_activation_time ON dbo.x_plugin_info(gds_activation_time ASC)
+GO
+CREATE NONCLUSTERED INDEX x_plugin_info_IDX_role_download_time ON dbo.x_plugin_info(role_download_time ASC)
+GO
+CREATE NONCLUSTERED INDEX x_plugin_info_IDX_role_activation_time ON dbo.x_plugin_info(role_activation_time ASC)
+GO
+CREATE NONCLUSTERED INDEX x_plugin_info_IDX_userstore_download_time ON dbo.x_plugin_info(userstore_download_time ASC)
+GO
+CREATE NONCLUSTERED INDEX x_plugin_info_IDX_userstore_activation_time ON dbo.x_plugin_info(userstore_activation_time ASC)
+GO
+CREATE NONCLUSTERED INDEX x_plugin_info_IDX_cluster_name ON dbo.x_plugin_info(cluster_name ASC)
+GO
+CREATE NONCLUSTERED INDEX x_service_version_info_IDX_policy_update_time ON dbo.x_service_version_info(policy_update_time ASC)
+GO
+CREATE NONCLUSTERED INDEX x_service_version_info_IDX_tag_update_time ON dbo.x_service_version_info(tag_update_time ASC)
+GO
+CREATE NONCLUSTERED INDEX x_service_version_info_IDX_role_update_time ON dbo.x_service_version_info(role_update_time ASC)
+GO
+CREATE NONCLUSTERED INDEX x_service_version_info_IDX_gds_update_time ON dbo.x_service_version_info(gds_update_time ASC)
+GO
+
 CREATE OR REPLACE FUNCTION dbo.getXportalUIdByLoginId (input_val CHAR(60))
 RETURNS INTEGER
 BEGIN
@@ -2236,6 +2298,8 @@ INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active
 GO
 INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('077',CURRENT_TIMESTAMP,'Ranger 3.0.0',CURRENT_TIMESTAMP,'localhost','Y');
 GO
+INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('078',CURRENT_TIMESTAMP,'Ranger 3.0.0',CURRENT_TIMESTAMP,'localhost','Y');
+GO
 INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('DB_PATCHES',CURRENT_TIMESTAMP,'Ranger 1.0.0',CURRENT_TIMESTAMP,'localhost','Y');
 GO
 INSERT INTO x_user_module_perm (user_id,module_id,create_time,update_time,added_by_id,upd_by_id,is_allowed) VALUES (dbo.getXportalUIdByLoginId('admin'),dbo.getModulesIdByName('Reports'),CURRENT_TIMESTAMP,CURRENT_TIMESTAMP,dbo.getXportalUIdByLoginId('admin'),dbo.getXportalUIdByLoginId('admin'),1);
@@ -2393,6 +2457,8 @@ GO
 INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('J10065',CURRENT_TIMESTAMP,'Ranger 3.0.0',CURRENT_TIMESTAMP,'localhost','Y');
 GO
 INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('J10066',CURRENT_TIMESTAMP,'Ranger 3.0.0',CURRENT_TIMESTAMP,'localhost','Y');
+GO
+INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('J10067',CURRENT_TIMESTAMP,'Ranger 3.0.0',CURRENT_TIMESTAMP,'localhost','Y');
 GO
 INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('JAVA_PATCHES',CURRENT_TIMESTAMP,'Ranger 1.0.0',CURRENT_TIMESTAMP,'localhost','Y');
 GO

--- a/security-admin/db/sqlanywhere/patches/078-add-columns-in-x_plugin_info.sql
+++ b/security-admin/db/sqlanywhere/patches/078-add-columns-in-x_plugin_info.sql
@@ -1,0 +1,114 @@
+-- Licensed to the Apache Software Foundation (ASF) under one or more
+-- contributor license agreements.  See the NOTICE file distributed with
+-- this work for additional information regarding copyright ownership.
+-- The ASF licenses this file to You under the Apache License, Version 2.0
+-- (the "License"); you may not use this file except in compliance with
+-- the License.  You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+IF EXISTS (SELECT * FROM SYS.SYSCOLUMNS where tname = 'x_plugin_info') THEN
+    IF NOT EXISTS (SELECT * FROM SYS.SYSCOLUMNS where tname = 'x_plugin_info' and cname = 'policy_download_time') THEN
+        ALTER TABLE dbo.x_plugin_info ADD policy_download_time BIGINT(20) NULL DEFAULT NULL;
+    END IF;
+
+    IF NOT EXISTS (SELECT * FROM SYS.SYSCOLUMNS where tname = 'x_plugin_info' and cname = 'policy_activation_time') THEN
+        ALTER TABLE dbo.x_plugin_info ADD policy_activation_time BIGINT(20) NULL DEFAULT NULL;
+    END IF;
+
+    IF NOT EXISTS (SELECT * FROM SYS.SYSCOLUMNS where tname = 'x_plugin_info' and cname = 'tag_download_time') THEN
+        ALTER TABLE dbo.x_plugin_info ADD tag_download_time BIGINT(20) NULL DEFAULT NULL;
+    END IF;
+
+    IF NOT EXISTS (SELECT * FROM SYS.SYSCOLUMNS where tname = 'x_plugin_info' and cname = 'tag_activation_time') THEN
+        ALTER TABLE dbo.x_plugin_info ADD tag_activation_time BIGINT(20) NULL DEFAULT NULL;
+    END IF;
+
+    IF NOT EXISTS (SELECT * FROM SYS.SYSCOLUMNS where tname = 'x_plugin_info' and cname = 'gds_download_time') THEN
+        ALTER TABLE dbo.x_plugin_info ADD gds_download_time BIGINT(20) NULL DEFAULT NULL;
+    END IF;
+
+    IF NOT EXISTS (SELECT * FROM SYS.SYSCOLUMNS where tname = 'x_plugin_info' and cname = 'gds_activation_time') THEN
+        ALTER TABLE dbo.x_plugin_info ADD gds_activation_time BIGINT(20) NULL DEFAULT NULL;
+    END IF;
+
+    IF NOT EXISTS (SELECT * FROM SYS.SYSCOLUMNS where tname = 'x_plugin_info' and cname = 'role_download_time') THEN
+        ALTER TABLE dbo.x_plugin_info ADD role_download_time BIGINT(20) NULL DEFAULT NULL;
+    END IF;
+
+    IF NOT EXISTS (SELECT * FROM SYS.SYSCOLUMNS where tname = 'x_plugin_info' and cname = 'role_activation_time') THEN
+        ALTER TABLE dbo.x_plugin_info ADD role_activation_time BIGINT(20) NULL DEFAULT NULL;
+    END IF;
+
+    IF NOT EXISTS (SELECT * FROM SYS.SYSCOLUMNS where tname = 'x_plugin_info' and cname = 'userstore_download_time') THEN
+        ALTER TABLE dbo.x_plugin_info ADD userstore_download_time BIGINT(20) NULL DEFAULT NULL;
+    END IF;
+
+    IF NOT EXISTS (SELECT * FROM SYS.SYSCOLUMNS where tname = 'x_plugin_info' and cname = 'userstore_activation_time') THEN
+        ALTER TABLE dbo.x_plugin_info ADD userstore_activation_time BIGINT(20) NULL DEFAULT NULL;
+    END IF;
+
+    IF NOT EXISTS (SELECT * FROM SYS.SYSCOLUMNS where tname = 'x_plugin_info' and cname = 'cluster_name') THEN
+        ALTER TABLE dbo.x_plugin_info ADD cluster_name VARCHAR(255) NULL DEFAULT NULL;
+    END IF;
+END IF;
+GO
+
+CREATE NONCLUSTERED INDEX x_plugin_info_IDX_policy_download_time ON dbo.x_plugin_info(policy_download_time ASC)
+GO
+CREATE NONCLUSTERED INDEX x_plugin_info_IDX_policy_activation_time ON dbo.x_plugin_info(policy_activation_time ASC)
+GO
+CREATE NONCLUSTERED INDEX x_plugin_info_IDX_tag_download_time ON dbo.x_plugin_info(tag_download_time ASC)
+GO
+CREATE NONCLUSTERED INDEX x_plugin_info_IDX_tag_activation_time ON dbo.x_plugin_info(tag_activation_time ASC)
+GO
+CREATE NONCLUSTERED INDEX x_plugin_info_IDX_gds_download_time ON dbo.x_plugin_info(gds_download_time ASC)
+GO
+CREATE NONCLUSTERED INDEX x_plugin_info_IDX_gds_activation_time ON dbo.x_plugin_info(gds_activation_time ASC)
+GO
+CREATE NONCLUSTERED INDEX x_plugin_info_IDX_role_download_time ON dbo.x_plugin_info(role_download_time ASC)
+GO
+CREATE NONCLUSTERED INDEX x_plugin_info_IDX_role_activation_time ON dbo.x_plugin_info(role_activation_time ASC)
+GO
+CREATE NONCLUSTERED INDEX x_plugin_info_IDX_userstore_download_time ON dbo.x_plugin_info(userstore_download_time ASC)
+GO
+CREATE NONCLUSTERED INDEX x_plugin_info_IDX_userstore_activation_time ON dbo.x_plugin_info(userstore_activation_time ASC)
+GO
+CREATE NONCLUSTERED INDEX x_plugin_info_IDX_cluster_name ON dbo.x_plugin_info(cluster_name ASC)
+GO
+CREATE NONCLUSTERED INDEX x_service_version_info_IDX_policy_update_time ON dbo.x_service_version_info(policy_update_time ASC)
+GO
+CREATE NONCLUSTERED INDEX x_service_version_info_IDX_tag_update_time ON dbo.x_service_version_info(tag_update_time ASC)
+GO
+CREATE NONCLUSTERED INDEX x_service_version_info_IDX_role_update_time ON dbo.x_service_version_info(role_update_time ASC)
+GO
+CREATE NONCLUSTERED INDEX x_service_version_info_IDX_gds_update_time ON dbo.x_service_version_info(gds_update_time ASC)
+GO
+
+DROP VIEW IF EXISTS dbo.vx_plugin_info
+GO
+CREATE VIEW dbo.vx_plugin_info AS
+    SELECT
+        xpi.id, xpi.create_time, xpi.update_time, xpi.service_name,
+        xsd.name AS service_type, xpi.app_type, xpi.host_name, xpi.ip_address, xpi.info, x_ts.is_enabled AS is_tag_service_enable,
+        xpi.policy_download_time, xpi.policy_activation_time, xpi.tag_download_time, xpi.tag_activation_time,
+        xpi.gds_download_time, xpi.gds_activation_time, xpi.role_download_time, xpi.role_activation_time,
+        xpi.userstore_download_time, xpi.userstore_activation_time, xpi.cluster_name,
+        xsvi.policy_update_time AS last_policy_update_time, xsvi.policy_version AS latest_policy_version,
+        xsvi.tag_update_time AS last_tag_update_time, xsvi.tag_version AS latest_tag_version,
+        xsvi.gds_update_time AS last_gds_update_time, xsvi.gds_version AS latest_gds_version,
+        xsvi.role_update_time AS last_role_update_time, xsvi.role_version AS latest_role_version
+    FROM
+        x_plugin_info xpi
+        LEFT OUTER JOIN x_service xs ON xs.name = xpi.service_name
+        LEFT OUTER JOIN x_service_version_info xsvi ON xsvi.service_id = xs.id
+        LEFT OUTER JOIN x_service_def xsd ON xsd.id = xs."type"
+        LEFT OUTER JOIN x_service x_ts ON x_ts.id = xs.tag_service
+GO
+exit

--- a/security-admin/db/sqlserver/optimized/current/ranger_core_db_sqlserver.sql
+++ b/security-admin/db/sqlserver/optimized/current/ranger_core_db_sqlserver.sql
@@ -1038,6 +1038,10 @@ IF (OBJECT_ID('x_db_version_h') IS NOT NULL)
 BEGIN
     DROP TABLE [dbo].[x_db_version_h]
 END
+IF (OBJECT_ID('vx_plugin_info') IS NOT NULL)
+BEGIN
+    DROP VIEW [dbo].[vx_plugin_info]
+END
 IF (OBJECT_ID('x_gds_dataset') IS NOT NULL)
 BEGIN
     DROP TABLE [dbo].[x_gds_dataset]
@@ -2220,6 +2224,17 @@ CREATE TABLE [dbo].[x_plugin_info](
         [host_name] [varchar](255) NOT NULL,
         [ip_address] [varchar](64) NOT NULL,
         [info] [varchar](1024) NOT NULL,
+        [policy_download_time] [bigint] DEFAULT NULL NULL,
+        [policy_activation_time] [bigint] DEFAULT NULL NULL,
+        [tag_download_time] [bigint] DEFAULT NULL NULL,
+        [tag_activation_time] [bigint] DEFAULT NULL NULL,
+        [gds_download_time] [bigint] DEFAULT NULL NULL,
+        [gds_activation_time] [bigint] DEFAULT NULL NULL,
+        [role_download_time] [bigint] DEFAULT NULL NULL,
+        [role_activation_time] [bigint] DEFAULT NULL NULL,
+        [userstore_download_time] [bigint] DEFAULT NULL NULL,
+        [userstore_activation_time] [bigint] DEFAULT NULL NULL,
+        [cluster_name] [varchar](255) DEFAULT NULL,
         PRIMARY KEY CLUSTERED
 (
         [id] ASC
@@ -3826,6 +3841,82 @@ CREATE NONCLUSTERED INDEX [x_data_hist_idx_objid_objclstype] ON [x_data_hist]
    [obj_id] ASC,[obj_class_type] ASC
 )WITH (SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, IGNORE_DUP_KEY = OFF, ONLINE = OFF) ON [PRIMARY]
 
+CREATE NONCLUSTERED INDEX [x_plugin_info_IDX_policy_download_time] ON [x_plugin_info]
+(
+   [policy_download_time] ASC
+)
+WITH (SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, IGNORE_DUP_KEY = OFF, ONLINE = OFF) ON [PRIMARY]
+CREATE NONCLUSTERED INDEX [x_plugin_info_IDX_policy_activation_time] ON [x_plugin_info]
+(
+   [policy_activation_time] ASC
+)
+WITH (SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, IGNORE_DUP_KEY = OFF, ONLINE = OFF) ON [PRIMARY]
+CREATE NONCLUSTERED INDEX [x_plugin_info_IDX_tag_download_time] ON [x_plugin_info]
+(
+   [tag_download_time] ASC
+)
+WITH (SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, IGNORE_DUP_KEY = OFF, ONLINE = OFF) ON [PRIMARY]
+CREATE NONCLUSTERED INDEX [x_plugin_info_IDX_tag_activation_time] ON [x_plugin_info]
+(
+   [tag_activation_time] ASC
+)
+WITH (SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, IGNORE_DUP_KEY = OFF, ONLINE = OFF) ON [PRIMARY]
+CREATE NONCLUSTERED INDEX [x_plugin_info_IDX_gds_download_time] ON [x_plugin_info]
+(
+   [gds_download_time] ASC
+)
+WITH (SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, IGNORE_DUP_KEY = OFF, ONLINE = OFF) ON [PRIMARY]
+CREATE NONCLUSTERED INDEX [x_plugin_info_IDX_gds_activation_time] ON [x_plugin_info]
+(
+   [gds_activation_time] ASC
+)
+WITH (SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, IGNORE_DUP_KEY = OFF, ONLINE = OFF) ON [PRIMARY]
+CREATE NONCLUSTERED INDEX [x_plugin_info_IDX_role_download_time] ON [x_plugin_info]
+(
+   [role_download_time] ASC
+)
+WITH (SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, IGNORE_DUP_KEY = OFF, ONLINE = OFF) ON [PRIMARY]
+CREATE NONCLUSTERED INDEX [x_plugin_info_IDX_role_activation_time] ON [x_plugin_info]
+(
+   [role_activation_time] ASC
+)
+WITH (SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, IGNORE_DUP_KEY = OFF, ONLINE = OFF) ON [PRIMARY]
+CREATE NONCLUSTERED INDEX [x_plugin_info_IDX_userstore_download_time] ON [x_plugin_info]
+(
+   [userstore_download_time] ASC
+)
+WITH (SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, IGNORE_DUP_KEY = OFF, ONLINE = OFF) ON [PRIMARY]
+CREATE NONCLUSTERED INDEX [x_plugin_info_IDX_userstore_activation_time] ON [x_plugin_info]
+(
+   [userstore_activation_time] ASC
+)
+WITH (SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, IGNORE_DUP_KEY = OFF, ONLINE = OFF) ON [PRIMARY]
+CREATE NONCLUSTERED INDEX [x_plugin_info_IDX_cluster_name] ON [x_plugin_info]
+(
+   [cluster_name] ASC
+)
+WITH (SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, IGNORE_DUP_KEY = OFF, ONLINE = OFF) ON [PRIMARY]
+CREATE NONCLUSTERED INDEX [x_service_version_info_IDX_policy_update_time] ON [x_service_version_info]
+(
+   [policy_update_time] ASC
+)
+WITH (SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, IGNORE_DUP_KEY = OFF, ONLINE = OFF) ON [PRIMARY]
+CREATE NONCLUSTERED INDEX [x_service_version_info_IDX_tag_update_time] ON [tag_update_time]
+(
+   [policy_update_time] ASC
+)
+WITH (SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, IGNORE_DUP_KEY = OFF, ONLINE = OFF) ON [PRIMARY]
+CREATE NONCLUSTERED INDEX [x_service_version_info_IDX_role_update_time] ON [role_update_time]
+(
+   [policy_update_time] ASC
+)
+WITH (SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, IGNORE_DUP_KEY = OFF, ONLINE = OFF) ON [PRIMARY]
+CREATE NONCLUSTERED INDEX [x_service_version_info_IDX_gds_update_time] ON [gds_update_time]
+(
+   [policy_update_time] ASC
+)
+WITH (SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, IGNORE_DUP_KEY = OFF, ONLINE = OFF) ON [PRIMARY]
+
 SET ANSI_NULLS ON
 GO
 SET QUOTED_IDENTIFIER ON
@@ -4512,6 +4603,7 @@ INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active
 INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('075',CURRENT_TIMESTAMP,'Ranger 3.0.0',CURRENT_TIMESTAMP,'localhost','Y');
 INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('076',CURRENT_TIMESTAMP,'Ranger 3.0.0',CURRENT_TIMESTAMP,'localhost','Y');
 INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('077',CURRENT_TIMESTAMP,'Ranger 3.0.0',CURRENT_TIMESTAMP,'localhost','Y');
+INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('078',CURRENT_TIMESTAMP,'Ranger 3.0.0',CURRENT_TIMESTAMP,'localhost','Y');
 INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('DB_PATCHES',CURRENT_TIMESTAMP,'Ranger 1.0.0',CURRENT_TIMESTAMP,'localhost','Y');
 INSERT INTO x_user_module_perm (user_id,module_id,create_time,update_time,added_by_id,upd_by_id,is_allowed) VALUES (dbo.getXportalUIdByLoginId('admin'),dbo.getModulesIdByName('Reports'),CURRENT_TIMESTAMP,CURRENT_TIMESTAMP,dbo.getXportalUIdByLoginId('admin'),dbo.getXportalUIdByLoginId('admin'),1);
 INSERT INTO x_user_module_perm (user_id,module_id,create_time,update_time,added_by_id,upd_by_id,is_allowed) VALUES (dbo.getXportalUIdByLoginId('admin'),dbo.getModulesIdByName('Resource Based Policies'),CURRENT_TIMESTAMP,CURRENT_TIMESTAMP,dbo.getXportalUIdByLoginId('admin'),dbo.getXportalUIdByLoginId('admin'),1);
@@ -4596,5 +4688,25 @@ INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active
 INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('J10064',CURRENT_TIMESTAMP,'Ranger 3.0.0',CURRENT_TIMESTAMP,'localhost','Y');
 INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('J10065',CURRENT_TIMESTAMP,'Ranger 3.0.0',CURRENT_TIMESTAMP,'localhost','Y');
 INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('J10066',CURRENT_TIMESTAMP,'Ranger 3.0.0',CURRENT_TIMESTAMP,'localhost','Y');
+INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('J10067',CURRENT_TIMESTAMP,'Ranger 3.0.0',CURRENT_TIMESTAMP,'localhost','Y');
 INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('JAVA_PATCHES',CURRENT_TIMESTAMP,'Ranger 1.0.0',CURRENT_TIMESTAMP,'localhost','Y');
+GO
+
+CREATE VIEW [dbo].[vx_plugin_info] AS
+    SELECT
+        xpi.id, xpi.create_time, xpi.update_time, xpi.service_name,
+        xsd.name AS service_type, xpi.app_type, xpi.host_name, xpi.ip_address, xpi.info, x_ts.is_enabled AS is_tag_service_enable,
+        xpi.policy_download_time, xpi.policy_activation_time, xpi.tag_download_time, xpi.tag_activation_time,
+        xpi.gds_download_time, xpi.gds_activation_time, xpi.role_download_time, xpi.role_activation_time,
+        xpi.userstore_download_time, xpi.userstore_activation_time, xpi.cluster_name,
+        xsvi.policy_update_time AS last_policy_update_time, xsvi.policy_version AS latest_policy_version,
+        xsvi.tag_update_time AS last_tag_update_time, xsvi.tag_version AS latest_tag_version,
+        xsvi.gds_update_time AS last_gds_update_time, xsvi.gds_version AS latest_gds_version,
+        xsvi.role_update_time AS last_role_update_time, xsvi.role_version AS latest_role_version
+    FROM
+        x_plugin_info xpi
+        LEFT OUTER JOIN x_service xs ON xs.name = xpi.service_name
+        LEFT OUTER JOIN x_service_version_info xsvi ON xsvi.service_id = xs.id
+        LEFT OUTER JOIN x_service_def xsd ON xsd.id = xs.[type]
+        LEFT OUTER JOIN x_service x_ts ON x_ts.id = xs.tag_service;
 GO

--- a/security-admin/db/sqlserver/patches/078-add-columns-in-x_plugin_info.sql
+++ b/security-admin/db/sqlserver/patches/078-add-columns-in-x_plugin_info.sql
@@ -1,0 +1,222 @@
+-- Licensed to the Apache Software Foundation (ASF) under one or more
+-- contributor license agreements.  See the NOTICE file distributed with
+-- this work for additional information regarding copyright ownership.
+-- The ASF licenses this file to You under the Apache License, Version 2.0
+-- (the "License"); you may not use this file except in compliance with
+-- the License.  You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+GO
+IF EXISTS (SELECT * FROM INFORMATION_SCHEMA.columns where table_name = 'x_plugin_info')
+BEGIN
+    IF NOT EXISTS (SELECT * FROM SYS.SYSCOLUMNS where tname = 'x_plugin_info' and cname = 'policy_download_time')
+    BEGIN
+        ALTER TABLE [dbo].[x_plugin_info] ADD [policy_download_time] [bigint] DEFAULT NULL NULL;
+    END
+
+    IF NOT EXISTS (SELECT * FROM SYS.SYSCOLUMNS where tname = 'x_plugin_info' and cname = 'policy_activation_time')
+    BEGIN
+        ALTER TABLE [dbo].[x_plugin_info] ADD [policy_activation_time] [bigint] DEFAULT NULL NULL;
+    END
+
+    IF NOT EXISTS (SELECT * FROM SYS.SYSCOLUMNS where tname = 'x_plugin_info' and cname = 'tag_download_time')
+    BEGIN
+        ALTER TABLE [dbo].[x_plugin_info] ADD [tag_download_time] [bigint] DEFAULT NULL NULL;
+    END
+
+    IF NOT EXISTS (SELECT * FROM SYS.SYSCOLUMNS where tname = 'x_plugin_info' and cname = 'tag_activation_time')
+    BEGIN
+        ALTER TABLE [dbo].[x_plugin_info] ADD [tag_activation_time] [bigint] DEFAULT NULL NULL;
+    END
+
+    IF NOT EXISTS (SELECT * FROM SYS.SYSCOLUMNS where tname = 'x_plugin_info' and cname = 'gds_download_time')
+    BEGIN
+        ALTER TABLE [dbo].[x_plugin_info] ADD [gds_download_time] [bigint] DEFAULT NULL NULL;
+    END
+
+    IF NOT EXISTS (SELECT * FROM SYS.SYSCOLUMNS where tname = 'x_plugin_info' and cname = 'gds_activation_time')
+    BEGIN
+        ALTER TABLE [dbo].[x_plugin_info] ADD [gds_activation_time] [bigint] DEFAULT NULL NULL;
+    END
+
+    IF NOT EXISTS (SELECT * FROM SYS.SYSCOLUMNS where tname = 'x_plugin_info' and cname = 'role_download_time')
+    BEGIN
+        ALTER TABLE [dbo].[x_plugin_info] ADD [role_download_time] [bigint] DEFAULT NULL NULL;
+    END
+
+    IF NOT EXISTS (SELECT * FROM SYS.SYSCOLUMNS where tname = 'x_plugin_info' and cname = 'role_activation_time')
+    BEGIN
+        ALTER TABLE [dbo].[x_plugin_info] ADD [role_activation_time] [bigint] DEFAULT NULL NULL;
+    END
+
+    IF NOT EXISTS (SELECT * FROM SYS.SYSCOLUMNS where tname = 'x_plugin_info' and cname = 'userstore_download_time')
+    BEGIN
+        ALTER TABLE [dbo].[x_plugin_info] ADD [userstore_download_time] [bigint] DEFAULT NULL NULL;
+    END
+
+    IF NOT EXISTS (SELECT * FROM SYS.SYSCOLUMNS where tname = 'x_plugin_info' and cname = 'userstore_activation_time')
+    BEGIN
+        ALTER TABLE [dbo].[x_plugin_info] ADD [userstore_activation_time] [bigint] DEFAULT NULL NULL;
+    END
+
+    IF NOT EXISTS (SELECT * FROM SYS.SYSCOLUMNS where tname = 'x_plugin_info' and cname = 'cluster_name')
+    BEGIN
+        ALTER TABLE [dbo].[x_plugin_info] ADD [cluster_name] [varchar](255) DEFAULT NULL;
+    END
+END
+GO
+
+IF NOT EXISTS(SELECT * FROM sys.indexes WHERE name = 'x_plugin_info_IDX_policy_download_time' AND object_id = OBJECT_ID('x_plugin_info'))
+BEGIN
+    CREATE NONCLUSTERED INDEX [x_plugin_info_IDX_policy_download_time] ON [x_plugin_info]
+    (
+        [policy_download_time] ASC
+    )
+    WITH (SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, IGNORE_DUP_KEY = OFF, ONLINE = OFF) ON [PRIMARY]
+END
+IF NOT EXISTS(SELECT * FROM sys.indexes WHERE name = 'x_plugin_info_IDX_policy_activation_time' AND object_id = OBJECT_ID('x_plugin_info'))
+BEGIN
+    CREATE NONCLUSTERED INDEX [x_plugin_info_IDX_policy_activation_time] ON [x_plugin_info]
+    (
+        [policy_activation_time] ASC
+    )
+    WITH (SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, IGNORE_DUP_KEY = OFF, ONLINE = OFF) ON [PRIMARY]
+END
+IF NOT EXISTS(SELECT * FROM sys.indexes WHERE name = 'x_plugin_info_IDX_tag_download_time' AND object_id = OBJECT_ID('x_plugin_info'))
+BEGIN
+    CREATE NONCLUSTERED INDEX [x_plugin_info_IDX_tag_download_time] ON [x_plugin_info]
+    (
+        [tag_download_time] ASC
+    )
+    WITH (SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, IGNORE_DUP_KEY = OFF, ONLINE = OFF) ON [PRIMARY]
+END
+IF NOT EXISTS(SELECT * FROM sys.indexes WHERE name = 'x_plugin_info_IDX_tag_activation_time' AND object_id = OBJECT_ID('x_plugin_info'))
+BEGIN
+    CREATE NONCLUSTERED INDEX [x_plugin_info_IDX_tag_activation_time] ON [x_plugin_info]
+    (
+        [tag_activation_time] ASC
+    )
+    WITH (SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, IGNORE_DUP_KEY = OFF, ONLINE = OFF) ON [PRIMARY]
+END
+IF NOT EXISTS(SELECT * FROM sys.indexes WHERE name = 'x_plugin_info_IDX_gds_download_time' AND object_id = OBJECT_ID('x_plugin_info'))
+BEGIN
+    CREATE NONCLUSTERED INDEX [x_plugin_info_IDX_gds_download_time] ON [x_plugin_info]
+    (
+        [gds_download_time] ASC
+    )
+    WITH (SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, IGNORE_DUP_KEY = OFF, ONLINE = OFF) ON [PRIMARY]
+END
+IF NOT EXISTS(SELECT * FROM sys.indexes WHERE name = 'x_plugin_info_IDX_gds_activation_time' AND object_id = OBJECT_ID('x_plugin_info'))
+BEGIN
+    CREATE NONCLUSTERED INDEX [x_plugin_info_IDX_gds_activation_time] ON [x_plugin_info]
+    (
+        [gds_activation_time] ASC
+    )
+    WITH (SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, IGNORE_DUP_KEY = OFF, ONLINE = OFF) ON [PRIMARY]
+END
+IF NOT EXISTS(SELECT * FROM sys.indexes WHERE name = 'x_plugin_info_IDX_role_download_time' AND object_id = OBJECT_ID('x_plugin_info'))
+BEGIN
+    CREATE NONCLUSTERED INDEX [x_plugin_info_IDX_role_download_time] ON [x_plugin_info]
+    (
+        [role_download_time] ASC
+    )
+    WITH (SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, IGNORE_DUP_KEY = OFF, ONLINE = OFF) ON [PRIMARY]
+END
+IF NOT EXISTS(SELECT * FROM sys.indexes WHERE name = 'x_plugin_info_IDX_role_activation_time' AND object_id = OBJECT_ID('x_plugin_info'))
+BEGIN
+    CREATE NONCLUSTERED INDEX [x_plugin_info_IDX_role_activation_time] ON [x_plugin_info]
+    (
+        [role_activation_time] ASC
+    )
+    WITH (SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, IGNORE_DUP_KEY = OFF, ONLINE = OFF) ON [PRIMARY]
+END
+IF NOT EXISTS(SELECT * FROM sys.indexes WHERE name = 'x_plugin_info_IDX_userstore_download_time' AND object_id = OBJECT_ID('x_plugin_info'))
+BEGIN
+    CREATE NONCLUSTERED INDEX [x_plugin_info_IDX_userstore_download_time] ON [x_plugin_info]
+    (
+        [userstore_download_time] ASC
+    )
+    WITH (SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, IGNORE_DUP_KEY = OFF, ONLINE = OFF) ON [PRIMARY]
+END
+IF NOT EXISTS(SELECT * FROM sys.indexes WHERE name = 'x_plugin_info_IDX_userstore_activation_time' AND object_id = OBJECT_ID('x_plugin_info'))
+BEGIN
+    CREATE NONCLUSTERED INDEX [x_plugin_info_IDX_userstore_activation_time] ON [x_plugin_info]
+    (
+        [userstore_activation_time] ASC
+    )
+    WITH (SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, IGNORE_DUP_KEY = OFF, ONLINE = OFF) ON [PRIMARY]
+END
+IF NOT EXISTS(SELECT * FROM sys.indexes WHERE name = 'x_plugin_info_IDX_cluster_name' AND object_id = OBJECT_ID('x_plugin_info'))
+BEGIN
+    CREATE NONCLUSTERED INDEX [x_plugin_info_IDX_cluster_name] ON [x_plugin_info]
+    (
+        [cluster_name] ASC
+    )
+    WITH (SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, IGNORE_DUP_KEY = OFF, ONLINE = OFF) ON [PRIMARY]
+END
+IF NOT EXISTS(SELECT * FROM sys.indexes WHERE name = 'x_service_version_info_IDX_policy_update_time' AND object_id = OBJECT_ID('x_service_version_info'))
+BEGIN
+    CREATE NONCLUSTERED INDEX [x_service_version_info_IDX_policy_update_time] ON [x_service_version_info]
+    (
+        [policy_update_time] ASC
+    )
+    WITH (SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, IGNORE_DUP_KEY = OFF, ONLINE = OFF) ON [PRIMARY]
+END
+IF NOT EXISTS(SELECT * FROM sys.indexes WHERE name = 'x_service_version_info_IDX_tag_update_time' AND object_id = OBJECT_ID('x_service_version_info'))
+BEGIN
+    CREATE NONCLUSTERED INDEX [x_service_version_info_IDX_tag_update_time] ON [x_service_version_info]
+    (
+        [tag_update_time] ASC
+    )
+    WITH (SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, IGNORE_DUP_KEY = OFF, ONLINE = OFF) ON [PRIMARY]
+END
+IF NOT EXISTS(SELECT * FROM sys.indexes WHERE name = 'x_service_version_info_IDX_role_update_time' AND object_id = OBJECT_ID('x_service_version_info'))
+BEGIN
+    CREATE NONCLUSTERED INDEX [x_service_version_info_IDX_role_update_time] ON [x_service_version_info]
+    (
+        [role_update_time] ASC
+    )
+    WITH (SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, IGNORE_DUP_KEY = OFF, ONLINE = OFF) ON [PRIMARY]
+END
+IF NOT EXISTS(SELECT * FROM sys.indexes WHERE name = 'x_service_version_info_IDX_gds_update_time' AND object_id = OBJECT_ID('x_service_version_info'))
+BEGIN
+    CREATE NONCLUSTERED INDEX [x_service_version_info_IDX_gds_update_time] ON [x_service_version_info]
+    (
+        [gds_update_time] ASC
+    )
+    WITH (SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, IGNORE_DUP_KEY = OFF, ONLINE = OFF) ON [PRIMARY]
+END
+GO
+
+IF (OBJECT_ID('vx_plugin_info') IS NOT NULL)
+BEGIN
+    DROP VIEW [dbo].[vx_plugin_info]
+END
+
+CREATE VIEW [dbo].[vx_plugin_info] AS
+    SELECT
+        xpi.id, xpi.create_time, xpi.update_time, xpi.service_name,
+        xsd.name AS service_type, xpi.app_type, xpi.host_name, xpi.ip_address, xpi.info, x_ts.is_enabled AS is_tag_service_enable,
+        xpi.policy_download_time, xpi.policy_activation_time, xpi.tag_download_time, xpi.tag_activation_time,
+        xpi.gds_download_time, xpi.gds_activation_time, xpi.role_download_time, xpi.role_activation_time,
+        xpi.userstore_download_time, xpi.userstore_activation_time, xpi.cluster_name,
+        xsvi.policy_update_time AS last_policy_update_time, xsvi.policy_version AS latest_policy_version,
+        xsvi.tag_update_time AS last_tag_update_time, xsvi.tag_version AS latest_tag_version,
+        xsvi.gds_update_time AS last_gds_update_time, xsvi.gds_version AS latest_gds_version,
+        xsvi.role_update_time AS last_role_update_time, xsvi.role_version AS latest_role_version
+    FROM
+        x_plugin_info xpi
+        LEFT OUTER JOIN x_service xs ON xs.name = xpi.service_name
+        LEFT OUTER JOIN x_service_version_info xsvi ON xsvi.service_id = xs.id
+        LEFT OUTER JOIN x_service_def xsd ON xsd.id = xs.[type]
+        LEFT OUTER JOIN x_service x_ts ON x_ts.id = xs.tag_service;
+GO
+
+exit

--- a/security-admin/src/main/java/org/apache/ranger/biz/AssetMgr.java
+++ b/security-admin/src/main/java/org/apache/ranger/biz/AssetMgr.java
@@ -1308,7 +1308,7 @@ public class AssetMgr extends AssetMgrBase {
                 Map<String, String> infoMap       = dbObj.getInfo();
 
                 if (infoMap != null && !stringUtil.isEmpty(clusterName)) {
-                    if (!stringUtil.isEmpty(infoMap.get(SearchFilter.CLUSTER_NAME)) && !stringUtil.equals(infoMap.get(SearchFilter.CLUSTER_NAME), clusterName)) {
+                    if (stringUtil.isEmpty(infoMap.get(SearchFilter.CLUSTER_NAME)) || !stringUtil.equals(infoMap.get(SearchFilter.CLUSTER_NAME), clusterName)) {
                         infoMap.put(SearchFilter.CLUSTER_NAME, clusterName);
 
                         needsUpdating = true;

--- a/security-admin/src/main/java/org/apache/ranger/entity/view/VXXPluginInfo.java
+++ b/security-admin/src/main/java/org/apache/ranger/entity/view/VXXPluginInfo.java
@@ -17,33 +17,25 @@
  * under the License.
  */
 
-package org.apache.ranger.entity;
+package org.apache.ranger.entity.view;
 
-import org.apache.ranger.common.AppConstants;
+import org.apache.ranger.common.DateUtil;
 
-import javax.persistence.Cacheable;
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
 
 import java.util.Date;
-import java.util.Objects;
 
 @Entity
-@Cacheable
-@Table(name = "x_plugin_info")
-public class XXPluginInfo implements java.io.Serializable {
+@Table(name = "vx_plugin_info")
+public class VXXPluginInfo implements java.io.Serializable {
     private static final long serialVersionUID = 1L;
 
     @Id
-    @SequenceGenerator(name = "X_PLUGIN_INFO_SEQ", sequenceName = "X_PLUGIN_INFO_SEQ", allocationSize = 1)
-    @GeneratedValue(strategy = GenerationType.AUTO, generator = "X_PLUGIN_INFO_SEQ")
     @Column(name = "id")
     protected Long id;
 
@@ -58,6 +50,9 @@ public class XXPluginInfo implements java.io.Serializable {
     @Column(name = "service_name")
     protected String serviceName;
 
+    @Column(name = "service_type")
+    protected String serviceType;
+
     @Column(name = "app_type")
     protected String appType;
 
@@ -69,6 +64,9 @@ public class XXPluginInfo implements java.io.Serializable {
 
     @Column(name = "info")
     protected String info;
+
+    @Column(name = "is_tag_service_enable")
+    protected Boolean isTagServiceEnabled;
 
     @Column(name = "policy_download_time")
     protected Long policyDownloadTime;
@@ -103,84 +101,36 @@ public class XXPluginInfo implements java.io.Serializable {
     @Column(name = "cluster_name")
     protected String clusterName;
 
-    /**
-     * Default constructor. This will set all the attributes to default value.
-     */
-    public XXPluginInfo() {
-    }
+    @Column(name = "latest_policy_version")
+    protected Long latestPolicyVersion;
 
-    public static boolean equals(Object object1, Object object2) {
-        if (object1 == object2) {
-            return true;
-        } else if ((object1 == null) || (object2 == null)) {
-            return false;
-        }
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name = "last_policy_update_time", nullable = false)
+    protected Date lastPolicyUpdateTime = DateUtil.getUTCDate();
 
-        return object1.equals(object2);
-    }
+    @Column(name = "latest_tag_version")
+    protected Long latestTagVersion;
 
-    @Override
-    public int hashCode() {
-        return super.hashCode();
-    }
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name = "last_tag_update_time", nullable = false)
+    protected Date lastTagUpdateTime = DateUtil.getUTCDate();
 
-    /**
-     * Checks for all attributes except referenced db objects
-     *
-     * @return true if all attributes match
-     */
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        } else if (obj == null) {
-            return false;
-        } else if (getClass() != obj.getClass()) {
-            return false;
-        }
+    @Column(name = "latest_gds_version")
+    protected Long latestGdsVersion;
 
-        XXPluginInfo other = (XXPluginInfo) obj;
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name = "last_gds_update_time", nullable = false)
+    protected Date lastGdsUpdateTime = DateUtil.getUTCDate();
 
-        return Objects.equals(id, other.id) &&
-                Objects.equals(createTime, other.createTime) &&
-                Objects.equals(updateTime, other.updateTime) &&
-                Objects.equals(serviceName, other.serviceName) &&
-                Objects.equals(hostName, other.hostName) &&
-                Objects.equals(appType, other.appType) &&
-                Objects.equals(ipAddress, other.ipAddress) &&
-                Objects.equals(info, other.info);
-    }
+    @Column(name = "latest_role_version")
+    protected Long latestRoleVersion;
 
-    /**
-     * This return the bean content in string format
-     *
-     * @return formatedStr
-     */
-    @Override
-    public String toString() {
-        String str = "XXPluginInfo={";
-        str += "id={" + id + "} ";
-        str += "createTime={" + createTime + "} ";
-        str += "updateTime={" + updateTime + "} ";
-        str += "serviceName={" + serviceName + "} ";
-        str += "hostName={" + hostName + "} ";
-        str += "appType={" + appType + "} ";
-        str += "ipAddress={" + ipAddress + "} ";
-        str += "info={" + info + "} ";
-        str += "}";
-        return str;
-    }
-
-    public int getMyClassType() {
-        return AppConstants.CLASS_TYPE_NONE;
-    }
-
-    public String getMyDisplayValue() {
-        return null;
-    }
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name = "last_role_update_time", nullable = false)
+    protected Date lastRoleUpdateTime = DateUtil.getUTCDate();
 
     public Long getId() {
-        return this.id;
+        return id;
     }
 
     public void setId(Long id) {
@@ -188,7 +138,7 @@ public class XXPluginInfo implements java.io.Serializable {
     }
 
     public Date getCreateTime() {
-        return this.createTime;
+        return createTime;
     }
 
     public void setCreateTime(Date createTime) {
@@ -196,7 +146,7 @@ public class XXPluginInfo implements java.io.Serializable {
     }
 
     public Date getUpdateTime() {
-        return this.updateTime;
+        return updateTime;
     }
 
     public void setUpdateTime(Date updateTime) {
@@ -204,15 +154,23 @@ public class XXPluginInfo implements java.io.Serializable {
     }
 
     public String getServiceName() {
-        return this.serviceName;
+        return serviceName;
     }
 
     public void setServiceName(String serviceName) {
         this.serviceName = serviceName;
     }
 
+    public String getServiceType() {
+        return serviceType;
+    }
+
+    public void setServiceType(String serviceType) {
+        this.serviceType = serviceType;
+    }
+
     public String getAppType() {
-        return this.appType;
+        return appType;
     }
 
     public void setAppType(String appType) {
@@ -220,7 +178,7 @@ public class XXPluginInfo implements java.io.Serializable {
     }
 
     public String getHostName() {
-        return this.hostName;
+        return hostName;
     }
 
     public void setHostName(String hostName) {
@@ -228,7 +186,7 @@ public class XXPluginInfo implements java.io.Serializable {
     }
 
     public String getIpAddress() {
-        return this.ipAddress;
+        return ipAddress;
     }
 
     public void setIpAddress(String ipAddress) {
@@ -236,11 +194,19 @@ public class XXPluginInfo implements java.io.Serializable {
     }
 
     public String getInfo() {
-        return this.info;
+        return info;
     }
 
     public void setInfo(String info) {
         this.info = info;
+    }
+
+    public Boolean getIsTagServiceEnabled() {
+        return isTagServiceEnabled;
+    }
+
+    public void setIsTagServiceEnabled(Boolean isTagServiceEnabled) {
+        this.isTagServiceEnabled = isTagServiceEnabled;
     }
 
     public Long getPolicyDownloadTime() {
@@ -329,5 +295,98 @@ public class XXPluginInfo implements java.io.Serializable {
 
     public void setClusterName(String clusterName) {
         this.clusterName = clusterName;
+    }
+
+    public Long getLatestPolicyVersion() {
+        return latestPolicyVersion;
+    }
+
+    public void setLatestPolicyVersion(Long latestPolicyVersion) {
+        this.latestPolicyVersion = latestPolicyVersion;
+    }
+
+    public Date getLastPolicyUpdateTime() {
+        return lastPolicyUpdateTime;
+    }
+
+    public void setLastPolicyUpdateTime(Date lastPolicyUpdateTime) {
+        this.lastPolicyUpdateTime = lastPolicyUpdateTime;
+    }
+
+    public Long getLatestTagVersion() {
+        return latestTagVersion;
+    }
+
+    public void setLatestTagVersion(Long latestTagVersion) {
+        this.latestTagVersion = latestTagVersion;
+    }
+
+    public Date getLastTagUpdateTime() {
+        return lastTagUpdateTime;
+    }
+
+    public void setLastTagUpdateTime(Date lastTagUpdateTime) {
+        this.lastTagUpdateTime = lastTagUpdateTime;
+    }
+
+    public Long getLatestGdsVersion() {
+        return latestGdsVersion;
+    }
+
+    public void setLatestGdsVersion(Long latestGdsVersion) {
+        this.latestGdsVersion = latestGdsVersion;
+    }
+
+    public Date getLastGdsUpdateTime() {
+        return lastGdsUpdateTime;
+    }
+
+    public void setLastGdsUpdateTime(Date lastGdsUpdateTime) {
+        this.lastGdsUpdateTime = lastGdsUpdateTime;
+    }
+
+    public Long getLatestRoleVersion() {
+        return latestRoleVersion;
+    }
+
+    public void setLatestRoleVersion(Long latestRoleVersion) {
+        this.latestRoleVersion = latestRoleVersion;
+    }
+
+    public Date getLastRoleUpdateTime() {
+        return lastRoleUpdateTime;
+    }
+
+    public void setLastRoleUpdateTime(Date lastRoleUpdateTime) {
+        this.lastRoleUpdateTime = lastRoleUpdateTime;
+    }
+
+    @Override
+    public String toString() {
+        String str = "VXXPluginInfo={";
+        str += "id={" + id + "} ";
+        str += "createTime={" + createTime + "} ";
+        str += "updateTime={" + updateTime + "} ";
+        str += "serviceName={" + serviceName + "} ";
+        str += "hostName={" + hostName + "} ";
+        str += "appType={" + appType + "} ";
+        str += "ipAddress={" + ipAddress + "} ";
+        str += "serviceType={" + serviceType + "} ";
+        str += "isTagServiceEnabled={" + isTagServiceEnabled + "} ";
+        str += "clusterName={" + clusterName + "} ";
+        str += "}";
+        return str;
+    }
+
+    public static boolean equals(Object object1, Object object2) {
+        boolean ret = false;
+
+        if (object1 == object2) {
+            ret = true;
+        } else if ((object1 != null) && (object2 != null)) {
+            ret = object1.equals(object2);
+        }
+
+        return ret;
     }
 }

--- a/security-admin/src/main/java/org/apache/ranger/patch/PatchForPluginStatusEventSorting_J10067.java
+++ b/security-admin/src/main/java/org/apache/ranger/patch/PatchForPluginStatusEventSorting_J10067.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ranger.patch;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.ranger.db.RangerDaoManager;
+import org.apache.ranger.entity.XXPluginInfo;
+import org.apache.ranger.plugin.model.RangerPluginInfo;
+import org.apache.ranger.service.RangerPluginInfoService;
+import org.apache.ranger.util.CLIUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.support.TransactionCallback;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+@Component
+public class PatchForPluginStatusEventSorting_J10067 extends BaseLoader {
+    private static final Logger logger = LoggerFactory.getLogger(PatchForPluginStatusEventSorting_J10067.class);
+
+    private static final int BATCH_SIZE  = 25;
+    private static final int NUM_THREADS = 5;
+
+    private TransactionTemplate          txTemplate;
+    private Iterator<XXPluginInfo>       pluginInfoIterator = Collections.emptyIterator();
+    private final AtomicLong             migratedCount      = new AtomicLong();
+
+    @Autowired
+    RangerDaoManager daoMgr;
+
+    @Autowired
+    RangerPluginInfoService pluginInfoService;
+
+    @Autowired
+    @Qualifier(value = "transactionManager")
+    PlatformTransactionManager txManager;
+
+    public static void main(String[] args) {
+        logger.info("PatchForPluginStatusEventSorting_J10067: main()");
+
+        try {
+            PatchForPluginStatusEventSorting_J10067 loader = (PatchForPluginStatusEventSorting_J10067) CLIUtil.getBean(PatchForPluginStatusEventSorting_J10067.class);
+
+            loader.init();
+
+            while (loader.isMoreToProcess()) {
+                loader.load();
+            }
+
+            logger.info("Load complete. Exiting!!!");
+            System.exit(0);
+        } catch (Exception e) {
+            logger.error("Error loading plugin status event sorting patch.", e);
+            System.exit(1);
+        }
+    }
+
+    @Override
+    public void init() throws Exception {
+        txTemplate = new TransactionTemplate(txManager);
+        txTemplate.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+    }
+
+    @Override
+    public void execLoad() {
+        logger.info("==> PatchForPluginStatusEventSorting_J10067.execLoad()");
+
+        try {
+            updateXPluginInfoForEventSorting();
+        } catch (Exception e) {
+            logger.error("Error while updating plugin info for event sorting.", e);
+        }
+
+        logger.info("<== PatchForPluginStatusEventSorting_J10067.execLoad()");
+    }
+
+    @Override
+    public void printStats() {
+        logger.debug("Starting plugin status migration with {} threads and a commit batch size of {}.", NUM_THREADS, BATCH_SIZE);
+    }
+
+    private void updateXPluginInfoForEventSorting() throws Exception {
+        logger.info("==> updateXPluginInfoForEventSorting() ");
+
+        String             queryStr = "SELECT obj FROM " + XXPluginInfo.class.getName() + " obj ";
+        List<XXPluginInfo> xObjList  = daoMgr.getEntityManager().createQuery(queryStr, XXPluginInfo.class).getResultList();
+
+        if (CollectionUtils.isNotEmpty(xObjList)) {
+            logger.info("Found {} plugin info records to process.", xObjList.size());
+
+            pluginInfoIterator = xObjList.iterator();
+
+            PluginStatusThread[] migrationThreads = new PluginStatusThread[NUM_THREADS];
+
+            for (int i = 0; i < migrationThreads.length; i++) {
+                migrationThreads[i] = new PluginStatusThread();
+                migrationThreads[i].start();
+            }
+
+            for (PluginStatusThread migrationThread : migrationThreads) {
+                migrationThread.join();
+            }
+        } else {
+            logger.info("No plugin info records found to process.");
+        }
+
+        logger.info("<== updateXPluginInfoForEventSorting() ");
+    }
+
+    private void updateXPluginInfo(XXPluginInfo xObj) {
+        RangerPluginInfo pluginInfo = pluginInfoService.populateViewObject(xObj);
+
+        daoMgr.getXXPluginInfo().update(pluginInfoService.populateDBObject(pluginInfo));
+
+        long count = migratedCount.incrementAndGet();
+
+        if (count % 1000 == 0) {
+            logger.info("PROGRESS: {} plugin status records processed.", count);
+        }
+    }
+
+    private void fetchNextBatch(List<XXPluginInfo> pluginInfos) {
+        pluginInfos.clear();
+
+        synchronized (this) {
+            for (int i = 0; i < BATCH_SIZE && pluginInfoIterator.hasNext(); i++) {
+                pluginInfos.add(pluginInfoIterator.next());
+            }
+        }
+    }
+
+    class PluginStatusThread extends Thread {
+        @Override
+        public void run() {
+            List<XXPluginInfo> pluginInfos = new ArrayList<>(BATCH_SIZE);
+
+            fetchNextBatch(pluginInfos);
+
+            while (!pluginInfos.isEmpty()) {
+                txTemplate.execute((TransactionCallback<Void>) status -> {
+                    for (XXPluginInfo pluginInfo : pluginInfos) {
+                        updateXPluginInfo(pluginInfo);
+                    }
+
+                    return null;
+                });
+                fetchNextBatch(pluginInfos);
+            }
+        }
+    }
+}

--- a/security-admin/src/main/java/org/apache/ranger/service/RangerPluginInfoService.java
+++ b/security-admin/src/main/java/org/apache/ranger/service/RangerPluginInfoService.java
@@ -17,7 +17,6 @@
 
 package org.apache.ranger.service;
 
-import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.ranger.biz.RangerBizUtil;
 import org.apache.ranger.common.JSONUtil;
@@ -28,7 +27,7 @@ import org.apache.ranger.db.RangerDaoManager;
 import org.apache.ranger.entity.XXPluginInfo;
 import org.apache.ranger.entity.XXService;
 import org.apache.ranger.entity.XXServiceDef;
-import org.apache.ranger.entity.XXServiceVersionInfo;
+import org.apache.ranger.entity.view.VXXPluginInfo;
 import org.apache.ranger.plugin.model.RangerPluginInfo;
 import org.apache.ranger.plugin.store.PList;
 import org.apache.ranger.plugin.util.SearchFilter;
@@ -45,7 +44,6 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 @Service
 public class RangerPluginInfoService {
@@ -71,10 +69,29 @@ public class RangerPluginInfoService {
         searchFields.add(new SearchField(SearchFilter.PLUGIN_HOST_NAME, "obj.hostName", SearchField.DATA_TYPE.STRING, SearchField.SEARCH_TYPE.FULL));
         searchFields.add(new SearchField(SearchFilter.PLUGIN_APP_TYPE, "obj.appType", SearchField.DATA_TYPE.STRING, SearchField.SEARCH_TYPE.FULL));
         searchFields.add(new SearchField(SearchFilter.PLUGIN_IP_ADDRESS, "obj.ipAddress", SearchField.DATA_TYPE.STRING, SearchField.SEARCH_TYPE.FULL));
+        searchFields.add(new SearchField(SearchFilter.SERVICE_TYPE, "obj.serviceType", SearchField.DATA_TYPE.STRING, SearchField.SEARCH_TYPE.FULL));
+        searchFields.add(new SearchField(SearchFilter.CLUSTER_NAME, "obj.clusterName", SearchField.DATA_TYPE.STRING, SearchField.SEARCH_TYPE.FULL));
 
         sortFields.add(new SortField(SearchFilter.SERVICE_NAME, "obj.serviceName", true, SortField.SORT_ORDER.ASC));
         sortFields.add(new SortField(SearchFilter.PLUGIN_HOST_NAME, "obj.hostName", true, SortField.SORT_ORDER.ASC));
         sortFields.add(new SortField(SearchFilter.PLUGIN_APP_TYPE, "obj.appType", true, SortField.SORT_ORDER.ASC));
+        sortFields.add(new SortField(SearchFilter.PLUGIN_IP_ADDRESS, "obj.ipAddress", true, SortField.SORT_ORDER.ASC));
+        sortFields.add(new SortField(SearchFilter.SERVICE_TYPE, "obj.serviceType", true, SortField.SORT_ORDER.ASC));
+        sortFields.add(new SortField(SearchFilter.CLUSTER_NAME, "obj.clusterName", true, SortField.SORT_ORDER.ASC));
+        sortFields.add(new SortField("policyDownloadTime", "obj.policyDownloadTime", true, SortField.SORT_ORDER.ASC));
+        sortFields.add(new SortField("policyActivationTime", "obj.policyActivationTime", true, SortField.SORT_ORDER.ASC));
+        sortFields.add(new SortField("lastPolicyUpdateTime", "obj.lastPolicyUpdateTime", true, SortField.SORT_ORDER.ASC));
+        sortFields.add(new SortField("tagDownloadTime", "obj.tagDownloadTime", true, SortField.SORT_ORDER.ASC));
+        sortFields.add(new SortField("tagActivationTime", "obj.tagActivationTime", true, SortField.SORT_ORDER.ASC));
+        sortFields.add(new SortField("lastTagUpdateTime", "obj.lastTagUpdateTime", true, SortField.SORT_ORDER.ASC));
+        sortFields.add(new SortField("gdsDownloadTime", "obj.gdsDownloadTime", true, SortField.SORT_ORDER.ASC));
+        sortFields.add(new SortField("gdsActivationTime", "obj.gdsActivationTime", true, SortField.SORT_ORDER.ASC));
+        sortFields.add(new SortField("lastGdsUpdateTime", "obj.lastGdsUpdateTime", true, SortField.SORT_ORDER.ASC));
+        sortFields.add(new SortField("roleDownloadTime", "obj.roleDownloadTime", true, SortField.SORT_ORDER.ASC));
+        sortFields.add(new SortField("roleActivationTime", "obj.roleActivationTime", true, SortField.SORT_ORDER.ASC));
+        sortFields.add(new SortField("lastRoleUpdateTime", "obj.lastRoleUpdateTime", true, SortField.SORT_ORDER.ASC));
+        sortFields.add(new SortField("userstoreDownloadTime", "obj.userstoreDownloadTime", true, SortField.SORT_ORDER.ASC));
+        sortFields.add(new SortField("userstoreActivationTime", "obj.userstoreActivationTime", true, SortField.SORT_ORDER.ASC));
     }
 
     public List<SearchField> getSearchFields() {
@@ -89,70 +106,12 @@ public class RangerPluginInfoService {
         PList<RangerPluginInfo> retList = new PList<>();
         List<RangerPluginInfo>  objList = new ArrayList<>();
 
-        List<XXService> servicesWithTagService = daoManager.getXXService().getAllServicesWithTagService();
-        String          serviceTypeToSearch    = searchFilter.getParam(SearchFilter.SERVICE_TYPE);
-        String          clusterNameToSearch    = searchFilter.getParam(SearchFilter.CLUSTER_NAME);
+        List<VXXPluginInfo> xObjList = searchRangerObjects(searchFilter, searchFields, sortFields, retList);
 
-        // Rebuild searchFilter without serviceType
-        if (StringUtils.isNotBlank(serviceTypeToSearch)) {
-            searchFilter.removeParam(SearchFilter.SERVICE_TYPE);
-        }
+        for (VXXPluginInfo xObj : xObjList) {
+            RangerPluginInfo obj = populatePluginViewObject(xObj);
 
-        List<XXPluginInfo> xObjList = searchRangerObjects(searchFilter, searchFields, sortFields, retList);
-
-        List<Object[]> objectsList = null;
-
-        if (CollectionUtils.isNotEmpty(xObjList)) {
-            objectsList = daoManager.getXXServiceVersionInfo().getAllWithServiceNames();
-        }
-
-        for (XXPluginInfo xObj : xObjList) {
-            XXServiceVersionInfo xxServiceVersionInfo    = null;
-            boolean              hasAssociatedTagService = false;
-
-            if (CollectionUtils.isNotEmpty(objectsList)) {
-                for (Object[] objects : objectsList) {
-                    if (objects.length == 2) {
-                        if (xObj.getServiceName().equals(objects[1])) {
-                            if (objects[0] instanceof XXServiceVersionInfo) {
-                                xxServiceVersionInfo = (XXServiceVersionInfo) objects[0];
-
-                                for (XXService service : servicesWithTagService) {
-                                    if (service.getName().equals(xObj.getServiceName())) {
-                                        hasAssociatedTagService = true;
-                                        break;
-                                    }
-                                }
-                            } else {
-                                LOG.warn("Expected first object to be XXServiceVersionInfo, got {}", objects[0]);
-                            }
-                            break;
-                        }
-                    } else {
-                        LOG.warn("Expected 2 objects in the list returned by getAllWithServiceNames(), received {}", objects.length);
-                    }
-                }
-            }
-
-            RangerPluginInfo obj = populateViewObjectWithServiceVersionInfo(xObj, xxServiceVersionInfo, hasAssociatedTagService);
-
-            if (StringUtils.isBlank(serviceTypeToSearch) || StringUtils.equals(serviceTypeToSearch, obj.getServiceType())) {
-                objList.add(obj);
-            }
-
-            if (StringUtils.isNotBlank(clusterNameToSearch)) {
-                Map<String, String>            infoMap = obj.getInfo();
-                Set<Map.Entry<String, String>> infoSet = infoMap.entrySet();
-
-                for (Map.Entry<String, String> info : infoSet) {
-                    if (StringUtils.equals(info.getKey(), SearchFilter.CLUSTER_NAME)) {
-                        if (!StringUtils.equals(info.getValue(), clusterNameToSearch)) {
-                            objList.remove(obj);
-                        }
-                        break;
-                    }
-                }
-            }
+            objList.add(obj);
         }
 
         retList.setList(objList);
@@ -167,17 +126,10 @@ public class RangerPluginInfoService {
         ret.setCreateTime(xObj.getCreateTime());
         ret.setUpdateTime(xObj.getUpdateTime());
         ret.setServiceName(xObj.getServiceName());
-
-        String serviceType = daoManager.getXXServiceDef().findServiceDefTypeByServiceName(ret.getServiceName());
-
-        if (StringUtils.isNotBlank(serviceType)) {
-            ret.setServiceType(serviceType);
-        }
-
         ret.setHostName(xObj.getHostName());
         ret.setAppType(xObj.getAppType());
         ret.setIpAddress(xObj.getIpAddress());
-        ret.setInfo(jsonStringToMap(xObj.getInfo(), null, false));
+        ret.setInfo(jsonStringToMap(xObj.getInfo(), null));
 
         return ret;
     }
@@ -193,11 +145,22 @@ public class RangerPluginInfoService {
         ret.setAppType(modelObj.getAppType());
         ret.setIpAddress(modelObj.getIpAddress());
         ret.setInfo(mapToJsonString(modelObj.getInfo()));
+        ret.setPolicyDownloadTime(modelObj.getPolicyDownloadTime());
+        ret.setPolicyActivationTime(modelObj.getPolicyActivationTime());
+        ret.setTagDownloadTime(modelObj.getTagDownloadTime());
+        ret.setTagActivationTime(modelObj.getTagActivationTime());
+        ret.setGdsDownloadTime(modelObj.getGdsDownloadTime());
+        ret.setGdsActivationTime(modelObj.getGdsActivationTime());
+        ret.setRoleDownloadTime(modelObj.getRoleDownloadTime());
+        ret.setRoleActivationTime(modelObj.getRoleActivationTime());
+        ret.setUserstoreDownloadTime(modelObj.getUserStoreDownloadTime());
+        ret.setUserstoreActivationTime(modelObj.getUserStoreActivationTime());
+        ret.setClusterName(modelObj.getClusterName());
 
         return ret;
     }
 
-    private RangerPluginInfo populateViewObjectWithServiceVersionInfo(XXPluginInfo xObj, XXServiceVersionInfo xxServiceVersionInfo, boolean hasAssociatedTagService) {
+    private RangerPluginInfo populatePluginViewObject(VXXPluginInfo xObj) {
         RangerPluginInfo ret = new RangerPluginInfo();
 
         ret.setId(xObj.getId());
@@ -205,7 +168,7 @@ public class RangerPluginInfoService {
         ret.setUpdateTime(xObj.getUpdateTime());
         ret.setServiceName(xObj.getServiceName());
 
-        String serviceDefName = daoManager.getXXServiceDef().findServiceDefTypeByServiceName(ret.getServiceName());
+        String serviceDefName = xObj.getServiceType();
 
         if (StringUtils.isNotBlank(serviceDefName)) {
             ret.setServiceType(serviceDefName);
@@ -218,7 +181,7 @@ public class RangerPluginInfoService {
         ret.setHostName(xObj.getHostName());
         ret.setAppType(xObj.getAppType());
         ret.setIpAddress(xObj.getIpAddress());
-        ret.setInfo(jsonStringToMap(xObj.getInfo(), xxServiceVersionInfo, hasAssociatedTagService));
+        ret.setInfo(jsonStringToMap(xObj.getInfo(), xObj));
 
         XXService xxService = daoManager.getXXService().findByName(ret.getServiceName());
 
@@ -229,8 +192,7 @@ public class RangerPluginInfoService {
         return ret;
     }
 
-    private List<XXPluginInfo> searchRangerObjects(SearchFilter searchCriteria, List<SearchField> searchFieldList, List<SortField> sortFieldList, PList<RangerPluginInfo> pList) {
-        // Get total count of the rows which meet the search criteria
+    private List<VXXPluginInfo> searchRangerObjects(SearchFilter searchCriteria, List<SearchField> searchFieldList, List<SortField> sortFieldList, PList<RangerPluginInfo> pList) {
         long count = -1;
 
         if (searchCriteria.isGetCount()) {
@@ -241,10 +203,10 @@ public class RangerPluginInfoService {
             }
         }
 
-        String             sortClause = searchUtil.constructSortClause(searchCriteria, sortFieldList);
-        String             queryStr   = "SELECT obj FROM " + XXPluginInfo.class.getName() + " obj ";
-        Query              query      = createQuery(queryStr, sortClause, searchCriteria, searchFieldList, false);
-        List<XXPluginInfo> resultList = daoManager.getXXPluginInfo().executeQueryInSecurityContext(XXPluginInfo.class, query);
+        String      sortClause = searchUtil.constructSortClause(searchCriteria, sortFieldList);
+        String      queryStr   = "SELECT obj FROM " + VXXPluginInfo.class.getName() + " obj ";
+        Query       query      = createQuery(queryStr, sortClause, searchCriteria, searchFieldList, false);
+        List<VXXPluginInfo> resultList = query.getResultList();
 
         if (pList != null) {
             pList.setResultSize(resultList.size());
@@ -265,15 +227,16 @@ public class RangerPluginInfoService {
     }
 
     private long getCountForSearchQuery(SearchFilter searchCriteria, List<SearchField> searchFieldList) {
-        String countQueryStr = "SELECT COUNT(obj) FROM " + XXPluginInfo.class.getName() + " obj ";
+        String countQueryStr = "SELECT COUNT(obj) FROM " + VXXPluginInfo.class.getName() + " obj ";
         Query  query         = createQuery(countQueryStr, null, searchCriteria, searchFieldList, true);
-        Long   count         = daoManager.getXXPluginInfo().executeCountQueryInSecurityContext(XXPluginInfo.class, query);
+        Long   count         = (Long) query.getSingleResult();
+        long   result        = 0;
 
-        if (count == null) {
-            return 0;
+        if (count != null) {
+            result = count;
         }
 
-        return count;
+        return result;
     }
 
     private String mapToJsonString(Map<String, String> map) {
@@ -290,26 +253,30 @@ public class RangerPluginInfoService {
         return ret;
     }
 
-    private Map<String, String> jsonStringToMap(String jsonStr, XXServiceVersionInfo xxServiceVersionInfo, boolean hasAssociatedTagService) {
+    private Map<String, String> jsonStringToMap(String jsonStr, VXXPluginInfo xObj) {
         Map<String, String> ret = null;
 
         try {
             ret = jsonUtil.jsonToMap(jsonStr);
 
-            if (xxServiceVersionInfo != null) {
-                Long latestPolicyVersion  = xxServiceVersionInfo.getPolicyVersion();
-                Date lastPolicyUpdateTime = xxServiceVersionInfo.getPolicyUpdateTime();
-                Long latestTagVersion     = xxServiceVersionInfo.getTagVersion();
-                Date lastTagUpdateTime    = xxServiceVersionInfo.getTagUpdateTime();
-                Long latestGdsVersion     = xxServiceVersionInfo.getGdsVersion();
-                Date lastGdsUpdateTime    = xxServiceVersionInfo.getGdsUpdateTime();
+            if (xObj != null) {
+                Long   latestPolicyVersion  = xObj.getLatestPolicyVersion();
+                Date   lastPolicyUpdateTime = xObj.getLastPolicyUpdateTime();
+                Long   latestTagVersion     = xObj.getLatestTagVersion();
+                Date   lastTagUpdateTime    = xObj.getLastTagUpdateTime();
+                Long   latestGdsVersion     = xObj.getLatestGdsVersion();
+                Date   lastGdsUpdateTime    = xObj.getLastGdsUpdateTime();
+                Long   latestRoleVersion    = xObj.getLatestRoleVersion();
+                Date   lastRoleUpdateTime   = xObj.getLastRoleUpdateTime();
 
-                ret.put(RangerPluginInfo.RANGER_ADMIN_LATEST_POLICY_VERSION, Long.toString(latestPolicyVersion));
+                ret.put(RangerPluginInfo.RANGER_ADMIN_LATEST_POLICY_VERSION, latestPolicyVersion == null ? "" : Long.toString(latestPolicyVersion));
                 ret.put(RangerPluginInfo.RANGER_ADMIN_LAST_POLICY_UPDATE_TIME, lastPolicyUpdateTime == null ? "" : Long.toString(lastPolicyUpdateTime.getTime()));
-                ret.put(RangerPluginInfo.RANGER_ADMIN_LATEST_GDS_VERSION, Long.toString(latestGdsVersion));
+                ret.put(RangerPluginInfo.RANGER_ADMIN_LATEST_GDS_VERSION, latestGdsVersion == null ? "" : Long.toString(latestGdsVersion));
                 ret.put(RangerPluginInfo.RANGER_ADMIN_LAST_GDS_UPDATE_TIME, lastGdsUpdateTime == null ? "" : Long.toString(lastGdsUpdateTime.getTime()));
+                ret.put(RangerPluginInfo.RANGER_ADMIN_LATEST_ROLE_VERSION, latestRoleVersion == null ? "" : Long.toString(latestRoleVersion));
+                ret.put(RangerPluginInfo.RANGER_ADMIN_LAST_ROLE_UPDATE_TIME, lastRoleUpdateTime == null ? "" : Long.toString(lastRoleUpdateTime.getTime()));
 
-                if (hasAssociatedTagService) {
+                if (xObj.getLatestTagVersion() != null && Boolean.TRUE.equals(xObj.getIsTagServiceEnabled())) {
                     ret.put(RangerPluginInfo.RANGER_ADMIN_LATEST_TAG_VERSION, Long.toString(latestTagVersion));
                     ret.put(RangerPluginInfo.RANGER_ADMIN_LAST_TAG_UPDATE_TIME, lastTagUpdateTime == null ? "" : Long.toString(lastTagUpdateTime.getTime()));
                 } else {

--- a/security-admin/src/test/java/org/apache/ranger/service/TestRangerPluginInfoService.java
+++ b/security-admin/src/test/java/org/apache/ranger/service/TestRangerPluginInfoService.java
@@ -31,6 +31,7 @@ import org.apache.ranger.entity.XXPluginInfo;
 import org.apache.ranger.entity.XXService;
 import org.apache.ranger.entity.XXServiceDef;
 import org.apache.ranger.entity.XXServiceVersionInfo;
+import org.apache.ranger.entity.view.VXXPluginInfo;
 import org.apache.ranger.plugin.model.RangerPluginInfo;
 import org.apache.ranger.plugin.store.PList;
 import org.apache.ranger.plugin.util.SearchFilter;
@@ -39,7 +40,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 import javax.persistence.EntityManager;
@@ -109,7 +109,7 @@ public class TestRangerPluginInfoService {
     }
 
     @Test
-    void testPopulateViewObject_setsServiceTypeAndInfo() {
+    void testPopulateViewObject_setsInfoWithoutServiceTypeLookup() {
         XXPluginInfo x = new XXPluginInfo();
         x.setId(1L);
         x.setServiceName("s1");
@@ -117,11 +117,10 @@ public class TestRangerPluginInfoService {
         x.setAppType("app");
         x.setIpAddress("ip");
         x.setInfo("{}");
-        when(xxServiceDefDao.findServiceDefTypeByServiceName("s1")).thenReturn("hive");
         when(jsonUtil.jsonToMap("{}")).thenReturn(new HashMap<>());
         RangerPluginInfo out = svc.populateViewObject(x);
-        assertEquals("hive", out.getServiceType());
         assertEquals("s1", out.getServiceName());
+        assertNotNull(out.getInfo());
     }
 
     @Test
@@ -221,19 +220,16 @@ public class TestRangerPluginInfoService {
         when(searchUtil.constructSortClause(eq(f), any())).thenReturn(" ORDER BY obj.serviceName asc");
         when(query.getFirstResult()).thenReturn(0);
         when(query.getMaxResults()).thenReturn(1000);
-        when(xxPluginInfoDao.executeCountQueryInSecurityContext(eq(XXPluginInfo.class), eq(query))).thenReturn(1L);
-        XXPluginInfo x = new XXPluginInfo();
+        when(query.getSingleResult()).thenReturn(1L);
+        VXXPluginInfo x = new VXXPluginInfo();
         x.setServiceName("svc");
         x.setInfo("{}");
-        when(xxPluginInfoDao.executeQueryInSecurityContext(eq(XXPluginInfo.class), eq(query))).thenReturn(Collections.singletonList(x));
-        // also stub internal count query creation used by getCountForSearchQuery
-        Mockito.when(searchUtil.createSearchQuery(eq(entityManager), anyString(), isNull(), eq(f), any(), eq(true)))
-                .thenReturn(query);
+        when(query.getResultList()).thenReturn(Collections.singletonList(x));
         PList<RangerPluginInfo> pList = new PList<>();
         Method                  m     = RangerPluginInfoService.class.getDeclaredMethod("searchRangerObjects", SearchFilter.class, List.class, List.class, PList.class);
         m.setAccessible(true);
         @SuppressWarnings("unchecked")
-        List<XXPluginInfo> out = (List<XXPluginInfo>) m.invoke(svc, f, svc.getSearchFields(), svc.getSortFields(), pList);
+        List<VXXPluginInfo> out = (List<VXXPluginInfo>) m.invoke(svc, f, svc.getSearchFields(), svc.getSortFields(), pList);
         assertNotNull(out);
         assertEquals(1, out.size());
     }
@@ -241,12 +237,12 @@ public class TestRangerPluginInfoService {
     @Test
     public void testF_jsonStringToMap_reflection_variants() throws Exception {
         RangerPluginInfoService svc = createSvc();
-        Method                  m   = RangerPluginInfoService.class.getDeclaredMethod("jsonStringToMap", String.class, XXServiceVersionInfo.class, boolean.class);
+        Method                  m   = RangerPluginInfoService.class.getDeclaredMethod("jsonStringToMap", String.class, VXXPluginInfo.class);
         m.setAccessible(true);
         Map<String, String> base = new HashMap<>();
         when(jsonUtil.jsonToMap("{}")).thenReturn(base);
         @SuppressWarnings("unchecked")
-        Map<String, String> out = (Map<String, String>) m.invoke(svc, "{}", null, false);
+        Map<String, String> out = (Map<String, String>) m.invoke(svc, "{}", null);
         assertNotNull(out);
     }
 


### PR DESCRIPTION

## What changes were proposed in this pull request?

This PR implements RANGER-4692: server-side sorting on the Ranger Admin Audit → Plugin Status page by plugin download and activation events (Policy, Tag, Role, GDS, UserStore) and related metadata.

## How was this patch tested?

**Manual**: Plugin Status column sort sends sortBy/sortType to the API; results sort across pages
**Manual**: REST sort verified on policyDownloadTime, tagActivationTime, clusterName, with filters
**Upgrade**: DB patch 078 + Java patch J10067 Upgrade Testing.
