### PR TITLE
RANGER-5789: Exclude third-party docs JS from Apache RAT check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -731,6 +731,8 @@
                         <exclude>**/docs/src/site/resources/ranger-logo.svg</exclude>
                         <exclude>**/docs/src/site/resources/override-banner.js</exclude>
                         <exclude>**/docs/src/site/resources/smooth-scroll.js</exclude>
+                        <exclude>**/docs/src/site/resources/js/jquery.min.js</exclude>
+                        <exclude>**/docs/src/site/resources/js/html5.js</exclude>
                         <exclude>**/importRole/*.json</exclude>
                         <exclude>mkdocs/docs/assets/**</exclude>
                         <exclude>mkdocs/requirements.txt</exclude>


### PR DESCRIPTION
## Summary

Fixes `build-17` failure on master after RANGER-5788 (#1215): Apache RAT reported two unapproved third-party files under `docs/src/site/resources/js/`:

- `jquery.min.js` (jQuery 1.9.1, MIT)
- `html5.js` (HTML5 Shiv 3.7.3, MIT/GPL2)

Adds RAT excludes alongside existing docs site resource exclusions (`override-banner.js`, `smooth-scroll.js`, `bootstrap.min.js`).

**JIRA:** [RANGER-5789](https://issues.apache.org/jira/browse/RANGER-5789)

## Test plan

- [ ] `mvn -pl . -DskipTests apache-rat:check` passes
- [ ] CI `build-17` green
