### PR TITLE
RANGER-5696: Added deltaSyncServerType config to optimize delta sync …

### DIFF
--- a/ugsync/src/main/java/org/apache/ranger/ldapusersync/process/LdapUserGroupBuilder.java
+++ b/ugsync/src/main/java/org/apache/ranger/ldapusersync/process/LdapUserGroupBuilder.java
@@ -122,7 +122,6 @@ public class LdapUserGroupBuilder implements UserGroupSource {
     private String         groupNameAttribute;
     private String         groupCloudIdAttribute;
     private String         currentSyncSource;
-    private String         deltaSyncServerType;
     private String[]       userSearchBase;
     private String[]       groupSearchBase;
     private Set<String>    groupNameSet;
@@ -377,7 +376,6 @@ public class LdapUserGroupBuilder implements UserGroupSource {
         currentSyncSource           = config.getCurrentSyncSource();
         userSearchEnabled           = config.isUserSearchEnabled();
         groupSearchEnabled          = config.isGroupSearchEnabled();
-        deltaSyncServerType         = config.getDeltaSyncServerType();
         ldapUrl                     = config.getLdapUrl();
         ldapBindDn                  = config.getLdapBindDn();
         ldapBindPassword            = config.getLdapBindPassword();
@@ -515,19 +513,13 @@ public class LdapUserGroupBuilder implements UserGroupSource {
             }
 
             if (config.isDeltaSyncEnabled()) {
-                if ("ad".equalsIgnoreCase(deltaSyncServerType)) {
-                    extendedUserSearchFilter = "(objectclass=" + userObjectClass + ")(uSNChanged>=" + deltaSyncUserTime + ")";
-                } else if ("ldap".equalsIgnoreCase(deltaSyncServerType)) {
-                    extendedUserSearchFilter = "(objectclass=" + userObjectClass + ")(modifyTimestamp>=" + deltaSyncUserTimeStamp + "Z)";
-                } else {
-                    extendedUserSearchFilter = "(objectclass=" + userObjectClass + ")(|(uSNChanged>=" + deltaSyncUserTime + ")(modifyTimestamp>=" + deltaSyncUserTimeStamp + "Z))";
-                }
+                extendedUserSearchFilter = "(objectclass=" + userObjectClass + ")" + getDeltaSyncFilter(deltaSyncUserTime, deltaSyncUserTimeStamp);
             } else {
                 extendedUserSearchFilter = "(objectclass=" + userObjectClass + ")";
             }
 
-            LOG.debug("custom userSearchFilter = {}, deltaSyncServerType = {}, extendedUserSearchFilter = {}", userSearchFilter, deltaSyncServerType, extendedUserSearchFilter);
-
+            LOG.debug("custom userSearchFilter = {}, extendedUserSearchFilter = {}", userSearchFilter, extendedUserSearchFilter);
+            LOG.info("extendedUserSearchFilter = {}", extendedUserSearchFilter);
             if (userSearchFilter != null && !userSearchFilter.trim().isEmpty()) {
                 String customFilter = userSearchFilter.trim();
 
@@ -768,18 +760,12 @@ public class LdapUserGroupBuilder implements UserGroupSource {
             }
 
             if (config.isDeltaSyncEnabled()) {
-                if ("ad".equalsIgnoreCase(deltaSyncServerType)) {
-                    extendedAllGroupsSearchFilter = "(&" + extendedGroupSearchFilter + "(uSNChanged>=" + deltaSyncGroupTime + "))";
-                } else if ("ldap".equalsIgnoreCase(deltaSyncServerType)) {
-                    extendedAllGroupsSearchFilter = "(&" + extendedGroupSearchFilter + "(modifyTimestamp>=" + deltaSyncGroupTimeStamp + "Z))";
-                } else {
-                    extendedAllGroupsSearchFilter = "(&" + extendedGroupSearchFilter + "(|(uSNChanged>=" + deltaSyncGroupTime + ")(modifyTimestamp>=" + deltaSyncGroupTimeStamp + "Z)))";
-                }
+                extendedAllGroupsSearchFilter = "(&" + extendedGroupSearchFilter + getDeltaSyncFilter(deltaSyncGroupTime, deltaSyncGroupTimeStamp) + ")";
             } else {
                 extendedAllGroupsSearchFilter = "(&"  + extendedGroupSearchFilter + ")";
             }
 
-            LOG.debug("custom groupSearchFilter = {}, deltaSyncServerType = {}, extendedGroupSearchFilter = {}", groupSearchFilter, deltaSyncServerType, extendedGroupSearchFilter);
+            LOG.debug("custom groupSearchFilter = {}, extendedGroupSearchFilter = {}", groupSearchFilter, extendedGroupSearchFilter);
             LOG.info("extendedAllGroupsSearchFilter = {}", extendedAllGroupsSearchFilter);
 
             for (int ou = 0; ou < groupSearchBase.length; ou++) {
@@ -924,6 +910,21 @@ public class LdapUserGroupBuilder implements UserGroupSource {
         LOG.debug("highestdeltaSyncGroupTime = {}", highestdeltaSyncGroupTime);
 
         return highestdeltaSyncGroupTime;
+    }
+
+    private String getDeltaSyncFilter(long usnChangedTime, String modifyTimestamp) {
+        String result     = "";
+        String serverType = config.getProperty("ranger.usersync.ldap.deltasync.server.type", "").trim();
+
+        if (serverType.equalsIgnoreCase("ad")) {
+            result = "(uSNChanged>=" + usnChangedTime + ")";
+        } else if (serverType.equalsIgnoreCase("ldap")) {
+            result = "(modifyTimestamp>=" + modifyTimestamp + "Z)";
+        } else {
+            result = "(|(uSNChanged>=" + usnChangedTime + ")(modifyTimestamp>=" + modifyTimestamp + "Z))";
+        }
+
+        return result;
     }
 
     private void goUpGroupHierarchy(Set<String> groups, int groupHierarchyLevels, String groupSName) {

--- a/ugsync/src/main/java/org/apache/ranger/ldapusersync/process/LdapUserGroupBuilder.java
+++ b/ugsync/src/main/java/org/apache/ranger/ldapusersync/process/LdapUserGroupBuilder.java
@@ -122,6 +122,7 @@ public class LdapUserGroupBuilder implements UserGroupSource {
     private String         groupNameAttribute;
     private String         groupCloudIdAttribute;
     private String         currentSyncSource;
+    private String         deltaSyncServerType;
     private String[]       userSearchBase;
     private String[]       groupSearchBase;
     private Set<String>    groupNameSet;
@@ -376,6 +377,7 @@ public class LdapUserGroupBuilder implements UserGroupSource {
         currentSyncSource           = config.getCurrentSyncSource();
         userSearchEnabled           = config.isUserSearchEnabled();
         groupSearchEnabled          = config.isGroupSearchEnabled();
+        deltaSyncServerType         = config.getDeltaSyncServerType();
         ldapUrl                     = config.getLdapUrl();
         ldapBindDn                  = config.getLdapBindDn();
         ldapBindPassword            = config.getLdapBindPassword();
@@ -513,10 +515,18 @@ public class LdapUserGroupBuilder implements UserGroupSource {
             }
 
             if (config.isDeltaSyncEnabled()) {
-                extendedUserSearchFilter = "(objectclass=" + userObjectClass + ")(|(uSNChanged>=" + deltaSyncUserTime + ")(modifyTimestamp>=" + deltaSyncUserTimeStamp + "Z))";
+                if ("ad".equalsIgnoreCase(deltaSyncServerType)) {
+                    extendedUserSearchFilter = "(objectclass=" + userObjectClass + ")(uSNChanged>=" + deltaSyncUserTime + ")";
+                } else if ("ldap".equalsIgnoreCase(deltaSyncServerType)) {
+                    extendedUserSearchFilter = "(objectclass=" + userObjectClass + ")(modifyTimestamp>=" + deltaSyncUserTimeStamp + "Z)";
+                } else {
+                    extendedUserSearchFilter = "(objectclass=" + userObjectClass + ")(|(uSNChanged>=" + deltaSyncUserTime + ")(modifyTimestamp>=" + deltaSyncUserTimeStamp + "Z))";
+                }
             } else {
                 extendedUserSearchFilter = "(objectclass=" + userObjectClass + ")";
             }
+
+            LOG.debug("custom userSearchFilter = {}, deltaSyncServerType = {}, extendedUserSearchFilter = {}", userSearchFilter, deltaSyncServerType, extendedUserSearchFilter);
 
             if (userSearchFilter != null && !userSearchFilter.trim().isEmpty()) {
                 String customFilter = userSearchFilter.trim();
@@ -758,11 +768,18 @@ public class LdapUserGroupBuilder implements UserGroupSource {
             }
 
             if (config.isDeltaSyncEnabled()) {
-                extendedAllGroupsSearchFilter = "(&"  + extendedGroupSearchFilter + "(|(uSNChanged>=" + deltaSyncGroupTime + ")(modifyTimestamp>=" + deltaSyncGroupTimeStamp + "Z)))";
+                if ("ad".equalsIgnoreCase(deltaSyncServerType)) {
+                    extendedAllGroupsSearchFilter = "(&" + extendedGroupSearchFilter + "(uSNChanged>=" + deltaSyncGroupTime + "))";
+                } else if ("ldap".equalsIgnoreCase(deltaSyncServerType)) {
+                    extendedAllGroupsSearchFilter = "(&" + extendedGroupSearchFilter + "(modifyTimestamp>=" + deltaSyncGroupTimeStamp + "Z))";
+                } else {
+                    extendedAllGroupsSearchFilter = "(&" + extendedGroupSearchFilter + "(|(uSNChanged>=" + deltaSyncGroupTime + ")(modifyTimestamp>=" + deltaSyncGroupTimeStamp + "Z)))";
+                }
             } else {
                 extendedAllGroupsSearchFilter = "(&"  + extendedGroupSearchFilter + ")";
             }
 
+            LOG.debug("custom groupSearchFilter = {}, deltaSyncServerType = {}, extendedGroupSearchFilter = {}", groupSearchFilter, deltaSyncServerType, extendedGroupSearchFilter);
             LOG.info("extendedAllGroupsSearchFilter = {}", extendedAllGroupsSearchFilter);
 
             for (int ou = 0; ou < groupSearchBase.length; ou++) {

--- a/ugsync/src/main/java/org/apache/ranger/unixusersync/config/UserGroupSyncConfig.java
+++ b/ugsync/src/main/java/org/apache/ranger/unixusersync/config/UserGroupSyncConfig.java
@@ -69,7 +69,6 @@ public class UserGroupSyncConfig {
     public static final  String UGSYNC_TEST_RUN_PROP                   = "ranger.usersync.policymanager.testrun";
     /* Other Configs */
     public static final  String UGSYNC_SERVER_HA_ENABLED_PARAM         = "ranger-ugsync.server.ha.enabled";
-    public static final  String UGSYNC_LDAP_DELTASYNC_SERVER_TYPE      = "ranger.usersync.ldap.deltasync.server.type";
     public static final  String UGSYNC_NAME_VALIDATION_ENABLED         = "ranger.usersync.name.validation.enabled";
     public static final  String UGSYNC_SYNC_SOURCE_VALIDATION_ENABLED  = "ranger.usersync.syncsource.validation.enabled";
     private static final Logger LOG                                    = LoggerFactory.getLogger(UserGroupSyncConfig.class);
@@ -804,18 +803,6 @@ public class UserGroupSyncConfig {
         }
 
         return groupSearchFirstEnabled;
-    }
-
-    public String getDeltaSyncServerType() {
-        String val = prop.getProperty(UGSYNC_LDAP_DELTASYNC_SERVER_TYPE);
-        if (val == null || val.trim().isEmpty()) {
-            return "";
-        } else if (val.trim().equalsIgnoreCase("ldap")) {
-            return "ldap";
-        } else if (val.trim().equalsIgnoreCase("ad")) {
-            return "ad";
-        }
-        return "";
     }
 
     /* Used only for unit testing */

--- a/ugsync/src/main/java/org/apache/ranger/unixusersync/config/UserGroupSyncConfig.java
+++ b/ugsync/src/main/java/org/apache/ranger/unixusersync/config/UserGroupSyncConfig.java
@@ -69,6 +69,7 @@ public class UserGroupSyncConfig {
     public static final  String UGSYNC_TEST_RUN_PROP                   = "ranger.usersync.policymanager.testrun";
     /* Other Configs */
     public static final  String UGSYNC_SERVER_HA_ENABLED_PARAM         = "ranger-ugsync.server.ha.enabled";
+    public static final  String UGSYNC_LDAP_DELTASYNC_SERVER_TYPE      = "ranger.usersync.ldap.deltasync.server.type";
     public static final  String UGSYNC_NAME_VALIDATION_ENABLED         = "ranger.usersync.name.validation.enabled";
     public static final  String UGSYNC_SYNC_SOURCE_VALIDATION_ENABLED  = "ranger.usersync.syncsource.validation.enabled";
     private static final Logger LOG                                    = LoggerFactory.getLogger(UserGroupSyncConfig.class);
@@ -803,6 +804,18 @@ public class UserGroupSyncConfig {
         }
 
         return groupSearchFirstEnabled;
+    }
+
+    public String getDeltaSyncServerType() {
+        String val = prop.getProperty(UGSYNC_LDAP_DELTASYNC_SERVER_TYPE);
+        if (val == null || val.trim().isEmpty()) {
+            return "";
+        } else if (val.trim().equalsIgnoreCase("ldap")) {
+            return "ldap";
+        } else if (val.trim().equalsIgnoreCase("ad")) {
+            return "ad";
+        }
+        return "";
     }
 
     /* Used only for unit testing */

--- a/ugsync/src/test/java/org/apache/ranger/ldapusersync/process/TestLdapUserGroupBuilder.java
+++ b/ugsync/src/test/java/org/apache/ranger/ldapusersync/process/TestLdapUserGroupBuilder.java
@@ -421,6 +421,112 @@ public class TestLdapUserGroupBuilder extends AbstractLdapTestUnit {
     }
 
     @Test
+    void testUG_getUsers_ad_filter_uses_uSNChanged_only() throws Throwable {
+        resetConfig();
+        configureMinimalLdapConfig();
+        UserGroupSyncConfig cfg = UserGroupSyncConfig.getInstance();
+        cfg.setProperty("ranger.usersync.ldap.deltasync", "true");
+        cfg.setProperty("ranger.usersync.ldap.deltasync.server.type", "ad");
+
+        LdapUserGroupBuilder b = new LdapUserGroupBuilder();
+        b.init();
+
+        Field fGroupEnabled = LdapUserGroupBuilder.class.getDeclaredField("groupSearchEnabled");
+        fGroupEnabled.setAccessible(true);
+        fGroupEnabled.setBoolean(b, false);
+
+        Field gutF      = LdapUserGroupBuilder.class.getDeclaredField("groupUserTable");
+        Field srcUsersF = LdapUserGroupBuilder.class.getDeclaredField("sourceUsers");
+        Field srcGroupsF = LdapUserGroupBuilder.class.getDeclaredField("sourceGroups");
+        gutF.setAccessible(true);
+        srcUsersF.setAccessible(true);
+        srcGroupsF.setAccessible(true);
+        gutF.set(b, HashBasedTable.create());
+        srcUsersF.set(b, new HashMap<>());
+        srcGroupsF.set(b, new HashMap<>());
+
+        final String userDn = "cn=User1000,ou=people,dc=example,dc=com";
+        Attributes attrs = new BasicAttributes(true);
+        attrs.put(new BasicAttribute("cn", "User1000"));
+        attrs.put(new BasicAttribute("uSNChanged", "2001"));
+
+        class TestSearchResult extends SearchResult {
+            private final String nameInNs;
+
+            TestSearchResult(String name, Attributes a, String nameInNs) {
+                super(name, null, a);
+                this.nameInNs = nameInNs;
+            }
+
+            @Override
+            public String getNameInNamespace() {
+                return nameInNs;
+            }
+        }
+
+        final SearchResult sr = new TestSearchResult(userDn, attrs, userDn);
+
+        class SingleEnum implements NamingEnumeration<SearchResult> {
+            private boolean consumed;
+
+            @Override
+            public SearchResult next() {
+                consumed = true;
+                return sr;
+            }
+
+            @Override
+            public boolean hasMore() {
+                return !consumed;
+            }
+
+            @Override
+            public void close() {}
+
+            @Override
+            public boolean hasMoreElements() {
+                return hasMore();
+            }
+
+            @Override
+            public SearchResult nextElement() {
+                return next();
+            }
+        }
+
+        try (MockedConstruction<InitialLdapContext> mocked = Mockito.mockConstruction(InitialLdapContext.class, (mock, ctx) -> {
+            Mockito.when(mock.search(Mockito.anyString(), Mockito.anyString(), Mockito.any(SearchControls.class)))
+                    .thenReturn(new SingleEnum());
+            Mockito.when(mock.getResponseControls()).thenReturn(null);
+        })) {
+            Method getUsers = LdapUserGroupBuilder.class.getDeclaredMethod("getUsers", boolean.class);
+            getUsers.setAccessible(true);
+            getUsers.invoke(b, false);
+
+            Field extFilF = LdapUserGroupBuilder.class.getDeclaredField("extendedUserSearchFilter");
+            extFilF.setAccessible(true);
+            String ext = (String) extFilF.get(b);
+            assertTrue(ext.contains("uSNChanged>="), ext);
+            assertFalse(ext.contains("modifyTimestamp>="), ext);
+        }
+    }
+
+    @Test
+    void testUF_init_loads_deltaSyncServerType() throws Throwable {
+        resetConfig();
+        configureMinimalLdapConfig();
+        UserGroupSyncConfig cfg = UserGroupSyncConfig.getInstance();
+        cfg.setProperty("ranger.usersync.ldap.deltasync.server.type", "ad");
+
+        LdapUserGroupBuilder b = new LdapUserGroupBuilder();
+        b.init();
+
+        Field f = LdapUserGroupBuilder.class.getDeclaredField("deltaSyncServerType");
+        f.setAccessible(true);
+        assertEquals("ad", f.get(b));
+    }
+
+    @Test
     public void testV_getUsers_processes_user_and_group_memberships() throws Throwable {
         resetConfig();
         configureMinimalLdapConfig();

--- a/ugsync/src/test/java/org/apache/ranger/ldapusersync/process/TestLdapUserGroupBuilder.java
+++ b/ugsync/src/test/java/org/apache/ranger/ldapusersync/process/TestLdapUserGroupBuilder.java
@@ -512,21 +512,6 @@ public class TestLdapUserGroupBuilder extends AbstractLdapTestUnit {
     }
 
     @Test
-    void testUF_init_loads_deltaSyncServerType() throws Throwable {
-        resetConfig();
-        configureMinimalLdapConfig();
-        UserGroupSyncConfig cfg = UserGroupSyncConfig.getInstance();
-        cfg.setProperty("ranger.usersync.ldap.deltasync.server.type", "ad");
-
-        LdapUserGroupBuilder b = new LdapUserGroupBuilder();
-        b.init();
-
-        Field f = LdapUserGroupBuilder.class.getDeclaredField("deltaSyncServerType");
-        f.setAccessible(true);
-        assertEquals("ad", f.get(b));
-    }
-
-    @Test
     public void testV_getUsers_processes_user_and_group_memberships() throws Throwable {
         resetConfig();
         configureMinimalLdapConfig();

--- a/ugsync/src/test/resources/ranger-ugsync-site.xml
+++ b/ugsync/src/test/resources/ranger-ugsync-site.xml
@@ -177,4 +177,16 @@
       <name>ranger.usersync.group.hierarchylevels</name>
       <value>2</value>
     </property>
+
+    <property>
+        <name>ranger.usersync.ldap.deltasync.server.type</name>
+        <value></value>
+        <description>Specifies the LDAP server type for delta sync attribute selection.
+            Accepted values:
+            - "AD"   : Uses only 'uSNChanged' attribute for delta sync (Active Directory).
+            - "LDAP" : Uses only 'modifyTimestamp' attribute for delta sync (OpenLDAP).
+            - ""     : Uses both 'uSNChanged' and 'modifyTimestamp' attributes (default behavior).
+        </description>
+    </property>
+
   </configuration>


### PR DESCRIPTION
### Summary: Add configuration property to optimize AD/LDAP delta sync search filters

**Description:**
Currently, Ranger Usersync uses an OR conditional query containing both modifyTimeStamp and uSNChanged attributes to detect changes during delta syncs. According to customer feedback, executing a search query with both attributes combined negatively affects Active Directory (AD) performance. At present, this behavior is hardcoded by design and cannot be configured to use only the environment-specific attribute (such as uSNChanged for AD).

**Changes:**
Introduced a new configuration property (e.g., ranger.usersync.ldap.deltasync.servertype) to allow administrators to specify the directory server type and optimize the search query:

**When set to ad:** _The delta sync query uses only the uSNChanged attribute._

**When set to ldap:** _The delta sync query uses only the modifyTimestamp attribute._

**When empty or unset:** _Falls back to the existing OR-combined filter to ensure backward compatibility._

**Impact:**
Improves Active Directory search performance and reduces query overhead by eliminating complex OR conditions and avoiding unsupported attribute queries. There is no behavioral change or impact on existing deployments unless the new property is explicitly configured.

**Testing:**

- _Verified delta sync works correctly against Active Directory when the property is configured as ad._

- _Verified delta sync works correctly against OpenLDAP when the property is configured as ldap._

- _Verified legacy backward compatibility behaves as expected (using the OR conditional) when the property is not configured._

- _Tested the performance by synchronizing ~1.14 million users. With the optimized ad configuration, the sync process completed 1 minute faster compared to the default OR-combined filter._