### PR TITLE
RANGER-5752:Audit dispatcher consumer dies on TopicAuthorizationException - container stays healthy, audits stop flowing

### DIFF
--- a/audit-server/audit-common/src/main/java/org/apache/ranger/audit/server/AuditServerConstants.java
+++ b/audit-server/audit-common/src/main/java/org/apache/ranger/audit/server/AuditServerConstants.java
@@ -135,6 +135,8 @@ public class AuditServerConstants {
     public static final String PROP_DISPATCHER_MAX_POLL_INTERVAL_MS          = "max.poll.interval.ms";
     public static final String PROP_DISPATCHER_HEARTBEAT_INTERVAL_MS         = "heartbeat.interval.ms";
     public static final String PROP_DISPATCHER_PARTITION_ASSIGNMENT_STRATEGY = "partition.assignment.strategy";
+    public static final String PROP_DISPATCHER_AUTH_RETRY_DELAY_MS           = "auth.retry.delay.ms";
+    public static final String PROP_DISPATCHER_POLL_ERROR_RETRY_DELAY_MS     = "poll.error.retry.delay.ms";
     public static final String PROP_DISPATCHER_TYPE                          = "ranger.audit.dispatcher.type";
     public static final String PROP_DISPATCHER_CLASS                         = "ranger.audit.dispatcher.class";
 
@@ -142,4 +144,6 @@ public class AuditServerConstants {
     public static final int    DEFAULT_SESSION_TIMEOUT_MS                    = 60000;  // 60 seconds - failure detection
     public static final int    DEFAULT_MAX_POLL_INTERVAL_MS                  = 300000; // 5 minutes - max processing time
     public static final int    DEFAULT_HEARTBEAT_INTERVAL_MS                 = 10000;  // 10 seconds - heartbeat frequency
+    public static final int    DEFAULT_DISPATCHER_AUTH_RETRY_DELAY_MS        = 10000;  // 10 seconds - auth retry delay
+    public static final int    DEFAULT_DISPATCHER_POLL_ERROR_RETRY_DELAY_MS  = 5000;   // 5 seconds - poll error retry delay
 }

--- a/audit-server/audit-dispatcher/dispatcher-common/pom.xml
+++ b/audit-server/audit-dispatcher/dispatcher-common/pom.xml
@@ -147,6 +147,17 @@
             <artifactId>spring-context</artifactId>
             <version>${springframework.version}</version>
         </dependency>
+        <!-- Test Dependencies -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/audit-server/audit-dispatcher/dispatcher-common/src/main/java/org/apache/ranger/audit/dispatcher/kafka/AuditDispatcherBase.java
+++ b/audit-server/audit-dispatcher/dispatcher-common/src/main/java/org/apache/ranger/audit/dispatcher/kafka/AuditDispatcherBase.java
@@ -24,6 +24,10 @@ import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.AuthenticationException;
+import org.apache.kafka.common.errors.AuthorizationException;
+import org.apache.kafka.common.errors.InterruptException;
+import org.apache.kafka.common.errors.WakeupException;
 import org.apache.ranger.audit.provider.MiscUtil;
 import org.apache.ranger.audit.server.AuditServerConstants;
 import org.apache.ranger.audit.utils.AuditMessageQueueUtils;
@@ -40,6 +44,7 @@ import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -54,10 +59,13 @@ public abstract class AuditDispatcherBase implements AuditDispatcher {
 
     protected final AtomicBoolean                 running               = new AtomicBoolean(false);
     protected final Map<String, DispatcherWorker> dispatcherWorkers     = new ConcurrentHashMap<>();
+    protected final Map<String, Future<?>>        workerFutures         = new ConcurrentHashMap<>();
     protected ExecutorService                     dispatcherThreadPool;
     protected int                                 dispatcherThreadCount = 1;
     protected String                              offsetCommitStrategy  = AuditServerConstants.DEFAULT_OFFSET_COMMIT_STRATEGY;
     protected long                                offsetCommitInterval  = AuditServerConstants.DEFAULT_OFFSET_COMMIT_INTERVAL_MS;
+    protected long                                authRetryDelayMs      = AuditServerConstants.DEFAULT_DISPATCHER_AUTH_RETRY_DELAY_MS;
+    protected long                                pollErrorRetryDelayMs = AuditServerConstants.DEFAULT_DISPATCHER_POLL_ERROR_RETRY_DELAY_MS;
 
     public AuditDispatcherBase(Properties props, String propPrefix, String dispatcherGroupId) throws Exception {
         this.dispatcherGroupId = getDispatcherGroupId(props, propPrefix, dispatcherGroupId);
@@ -93,6 +101,9 @@ public abstract class AuditDispatcherBase implements AuditDispatcher {
         // Configure partition assignment strategy
         String partitionAssignmentStrategy = MiscUtil.getStringProperty(props, propPrefix + "." + AuditServerConstants.PROP_DISPATCHER_PARTITION_ASSIGNMENT_STRATEGY, AuditServerConstants.DEFAULT_PARTITION_ASSIGNMENT_STRATEGY);
         dispatcherProps.put(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG, partitionAssignmentStrategy);
+
+        authRetryDelayMs      = MiscUtil.getLongProperty(props, propPrefix + "." + AuditServerConstants.PROP_DISPATCHER_AUTH_RETRY_DELAY_MS, AuditServerConstants.DEFAULT_DISPATCHER_AUTH_RETRY_DELAY_MS);
+        pollErrorRetryDelayMs = MiscUtil.getLongProperty(props, propPrefix + "." + AuditServerConstants.PROP_DISPATCHER_POLL_ERROR_RETRY_DELAY_MS, AuditServerConstants.DEFAULT_DISPATCHER_POLL_ERROR_RETRY_DELAY_MS);
 
         LOG.info("Dispatcher '{}' configured for subscription-based partition assignment with re-balancing support", this.dispatcherGroupId);
         LOG.info("Re-balancing config - session.timeout.ms: {}, max.poll.interval.ms: {}, heartbeat.interval.ms: {}", sessionTimeoutMs, maxPollIntervalMs, heartbeatIntervalMs);
@@ -146,10 +157,11 @@ public abstract class AuditDispatcherBase implements AuditDispatcher {
                 startDispatcherWorkers();
             }
 
-            // Keep main thread alive while dispatcher threads are running
+            // Keep main thread alive while dispatcher threads are running and monitor their health
             while (running.get()) {
                 try {
-                    Thread.sleep(1000);
+                    Thread.sleep(5000); // Check worker health every 5 seconds
+                    monitorAndRestartWorkers();
                 } catch (InterruptedException e) {
                     LOG.info("{} dispatcher main thread interrupted", getDispatcherName());
                     Thread.currentThread().interrupt();
@@ -182,6 +194,7 @@ public abstract class AuditDispatcherBase implements AuditDispatcher {
         }
 
         dispatcherWorkers.clear();
+        workerFutures.clear();
 
         if (dispatcher != null) {
             try {
@@ -205,14 +218,42 @@ public abstract class AuditDispatcherBase implements AuditDispatcher {
 
         for (int i = 0; i < dispatcherThreadCount; i++) {
             String workerId = getDispatcherName().toLowerCase() + "-worker-" + i;
-            DispatcherWorker worker = createDispatcherWorker(workerId, new ArrayList<>());
-            dispatcherWorkers.put(workerId, worker);
-            dispatcherThreadPool.submit(worker);
-
-            LOG.info("Started {} dispatcher worker '{}' - will process ANY appId assigned by Kafka", getDispatcherName(), workerId);
+            startWorker(workerId);
         }
 
         LOG.info("<== AuditDispatcherBase.startDispatcherWorkers(): All {} workers started in SUBSCRIBE mode", dispatcherThreadCount);
+    }
+
+    private void startWorker(String workerId) {
+        DispatcherWorker worker = createDispatcherWorker(workerId, new ArrayList<>());
+        dispatcherWorkers.put(workerId, worker);
+        Future<?> future = dispatcherThreadPool.submit(worker);
+        workerFutures.put(workerId, future);
+        LOG.info("Started {} dispatcher worker '{}' - will process ANY appId assigned by Kafka", getDispatcherName(), workerId);
+    }
+
+    private void monitorAndRestartWorkers() {
+        if (!running.get()) {
+            return;
+        }
+
+        for (Map.Entry<String, Future<?>> entry : workerFutures.entrySet()) {
+            String workerId = entry.getKey();
+            Future<?> future = entry.getValue();
+
+            if (future.isDone()) {
+                LOG.warn("Worker '{}' has terminated unexpectedly. Attempting to restart...", workerId);
+                try {
+                    // Remove the dead worker
+                    dispatcherWorkers.remove(workerId);
+                    // Start a new worker with the same ID
+                    startWorker(workerId);
+                    LOG.info("Successfully restarted worker '{}'", workerId);
+                } catch (Exception e) {
+                    LOG.error("Failed to restart worker '{}'", workerId, e);
+                }
+            }
+        }
     }
 
     protected abstract class DispatcherWorker implements Runnable {
@@ -268,12 +309,18 @@ public abstract class AuditDispatcherBase implements AuditDispatcher {
 
                 // Consume messages
                 while (running.get()) {
-                    ConsumerRecords<String, String> records = workerDispatcher.poll(Duration.ofMillis(100));
+                    try {
+                        ConsumerRecords<String, String> records = workerDispatcher.poll(Duration.ofMillis(100));
 
-                    if (!records.isEmpty()) {
-                        processRecordBatch(records);
-                        // Handle offset committing based on strategy
-                        handleOffsetCommitting();
+                        if (!records.isEmpty()) {
+                            processRecordBatch(records);
+                            // Handle offset committing based on strategy
+                            handleOffsetCommitting();
+                        }
+                    } catch (Exception e) {
+                        if (!handlePollException(e)) {
+                            break;
+                        }
                     }
                 }
             } catch (Throwable e) {
@@ -298,6 +345,44 @@ public abstract class AuditDispatcherBase implements AuditDispatcher {
                     }
                 }
                 LOG.info("{} dispatcher worker '{}' stopped", getDispatcherName(), workerId);
+            }
+        }
+
+        private boolean handlePollException(Exception e) {
+            if (e instanceof WakeupException) {
+                if (!running.get()) {
+                    LOG.info("WakeupException in {} dispatcher worker '{}' during shutdown", getDispatcherName(), workerId);
+                    return false;
+                }
+                LOG.error("WakeupException in {} dispatcher worker '{}'", getDispatcherName(), workerId, e);
+                return true;
+            } else if (e instanceof InterruptException) {
+                if (!running.get()) {
+                    LOG.info("InterruptException in {} dispatcher worker '{}' during shutdown", getDispatcherName(), workerId);
+                    return false;
+                }
+                LOG.error("InterruptException in {} dispatcher worker '{}'", getDispatcherName(), workerId, e);
+                Thread.currentThread().interrupt();
+                return false;
+            } else if (e instanceof AuthorizationException) {
+                LOG.warn("Authorization error in {} dispatcher worker '{}'. Retrying in {} ms...", getDispatcherName(), workerId, authRetryDelayMs, e);
+                return sleepForRetry(authRetryDelayMs);
+            } else if (e instanceof AuthenticationException) {
+                LOG.warn("Authentication error in {} dispatcher worker '{}'. Retrying in {} ms...", getDispatcherName(), workerId, authRetryDelayMs, e);
+                return sleepForRetry(authRetryDelayMs);
+            } else {
+                LOG.error("Error while polling/processing in {} dispatcher worker '{}'. Retrying in {} ms...", getDispatcherName(), workerId, pollErrorRetryDelayMs, e);
+                return sleepForRetry(pollErrorRetryDelayMs);
+            }
+        }
+
+        private boolean sleepForRetry(long delayMs) {
+            try {
+                Thread.sleep(delayMs);
+                return true;
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                return false;
             }
         }
 

--- a/audit-server/audit-dispatcher/dispatcher-common/src/test/java/org/apache/ranger/audit/dispatcher/kafka/AuditDispatcherBaseTest.java
+++ b/audit-server/audit-dispatcher/dispatcher-common/src/test/java/org/apache/ranger/audit/dispatcher/kafka/AuditDispatcherBaseTest.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.audit.dispatcher.kafka;
+
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.errors.AuthorizationException;
+import org.apache.kafka.common.errors.InterruptException;
+import org.apache.ranger.audit.server.AuditServerConstants;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+
+public class AuditDispatcherBaseTest {
+    private TestAuditDispatcher           dispatcher;
+    private KafkaConsumer<String, String> mockConsumer;
+
+    @BeforeEach
+    public void setup() throws Exception {
+        Properties props = new Properties();
+        props.setProperty("ranger.audit.dispatcher.test.kafka.group.id", "test-group");
+        props.setProperty("ranger.audit.dispatcher.test." + AuditServerConstants.PROP_BOOTSTRAP_SERVERS, "localhost:9092");
+        props.setProperty("ranger.audit.dispatcher.test." + AuditServerConstants.PROP_DISPATCHER_AUTH_RETRY_DELAY_MS, "100");
+        props.setProperty("ranger.audit.dispatcher.test." + AuditServerConstants.PROP_DISPATCHER_POLL_ERROR_RETRY_DELAY_MS, "100");
+
+        mockConsumer = mock(KafkaConsumer.class);
+        dispatcher   = new TestAuditDispatcher(props, "ranger.audit.dispatcher.test", "test-group", mockConsumer);
+    }
+
+    @AfterEach
+    public void teardown() {
+        if (dispatcher != null) {
+            dispatcher.shutdown();
+        }
+    }
+
+    @Test
+    public void testAuthorizationExceptionRetry() throws Exception {
+        TestDispatcherWorker worker = dispatcher.createDispatcherWorker("worker-1", null);
+        worker.setWorkerDispatcher(mockConsumer);
+        dispatcher.running.set(true);
+
+        // Throw AuthorizationException on the first poll, then return empty records, then throw InterruptException to exit
+        doThrow(new AuthorizationException("Not authorized"))
+            .doReturn(ConsumerRecords.empty())
+            .doThrow(new InterruptException("Interrupted"))
+            .when(mockConsumer).poll(any(Duration.class));
+
+        worker.run();
+
+        // The worker should have caught the AuthorizationException, retried, and then exited on WakeupException
+        assertTrue(true, "Worker should have handled AuthorizationException");
+        assertEquals(0, worker.getProcessCount()); // 0 records processed
+    }
+
+    @Test
+    public void testInterruptException() throws Exception {
+        TestDispatcherWorker worker = dispatcher.createDispatcherWorker("worker-1", null);
+        worker.setWorkerDispatcher(mockConsumer);
+        dispatcher.running.set(true);
+
+        doThrow(new InterruptException("Interrupted"))
+            .when(mockConsumer).poll(any(Duration.class));
+
+        worker.run();
+
+        // The worker should exit on InterruptException
+        assertTrue(true, "Worker should have handled InterruptException");
+    }
+
+    private static class TestAuditDispatcher extends AuditDispatcherBase {
+        public TestAuditDispatcher(Properties props, String propPrefix, String dispatcherGroupId, KafkaConsumer<String, String> mockConsumer) throws Exception {
+            super(dispatcherGroupId, mockConsumer, "test-topic");
+            this.authRetryDelayMs = 100;
+            this.pollErrorRetryDelayMs = 100;
+        }
+
+        @Override
+        protected String getDispatcherName() {
+            return "TestDispatcher";
+        }
+
+        @Override
+        protected TestDispatcherWorker createDispatcherWorker(String workerId, List<Integer> assignedPartitions) {
+            return new TestDispatcherWorker(workerId, assignedPartitions, this);
+        }
+    }
+
+    private static class TestDispatcherWorker extends AuditDispatcherBase.DispatcherWorker {
+        private final AtomicInteger processCount = new AtomicInteger(0);
+
+        public TestDispatcherWorker(String workerId, List<Integer> assignedPartitions, AuditDispatcherBase dispatcher) {
+            dispatcher.super(workerId, assignedPartitions);
+            this.dispatcherInstance = dispatcher;
+        }
+
+        private final AuditDispatcherBase dispatcherInstance;
+
+        public void setWorkerDispatcher(KafkaConsumer<String, String> mockConsumer) {
+            this.workerDispatcher = mockConsumer;
+        }
+
+        @Override
+        protected void processRecordBatch(ConsumerRecords<String, String> records) {
+            processCount.incrementAndGet();
+        }
+
+        public int getProcessCount() {
+            return processCount.get();
+        }
+
+        @Override
+        public void run() {
+            // Override run to avoid the full setup of subscribe/rebalance listener which requires real Kafka
+            try {
+                while (dispatcherInstance.running.get()) {
+                    try {
+                        ConsumerRecords<String, String> records = workerDispatcher.poll(Duration.ofMillis(100));
+                        if (!records.isEmpty()) {
+                            processRecordBatch(records);
+                        }
+                    } catch (Exception e) {
+                        java.lang.reflect.Method method = AuditDispatcherBase.DispatcherWorker.class.getDeclaredMethod("handlePollException", Exception.class);
+                        method.setAccessible(true);
+                        boolean shouldContinue = (boolean) method.invoke(this, e);
+                        if (!shouldContinue) {
+                            break;
+                        }
+                    }
+                }
+            } catch (Throwable e) {
+                // ignore
+            }
+        }
+    }
+}


### PR DESCRIPTION


## What changes were proposed in this pull request?

The patch  addresses the issue where the AuditDispatcherBase.DispatcherWorker dies when Kafka is not ready yet.

Retry Logic: 
It wraps the poll() and processing logic in a try-catch block. When an AuthorizationException or AuthenticationException is thrown, the worker now sleeps for a configurable delay (auth.retry.delay.ms) and continues the loop instead of exiting.
Worker Health Monitoring: 
It adds monitorAndRestartWorkers() to the main thread's loop. If a worker thread terminates unexpectedly (e.g., due to an unhandled Error), the main thread will detect that its Future is done and restart the worker.


## How was this patch tested?

Patch tested in docker with scenarios to repro the situation and see how resilient is AuditDispatcher is.
