### PR TITLE
RANGER-5794: Atlas permissions reappear in tag policies when enableTagBasedPolicies is disabled

### DIFF
--- a/agents-common/src/main/java/org/apache/ranger/plugin/store/AbstractServiceStore.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/store/AbstractServiceStore.java
@@ -66,9 +66,7 @@ public abstract class AbstractServiceStore implements ServiceStore {
 
         List<RangerServiceDef> allServiceDefs = getServiceDefs(new SearchFilter());
         for (RangerServiceDef serviceDef : allServiceDefs) {
-            if (ServiceDefUtil.getOption_enableTagBasedPolicies(serviceDef, config)) {
-                updateTagServiceDefForUpdatingAccessTypes(serviceDef);
-            }
+            updateTagServiceDefForUpdatingAccessTypes(serviceDef);
         }
 
         LOG.debug("<== ServiceDefDBStore.updateTagServiceDefForAccessTypes()");
@@ -277,6 +275,12 @@ public abstract class AbstractServiceStore implements ServiceStore {
     private void updateTagServiceDefForUpdatingAccessTypes(RangerServiceDef serviceDef) throws Exception {
         if (StringUtils.equals(serviceDef.getName(), EmbeddedServiceDefsUtil.EMBEDDED_SERVICEDEF_TAG_NAME) ||
                 StringUtils.equals(serviceDef.getName(), EmbeddedServiceDefsUtil.EMBEDDED_SERVICEDEF_GDS_NAME)) {
+            return;
+        }
+
+        if (!ServiceDefUtil.getOption_enableTagBasedPolicies(serviceDef, config)) {
+            LOG.debug("AbstractServiceStore.updateTagServiceDefForUpdatingAccessTypes({}): tag-based policies disabled", serviceDef.getName());
+
             return;
         }
 

--- a/security-admin/src/main/java/org/apache/ranger/patch/PatchForUpdatingAtlasSvcDefAndTagPolicies_J10063.java
+++ b/security-admin/src/main/java/org/apache/ranger/patch/PatchForUpdatingAtlasSvcDefAndTagPolicies_J10063.java
@@ -97,6 +97,7 @@ public class PatchForUpdatingAtlasSvcDefAndTagPolicies_J10063 extends BaseLoader
         try {
             if (updateAtlasServiceDef()) {
                 disableAtlasAccessForTagPolicies();
+                updateTagServiceDef();
             }
         } catch (Exception e) {
             logger.error("Error while updateTagServiceDef()data.", e);
@@ -262,5 +263,52 @@ public class PatchForUpdatingAtlasSvcDefAndTagPolicies_J10063 extends BaseLoader
             }
         }
         return ret;
+    }
+
+    private void updateTagServiceDef() throws Exception {
+        logger.info("==> PatchForUpdatingAtlasSvcDefAndTagPolicies_J10063.updateTagServiceDef()");
+        RangerServiceDef embeddedTagServiceDef;
+        RangerServiceDef dbTagServiceDef;
+        XXServiceDef     xXServiceDefObj;
+
+        embeddedTagServiceDef = EmbeddedServiceDefsUtil.instance().getEmbeddedServiceDef(EmbeddedServiceDefsUtil.EMBEDDED_SERVICEDEF_TAG_NAME);
+
+        if (embeddedTagServiceDef != null) {
+            xXServiceDefObj = daoMgr.getXXServiceDef().findByName(EmbeddedServiceDefsUtil.EMBEDDED_SERVICEDEF_TAG_NAME);
+
+            if (xXServiceDefObj != null) {
+                dbTagServiceDef = svcStore.getServiceDefByName(EmbeddedServiceDefsUtil.EMBEDDED_SERVICEDEF_TAG_NAME);
+
+                if (dbTagServiceDef != null && CollectionUtils.isNotEmpty(dbTagServiceDef.getAccessTypes())) {
+                    List<RangerServiceDef.RangerAccessTypeDef> accessTypesToRemove = new ArrayList<>();
+
+                    for (RangerServiceDef.RangerAccessTypeDef accessTypeDef : dbTagServiceDef.getAccessTypes()) {
+                        if (accessTypeDef != null) {
+                            final String accessTypeName = accessTypeDef.getName();
+
+                            String[] svcDefAccType  = accessTypeName.split(":");
+                            String   serviceDefName = svcDefAccType.length > 0 ? svcDefAccType[0] : null;
+
+                            if (serviceDefName != null && serviceDefName.equals(EmbeddedServiceDefsUtil.EMBEDDED_SERVICEDEF_ATLAS_NAME)) {
+                                logger.info("==> PatchForUpdatingAtlasSvcDefAndTagPolicies_J10063.updateTagServiceDef() found atlas access type to remove: {}", accessTypeName);
+                                accessTypesToRemove.add(accessTypeDef);
+                            }
+                        }
+                    }
+
+                    if (!accessTypesToRemove.isEmpty()) {
+                        dbTagServiceDef.getAccessTypes().removeAll(accessTypesToRemove);
+
+                        svcStore.updateServiceDef(dbTagServiceDef);
+                    }
+                }
+            } else {
+                logger.error("Tag service-definition does not exist in the Ranger DAO.");
+            }
+        } else {
+            logger.error("The embedded Tag service-definition does not exist.");
+        }
+
+        logger.info("<== PatchForUpdatingAtlasSvcDefAndTagPolicies_J10063.updateTagServiceDef()");
     }
 }


### PR DESCRIPTION

## What changes were proposed in this pull request?

After [RANGER-4805](https://issues.apache.org/jira/browse/RANGER-4805), Atlas permissions (atlas:read, etc.) can still appear in tag policies and in x_access_type_def, especially after [RANGER-3491](https://issues.apache.org/jira/browse/RANGER-3491) changed the service-definition bootstrap flow.

Cause:
The enableTagBasedPolicies check was only present in updateTagServiceDefForAccessTypes(), which is no longer called from the production code. The actual sync path (postCreate / postUpdate → updateTagServiceDefForUpdatingAccessTypes()) did not have this check, allowing Atlas permissions to be synced into the tag service-definition.

## How was this patch tested?

Tested upgrade with J10063 patch; verified atlas:* absent from x_access_type_def and tag policy UI. Restarted Ranger Admin and updated Atlas service-def — Atlas permissions did not reappear. 